### PR TITLE
ci: add tag-release caller workflow

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,12 @@
+name: Tag Release
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    uses: ippoan/ci-workflows/.github/workflows/tag-release.yml@main
+    secrets: inherit


### PR DESCRIPTION
Tag Release reusable workflow の caller を追加。ci-dashboard の Deploy ボタンから実行可能に。