### PR TITLE
chore: update auth-client to 0.2.10

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -7,7 +7,7 @@
       "name": "web",
       "hasInstallScript": true,
       "dependencies": {
-        "@ippoan/auth-client": "^0.1.6",
+        "@ippoan/auth-client": "^0.2.10",
         "@nuxtjs/tailwindcss": "^6.14.0",
         "@vite-pwa/nuxt": "^1.1.1",
         "@vladmandic/human": "^3.3.6",
@@ -2758,9 +2758,9 @@
       "license": "MIT"
     },
     "node_modules/@ippoan/auth-client": {
-      "version": "0.1.6",
-      "resolved": "https://npm.pkg.github.com/download/@ippoan/auth-client/0.1.6/9deedfb9d05ced4ef660c20d69383afa4bdf3a6a",
-      "integrity": "sha512-Ae4lPqZtkgZLUXt8PKZt3qoH+NMzjol5z+jWRyyzPLkp3q6E819G6656f1BKVwIpyxsr5UA4Eo7nx6vFU5p+LQ==",
+      "version": "0.2.10",
+      "resolved": "https://npm.pkg.github.com/download/@ippoan/auth-client/0.2.10/84881621c09b304cd5d3dcc548a7aef698a9f7ec",
+      "integrity": "sha512-VHBgGtZjCRFDim74WpDn1nh/H/WCrD9BaIQJhiTeQjVsWJxwRJYYnR46rpYCcMNtYgiBttF2PlSJNRWOnmo+vQ==",
       "dependencies": {
         "uqr": "^0.1.2"
       },

--- a/web/package.json
+++ b/web/package.json
@@ -15,10 +15,10 @@
     "test:e2e": "playwright test"
   },
   "dependencies": {
+    "@ippoan/auth-client": "^0.2.10",
     "@nuxtjs/tailwindcss": "^6.14.0",
     "@vite-pwa/nuxt": "^1.1.1",
     "@vladmandic/human": "^3.3.6",
-    "@ippoan/auth-client": "^0.1.6",
     "fc1200-wasm": "file:../fc1200-wasm/pkg",
     "jspdf": "^4.2.0",
     "nuxt": "^4.3.1",


### PR DESCRIPTION
logout() が /logout 経由でサーバー側 cookie をクリアするように変更