### PR TITLE
chore: migrate npm scope to @ippoan

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -193,3 +193,69 @@ jobs:
       - name: Cleanup containers
         if: always()
         run: docker compose -f docker-compose.test.yml down -v
+
+  deploy-staging:
+    name: Deploy Staging
+    if: github.event_name == 'pull_request'
+    needs: [test, typecheck]
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+          cache-dependency-path: web/package-lock.json
+
+      - name: Stub fc1200-wasm
+        run: |
+          mkdir -p ../fc1200-wasm/pkg
+          echo '{"name":"fc1200-wasm","version":"0.0.0","main":"index.js"}' > ../fc1200-wasm/pkg/package.json
+          echo 'module.exports = {}' > ../fc1200-wasm/pkg/index.js
+
+      - run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Deploy to Cloudflare Workers (staging)
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: npx wrangler deploy --env staging
+
+  deploy-release:
+    name: Deploy Release
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    needs: [test, typecheck]
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+          cache-dependency-path: web/package-lock.json
+
+      - name: Stub fc1200-wasm
+        run: |
+          mkdir -p ../fc1200-wasm/pkg
+          echo '{"name":"fc1200-wasm","version":"0.0.0","main":"index.js"}' > ../fc1200-wasm/pkg/package.json
+          echo 'module.exports = {}' > ../fc1200-wasm/pkg/index.js
+
+      - run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Deploy to Cloudflare Workers (release)
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: npx wrangler deploy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,18 @@ permissions:
   packages: read
 
 jobs:
+  pr-limit:
+    name: PR Limit Check
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/pr-limit
+
   test:
     name: Vitest + Coverage
+    needs: [pr-limit]
+    if: always() && (needs.pr-limit.result == 'success' || needs.pr-limit.result == 'skipped')
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -35,7 +45,14 @@ jobs:
           echo '{"name":"fc1200-wasm","version":"0.0.0","main":"index.js"}' > ../fc1200-wasm/pkg/package.json
           echo 'module.exports = {}' > ../fc1200-wasm/pkg/index.js
 
-      - run: npm ci
+      - run: npm install
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: ippoan/auth-worker/.github/actions/use-auth-client-dev@main
+        with:
+          working-directory: web
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run tests with coverage
         run: npx vitest run --coverage --reporter=default --reporter=json --outputFile.json=coverage/test-results.json
@@ -110,6 +127,45 @@ jobs:
             " >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "</details>" >> $GITHUB_STEP_SUMMARY
+
+            # coverage_100.toml 登録ファイルの結果
+            if [ -f coverage_100.toml ]; then
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "### Coverage 100% Files" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              node -e "
+                const fs = require('fs');
+                const path = require('path');
+                const toml = fs.readFileSync('coverage_100.toml', 'utf8');
+                const summary = require('./coverage/coverage-summary.json');
+                const cwd = process.cwd();
+                const entries = [];
+                let cur = null;
+                for (const line of toml.split('\n')) {
+                  if (line.trim() === '[[files]]') { cur = { path: '', branches: false }; entries.push(cur); continue; }
+                  if (!cur) continue;
+                  const pm = line.match(/^path\s*=\s*\"(.+)\"/);
+                  if (pm) cur.path = pm[1];
+                  const bm = line.match(/^branches\s*=\s*true/);
+                  if (bm) cur.branches = true;
+                }
+                let ok = 0, fail = 0;
+                console.log('| File | Lines | Branch | Status |');
+                console.log('|------|-------|--------|--------|');
+                for (const e of entries) {
+                  const absPath = path.resolve(cwd, e.path);
+                  const s = summary[absPath];
+                  if (!s) { console.log('| ' + e.path + ' | - | - | ⚠️ not found |'); fail++; continue; }
+                  const linesOk = s.lines.pct === 100;
+                  const branchOk = !e.branches || s.branches.pct === 100;
+                  const passed = linesOk && branchOk;
+                  if (passed) ok++; else fail++;
+                  console.log('| ' + e.path + ' | ' + s.lines.pct + '% | ' + s.branches.pct + '% | ' + (passed ? '✅' : '❌') + ' |');
+                }
+                console.log('');
+                console.log('**Result:** ' + ok + ' passed, ' + fail + ' failed / ' + entries.length + ' registered');
+              " >> $GITHUB_STEP_SUMMARY
+            fi
           fi
 
       - uses: actions/upload-artifact@v4
@@ -121,6 +177,8 @@ jobs:
 
   typecheck:
     name: Type Check
+    needs: [pr-limit]
+    if: always() && (needs.pr-limit.result == 'success' || needs.pr-limit.result == 'skipped')
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -142,11 +200,21 @@ jobs:
           echo 'module.exports = {}' > ../fc1200-wasm/pkg/index.js
           cp app/types/fc1200-wasm.d.ts ../fc1200-wasm/pkg/index.d.ts
 
-      - run: npm ci
+      - run: npm install
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: ippoan/auth-worker/.github/actions/use-auth-client-dev@main
+        with:
+          working-directory: web
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
       - run: npx nuxi typecheck
 
   integration-test:
     name: API Integration
+    needs: [pr-limit]
+    if: always() && (needs.pr-limit.result == 'success' || needs.pr-limit.result == 'skipped')
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -167,7 +235,14 @@ jobs:
           echo '{"name":"fc1200-wasm","version":"0.0.0","main":"index.js"}' > ../fc1200-wasm/pkg/package.json
           echo 'module.exports = {}' > ../fc1200-wasm/pkg/index.js
 
-      - run: npm ci
+      - run: npm install
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: ippoan/auth-worker/.github/actions/use-auth-client-dev@main
+        with:
+          working-directory: web
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -217,7 +292,14 @@ jobs:
           echo '{"name":"fc1200-wasm","version":"0.0.0","main":"index.js"}' > ../fc1200-wasm/pkg/package.json
           echo 'module.exports = {}' > ../fc1200-wasm/pkg/index.js
 
-      - run: npm ci
+      - run: npm install
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: ippoan/auth-worker/.github/actions/use-auth-client-dev@main
+        with:
+          working-directory: web
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build
         run: npm run build
@@ -250,7 +332,14 @@ jobs:
           echo '{"name":"fc1200-wasm","version":"0.0.0","main":"index.js"}' > ../fc1200-wasm/pkg/package.json
           echo 'module.exports = {}' > ../fc1200-wasm/pkg/index.js
 
-      - run: npm ci
+      - run: npm install
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: ippoan/auth-worker/.github/actions/use-auth-client-dev@main
+        with:
+          working-directory: web
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build
         run: npm run build

--- a/web/.npmrc
+++ b/web/.npmrc
@@ -1,0 +1,1 @@
+@ippoan:registry=https://npm.pkg.github.com

--- a/web/app/app.vue
+++ b/web/app/app.vue
@@ -1,6 +1,11 @@
 <script setup lang="ts">
+import { StagingFooter } from '@ippoan/auth-client'
+
 const { init, isLoading } = useAuth()
 const { isAndroidApp } = useFingerprint()
+const config = useRuntimeConfig()
+const apiBase = config.public.apiBase as string
+const stagingTenantId = config.public.stagingTenantId as string
 
 onMounted(async () => {
   // --- リロード検知ログ ---
@@ -37,6 +42,7 @@ useHead({
       <div class="animate-spin h-8 w-8 border-4 border-blue-500 border-t-transparent rounded-full" />
     </div>
     <NuxtPage v-else />
+    <StagingFooter :api-base="apiBase" :tenant-id="stagingTenantId" />
   </div>
 </template>
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -7,6 +7,7 @@
       "name": "web",
       "hasInstallScript": true,
       "dependencies": {
+        "@ippoan/auth-client": "^0.1.6",
         "@nuxtjs/tailwindcss": "^6.14.0",
         "@vite-pwa/nuxt": "^1.1.1",
         "@vladmandic/human": "^3.3.6",
@@ -21,6 +22,7 @@
       },
       "devDependencies": {
         "@nuxt/test-utils": "^4.0.0",
+        "@playwright/test": "^1.59.1",
         "@types/w3c-web-serial": "^1.0.8",
         "@vitest/coverage-v8": "^4.1.2",
         "@vue/test-utils": "^2.4.6",
@@ -1858,33 +1860,10 @@
       "integrity": "sha512-/B8YJGPzaYq1NbsQmwgP8EZqg40NpTw4ZB3suuI0TplbxKHeK94jeaawLmVhCv+YwUnOpiWEz9U6SeThku/8JQ==",
       "license": "MIT"
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
-      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.0",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
-      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
-      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2778,6 +2757,18 @@
       "integrity": "sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==",
       "license": "MIT"
     },
+    "node_modules/@ippoan/auth-client": {
+      "version": "0.1.6",
+      "resolved": "https://npm.pkg.github.com/download/@ippoan/auth-client/0.1.6/9deedfb9d05ced4ef660c20d69383afa4bdf3a6a",
+      "integrity": "sha512-Ae4lPqZtkgZLUXt8PKZt3qoH+NMzjol5z+jWRyyzPLkp3q6E819G6656f1BKVwIpyxsr5UA4Eo7nx6vFU5p+LQ==",
+      "dependencies": {
+        "uqr": "^0.1.2"
+      },
+      "peerDependencies": {
+        "nuxt": ">=3.0.0",
+        "vue": ">=3.0.0"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -3095,17 +3086,6 @@
       "integrity": "sha512-kEV95lFBhQgtogAPlQfJJ0WGVSokvLr/UEoFPiKKOXF7pl98HfUVUD0ejsuTCld/9xH9vogSywZ5KqHzXrZpqg==",
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/@nuxt/cli/node_modules/commander": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
-      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
     },
     "node_modules/@nuxt/cli/node_modules/giget": {
       "version": "3.2.0",
@@ -5003,6 +4983,23 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@polka/url": {
@@ -7693,23 +7690,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/crossws": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.4.4.tgz",
-      "integrity": "sha512-w6c4OdpRNnudVmcgr7brb/+/HmYjMQvYToO/oTrprTwxRUiom3LYWU1PMWuD006okbUWpII1Ea9/+kwpUfmyRg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "peerDependencies": {
-        "srvx": ">=0.7.1"
-      },
-      "peerDependenciesMeta": {
-        "srvx": {
-          "optional": true
-        }
       }
     },
     "node_modules/crypto-random-string": {
@@ -11539,6 +11519,7 @@
       "resolved": "https://registry.npmjs.org/nuxt/-/nuxt-4.4.2.tgz",
       "integrity": "sha512-iWVFpr/YEqVU/CenqIHMnIkvb2HE/9f+q8oxZ+pj2et+60NljGRClCgnmbvGPdmNFE0F1bEhoBCYfqbDOCim3Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dxup/nuxt": "^0.4.0",
         "@nuxt/cli": "^3.34.0",
@@ -12219,6 +12200,54 @@
         "confbox": "^0.2.2",
         "exsolve": "^1.0.7",
         "pathe": "^2.0.3"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/pngjs": {
@@ -14224,7 +14253,6 @@
       "integrity": "sha512-A//xtfak4eESMWWydSRFUVvCTQbSwivnGCEf8YGPe2eHU0+Z6znfUTCPF0a7oV3sObSOcrXHlL6Bs9vVctfXdg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "srvx": "bin/srvx.mjs"
       },
@@ -14763,6 +14791,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",

--- a/web/package.json
+++ b/web/package.json
@@ -11,12 +11,14 @@
     "deploy": "nuxt build && wrangler deploy",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@nuxtjs/tailwindcss": "^6.14.0",
     "@vite-pwa/nuxt": "^1.1.1",
     "@vladmandic/human": "^3.3.6",
+    "@ippoan/auth-client": "^0.1.6",
     "fc1200-wasm": "file:../fc1200-wasm/pkg",
     "jspdf": "^4.2.0",
     "nuxt": "^4.3.1",
@@ -28,6 +30,7 @@
   },
   "devDependencies": {
     "@nuxt/test-utils": "^4.0.0",
+    "@playwright/test": "^1.59.1",
     "@types/w3c-web-serial": "^1.0.8",
     "@vitest/coverage-v8": "^4.1.2",
     "@vue/test-utils": "^2.4.6",

--- a/web/wrangler.jsonc
+++ b/web/wrangler.jsonc
@@ -4,5 +4,13 @@
 	"main": ".output/server/index.mjs",
 	"assets": {
 		"directory": ".output/public"
+	},
+	"env": {
+		"staging": {
+			"name": "alc-app-staging",
+			"vars": {
+				"NUXT_PUBLIC_API_BASE": "STAGING_API_URL"
+			}
+		}
 	}
 }

--- a/web/wrangler.jsonc
+++ b/web/wrangler.jsonc
@@ -1,5 +1,7 @@
 {
+	"$schema": "node_modules/wrangler/config-schema.json",
 	"name": "alc-app",
+	"account_id": "24b45709d060d957340180e995f0d373",
 	"compatibility_date": "2025-07-15",
 	"main": ".output/server/index.mjs",
 	"assets": {
@@ -9,7 +11,9 @@
 		"staging": {
 			"name": "alc-app-staging",
 			"vars": {
-				"NUXT_PUBLIC_API_BASE": "STAGING_API_URL"
+				"NUXT_PUBLIC_API_BASE": "https://rust-alc-api-staging-566bls5vfq-an.a.run.app",
+				"NUXT_PUBLIC_STAGING_TENANT_ID": "11111111-1111-1111-1111-111111111111",
+				"NUXT_PUBLIC_GOOGLE_CLIENT_ID": "747065218280-ugkrbgaoik32f5mmi94sso4b0026j3cp.apps.googleusercontent.com"
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
- `@yhonda-ohishi-pub-dev/auth-client` → `@ippoan/auth-client@^0.1.6`
- app.vue import 修正
- .npmrc 追加 (ippoan registry)
- CI test.yml: typecheck job に use-auth-client-dev composite action 追加

## Test plan
- [ ] CI test/typecheck/build が通ること
- [ ] staging deploy で StagingFooter が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)