### PR TITLE
chore: migrate npm scope to @ippoan

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,11 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - uses: ippoan/auth-worker/.github/actions/use-auth-client-dev@main
+        with:
+          working-directory: web
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Run tests with coverage
         run: npx vitest run --coverage --reporter=default --reporter=json --outputFile.json=coverage/test-results.json
 
@@ -198,6 +203,12 @@ jobs:
       - run: npm install
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: ippoan/auth-worker/.github/actions/use-auth-client-dev@main
+        with:
+          working-directory: web
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
       - run: npx nuxi typecheck
 
   integration-test:
@@ -227,6 +238,11 @@ jobs:
       - run: npm install
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: ippoan/auth-worker/.github/actions/use-auth-client-dev@main
+        with:
+          working-directory: web
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Log in to GHCR
         uses: docker/login-action@v3
@@ -280,6 +296,11 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - uses: ippoan/auth-worker/.github/actions/use-auth-client-dev@main
+        with:
+          working-directory: web
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build
         run: npm run build
 
@@ -314,6 +335,11 @@ jobs:
       - run: npm install
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: ippoan/auth-worker/.github/actions/use-auth-client-dev@main
+        with:
+          working-directory: web
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build
         run: npm run build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -272,7 +272,7 @@ jobs:
   deploy-staging:
     name: Deploy Staging
     if: github.event_name == 'pull_request'
-    needs: [test, typecheck]
+    needs: [test, typecheck, integration-test]
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/web/.npmrc
+++ b/web/.npmrc
@@ -1,2 +1,1 @@
-@yhonda-ohishi-pub-dev:registry=https://npm.pkg.github.com
-//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}
+@ippoan:registry=https://npm.pkg.github.com

--- a/web/.npmrc
+++ b/web/.npmrc
@@ -1,1 +1,2 @@
 @ippoan:registry=https://npm.pkg.github.com
+//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}

--- a/web/app/app.vue
+++ b/web/app/app.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { StagingFooter } from '@yhonda-ohishi-pub-dev/auth-client'
+import { StagingFooter } from '@ippoan/auth-client'
 
 const { init, isLoading } = useAuth()
 const { isAndroidApp } = useFingerprint()

--- a/web/docker-compose.test.yml
+++ b/web/docker-compose.test.yml
@@ -42,7 +42,7 @@ services:
     restart: "no"
 
   api-migrate:
-    image: ${API_IMAGE:-ghcr.io/yhonda-ohishi-alc/rust-alc-api:latest}
+    image: ${API_IMAGE:-ghcr.io/ippoan/rust-alc-api:dev}
     depends_on:
       test-db:
         condition: service_healthy
@@ -64,7 +64,7 @@ services:
     restart: "no"
 
   api:
-    image: ${API_IMAGE:-ghcr.io/yhonda-ohishi-alc/rust-alc-api:latest}
+    image: ${API_IMAGE:-ghcr.io/ippoan/rust-alc-api:dev}
     depends_on:
       db-seed:
         condition: service_completed_successfully

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -7,10 +7,10 @@
       "name": "web",
       "hasInstallScript": true,
       "dependencies": {
+        "@ippoan/auth-client": "^0.1.6",
         "@nuxtjs/tailwindcss": "^6.14.0",
         "@vite-pwa/nuxt": "^1.1.1",
         "@vladmandic/human": "^3.3.6",
-        "@yhonda-ohishi-pub-dev/auth-client": "^0.1.34",
         "fc1200-wasm": "file:../fc1200-wasm/pkg",
         "jspdf": "^4.2.0",
         "nuxt": "^4.3.1",
@@ -2756,6 +2756,18 @@
       "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.5.1.tgz",
       "integrity": "sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==",
       "license": "MIT"
+    },
+    "node_modules/@ippoan/auth-client": {
+      "version": "0.1.6",
+      "resolved": "https://npm.pkg.github.com/download/@ippoan/auth-client/0.1.6/9deedfb9d05ced4ef660c20d69383afa4bdf3a6a",
+      "integrity": "sha512-Ae4lPqZtkgZLUXt8PKZt3qoH+NMzjol5z+jWRyyzPLkp3q6E819G6656f1BKVwIpyxsr5UA4Eo7nx6vFU5p+LQ==",
+      "dependencies": {
+        "uqr": "^0.1.2"
+      },
+      "peerDependencies": {
+        "nuxt": ">=3.0.0",
+        "vue": ">=3.0.0"
+      }
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -6301,18 +6313,6 @@
       "dependencies": {
         "js-beautify": "^1.14.9",
         "vue-component-type-helpers": "^2.0.0"
-      }
-    },
-    "node_modules/@yhonda-ohishi-pub-dev/auth-client": {
-      "version": "0.1.34",
-      "resolved": "https://npm.pkg.github.com/download/@yhonda-ohishi-pub-dev/auth-client/0.1.34/44e7dc86ef70c337837360f53b3c9d54bd11bcf2",
-      "integrity": "sha512-sLHPY7NNxZwwaC8LO85ZXW1vqbsyPQ0z6xyliTBN5+xuOC50Y1AACIN4N9r9a5zICVmUbiEeHSVdiXW4QX1bTw==",
-      "dependencies": {
-        "uqr": "^0.1.2"
-      },
-      "peerDependencies": {
-        "nuxt": ">=3.0.0",
-        "vue": ">=3.0.0"
       }
     },
     "node_modules/abbrev": {

--- a/web/package.json
+++ b/web/package.json
@@ -18,7 +18,7 @@
     "@nuxtjs/tailwindcss": "^6.14.0",
     "@vite-pwa/nuxt": "^1.1.1",
     "@vladmandic/human": "^3.3.6",
-    "@yhonda-ohishi-pub-dev/auth-client": "^0.1.34",
+    "@ippoan/auth-client": "^0.1.6",
     "fc1200-wasm": "file:../fc1200-wasm/pkg",
     "jspdf": "^4.2.0",
     "nuxt": "^4.3.1",


### PR DESCRIPTION
## Summary
- `@yhonda-ohishi-pub-dev/auth-client` → `@ippoan/auth-client@^0.1.6`
- app.vue import 修正
- .npmrc: @ippoan registry (NODE_AUTH_TOKEN 行削除、グローバル設定に委譲)
- CI test.yml: 全5ジョブに use-auth-client-dev composite action 追加

Closes #14

## Test plan
- [ ] CI test/typecheck/build が通ること
- [ ] staging deploy で StagingFooter が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)