### PR TITLE
ci: upgrade Node.js 22 → 24

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: web/package-lock.json
 
@@ -130,7 +130,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: web/package-lock.json
 
@@ -156,7 +156,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: web/package-lock.json
 


### PR DESCRIPTION
## Summary
- CI の Node.js を 22 → 24 に更新
- ローカル (Node 24 / npm 11) と CI の npm バージョンを統一し、lockfile 非互換を解消

## Test plan
- [ ] CI 全3ジョブ pass (test, typecheck, integration-test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)