### PR TITLE
fix: add production vars (NUXT_PUBLIC_API_BASE)

### DIFF
--- a/web/wrangler.jsonc
+++ b/web/wrangler.jsonc
@@ -7,6 +7,10 @@
 	"assets": {
 		"directory": ".output/public"
 	},
+	"observability": {
+		"enabled": true,
+		"head_sampling_rate": 1
+	},
 	"env": {
 		"staging": {
 			"name": "alc-app-staging",
@@ -22,6 +26,10 @@
 				"NUXT_PUBLIC_GOOGLE_CLIENT_ID": "747065218280-ugkrbgaoik32f5mmi94sso4b0026j3cp.apps.googleusercontent.com"
 			}
 		}
+	},
+	"vars": {
+		"NUXT_PUBLIC_API_BASE": "https://alc-api.ippoan.org",
+		"NUXT_PUBLIC_GOOGLE_CLIENT_ID": "747065218280-ugkrbgaoik32f5mmi94sso4b0026j3cp.apps.googleusercontent.com"
 	},
 	"routes": [
 		{


### PR DESCRIPTION
## Summary
- Add production `vars` with `NUXT_PUBLIC_API_BASE` = `https://alc-api.ippoan.org`
- Without this, production falls back to `localhost:3001` (Failed to fetch)
- Add `observability` section matching other frontend projects

## Test plan
- [ ] CI passes
- [ ] After deploy, `alc.ippoan.org` no longer shows `localhost:3001` errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)