### PR TITLE
chore: add .ippoan-dev.yaml + dev-proxy validate CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,3 +33,6 @@ jobs:
       integration_env: 'TEST_LIVE=1 API_BASE_URL=http://localhost:18080'
       cache_dependency_path: web/package-lock.json
     secrets: inherit
+
+  dev-proxy:
+    uses: ippoan/ci-workflows/.github/workflows/dev-proxy-validate.yml@main

--- a/.ippoan-dev.yaml
+++ b/.ippoan-dev.yaml
@@ -1,0 +1,5 @@
+# dev-proxy metadata. Source of truth for https://<name>-dev.ippoan.org.
+name: alc-app
+port: 3014
+subdir: web
+cmd: "PORT=$PORT HOST=0.0.0.0 npm run dev"


### PR DESCRIPTION
## Summary
- Declare dev-proxy metadata (port 3014, subdir web).
- Wire dev-proxy-validate reusable into CI.

## Test plan
- [ ] CI dev-proxy job passes