### PR TITLE
feat: CI Job Summary にカバレッジ追加

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
       - run: npm ci
 
       - name: Run tests with coverage
-        run: npx vitest run --coverage --reporter=default --reporter=json-summary --outputFile.json-summary=coverage/test-summary.json
+        run: npx vitest run --coverage --reporter=default --reporter=json --outputFile.json=coverage/test-results.json
 
       - name: Coverage 100% regression check
         run: node scripts/check_coverage_100.mjs
@@ -45,10 +45,10 @@ jobs:
           echo "## Vitest Test Report" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
-          # テスト結果サマリ
-          if [ -f coverage/test-summary.json ]; then
+          # テスト結果サマリ (vitest json reporter)
+          if [ -f coverage/test-results.json ]; then
             node -e "
-              const s = require('./coverage/test-summary.json');
+              const s = require('./coverage/test-results.json');
               const suites = s.numTotalTestSuites || 0;
               const passed = s.numPassedTestSuites || 0;
               const tests = s.numTotalTests || 0;

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,10 +33,80 @@ jobs:
 
       - run: npm ci
 
-      - run: npx vitest run --coverage
+      - name: Run tests with coverage
+        run: npx vitest run --coverage --reporter=default --reporter=json-summary --outputFile.json-summary=coverage/test-summary.json
 
       - name: Coverage 100% regression check
         run: node scripts/check_coverage_100.mjs
+
+      - name: Job Summary
+        if: always()
+        run: |
+          echo "## Vitest Test Report" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          # テスト結果サマリ
+          if [ -f coverage/test-summary.json ]; then
+            node -e "
+              const s = require('./coverage/test-summary.json');
+              const suites = s.numTotalTestSuites || 0;
+              const passed = s.numPassedTestSuites || 0;
+              const tests = s.numTotalTests || 0;
+              const testsPassed = s.numPassedTests || 0;
+              const failed = s.numFailedTests || 0;
+              console.log('### Summary');
+              console.log('- Test Files: ' + (failed === 0 ? '✅' : '❌') + ' ' + passed + ' passes · ' + suites + ' total');
+              console.log('- Test Results: ' + (failed === 0 ? '✅' : '❌') + ' ' + testsPassed + ' passes · ' + tests + ' total');
+              if (failed > 0) console.log('- ❌ ' + failed + ' failed');
+            " >> $GITHUB_STEP_SUMMARY
+          fi
+
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          # カバレッジサマリ (coverage-summary.json)
+          if [ -f coverage/coverage-summary.json ]; then
+            echo "### Coverage" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "| Category | Stmts | Branch | Funcs | Lines |" >> $GITHUB_STEP_SUMMARY
+            echo "|----------|-------|--------|-------|-------|" >> $GITHUB_STEP_SUMMARY
+            node -e "
+              const s = require('./coverage/coverage-summary.json');
+              const t = s.total;
+              console.log('| **Total** | ' + t.statements.pct + '% | ' + t.branches.pct + '% | ' + t.functions.pct + '% | ' + t.lines.pct + '% |');
+            " >> $GITHUB_STEP_SUMMARY
+
+            echo "" >> $GITHUB_STEP_SUMMARY
+
+            # 100% ファイル数
+            node -e "
+              const s = require('./coverage/coverage-summary.json');
+              const files = Object.keys(s).filter(k => k !== 'total');
+              const full = files.filter(k => s[k].lines.pct === 100);
+              console.log('**Lines 100%:** ' + full.length + ' / ' + files.length + ' files');
+            " >> $GITHUB_STEP_SUMMARY
+
+            echo "" >> $GITHUB_STEP_SUMMARY
+
+            # Lines 100% 未達ファイル一覧
+            echo "<details><summary>Lines &lt; 100% ファイル一覧</summary>" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "| File | Stmts | Branch | Funcs | Lines |" >> $GITHUB_STEP_SUMMARY
+            echo "|------|-------|--------|-------|-------|" >> $GITHUB_STEP_SUMMARY
+            node -e "
+              const path = require('path');
+              const s = require('./coverage/coverage-summary.json');
+              const cwd = process.cwd();
+              Object.keys(s).filter(k => k !== 'total').forEach(k => {
+                const e = s[k];
+                if (e.lines.pct < 100) {
+                  const rel = path.relative(cwd, k);
+                  console.log('| ' + rel + ' | ' + e.statements.pct + '% | ' + e.branches.pct + '% | ' + e.functions.pct + '% | ' + e.lines.pct + '% |');
+                }
+              });
+            " >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "</details>" >> $GITHUB_STEP_SUMMARY
+          fi
 
       - uses: actions/upload-artifact@v4
         if: always()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,9 +111,29 @@ bash scripts/sync-types.sh
 ### CI
 
 - **GitHub Actions**: `.github/workflows/test.yml`
-  - `npm ci` → `vitest run --coverage` → `check_coverage_100.mjs` → artifact アップロード
+  - `npm ci` → `vitest run --coverage` → `check_coverage_100.mjs` → Job Summary → artifact
   - fc1200-wasm は CI でスタブ化 (ダミー package.json + index.js)
   - トリガー: push/PR to main (`web/**` パス変更時)
+  - **Job Summary**: テスト結果 + カバレッジ表 + 100% 未達ファイル一覧 (折りたたみ)
+
+### ブランチワークフロー
+
+**main に直接 push 禁止。** ブランチ保護ルール設定済み。
+
+- **CI 必須**: `Vitest + Coverage` 通過しないと merge 不可
+- **strict mode**: main 更新時はブランチの再テスト必要
+- **auto-merge**: `gh pr merge --squash --auto` で CI 通過後に自動マージ
+- **管理者バイパス**: `enforce_admins: false` (緊急時は可能)
+
+```bash
+# 基本フロー
+git checkout -b feat/xxx
+# ... 変更 ...
+git push -u origin feat/xxx
+gh pr create --title "タイトル" --body "説明"
+gh pr merge --squash --auto
+# CI 通過後に自動マージ
+```
 
 ## 重要な注意事項
 


### PR DESCRIPTION
## Summary
- Job Summary にテスト結果サマリ + カバレッジ表 + 100%未達ファイル一覧を追加
- `--reporter=json-summary` でテスト結果を JSON 出力
- `coverage-summary.json` からカバレッジ % を抽出

🤖 Generated with [Claude Code](https://claude.com/claude-code)