### PR TITLE
fix: switch auth-worker URL from mtamaramu to ippoan domain

### DIFF
--- a/web/app/pages/index.vue
+++ b/web/app/pages/index.vue
@@ -17,7 +17,8 @@ function loginWithLineworks() {
   if (!input) return
   const redirectUri = encodeURIComponent(window.location.origin + '/?role=general')
   const address = encodeURIComponent(input)
-  window.location.href = `https://auth.mtamaramu.com/oauth/lineworks/redirect?address=${address}&redirect_uri=${redirectUri}`
+  const authWorkerUrl = (config.public.authWorkerUrl as string) || 'https://auth.ippoan.org'
+  window.location.href = `${authWorkerUrl}/oauth/lineworks/redirect?address=${address}&redirect_uri=${redirectUri}`
 }
 initApi(
   config.public.apiBase as string,

--- a/web/nuxt.config.ts
+++ b/web/nuxt.config.ts
@@ -11,7 +11,7 @@ export default defineNuxtConfig({
       signalingUrl: process.env.NUXT_PUBLIC_SIGNALING_URL || 'http://localhost:8787',
       tenantId: process.env.NUXT_PUBLIC_TENANT_ID || 'default',
       googleClientId: process.env.NUXT_PUBLIC_GOOGLE_CLIENT_ID || '',
-      authWorkerUrl: process.env.NUXT_PUBLIC_AUTH_WORKER_URL || 'https://auth.mtamaramu.com',
+      authWorkerUrl: process.env.NUXT_PUBLIC_AUTH_WORKER_URL || 'https://auth.ippoan.org',
       stagingTenantId: process.env.NUXT_PUBLIC_STAGING_TENANT_ID || '',
     },
   },

--- a/web/wrangler.jsonc
+++ b/web/wrangler.jsonc
@@ -23,13 +23,15 @@
 			"vars": {
 				"NUXT_PUBLIC_API_BASE": "https://rust-alc-api-staging-566bls5vfq-an.a.run.app",
 				"NUXT_PUBLIC_STAGING_TENANT_ID": "11111111-1111-1111-1111-111111111111",
-				"NUXT_PUBLIC_GOOGLE_CLIENT_ID": "747065218280-ugkrbgaoik32f5mmi94sso4b0026j3cp.apps.googleusercontent.com"
+				"NUXT_PUBLIC_GOOGLE_CLIENT_ID": "747065218280-ugkrbgaoik32f5mmi94sso4b0026j3cp.apps.googleusercontent.com",
+				"NUXT_PUBLIC_AUTH_WORKER_URL": "https://auth-staging.ippoan.org"
 			}
 		}
 	},
 	"vars": {
 		"NUXT_PUBLIC_API_BASE": "https://alc-api.ippoan.org",
-		"NUXT_PUBLIC_GOOGLE_CLIENT_ID": "747065218280-ugkrbgaoik32f5mmi94sso4b0026j3cp.apps.googleusercontent.com"
+		"NUXT_PUBLIC_GOOGLE_CLIENT_ID": "747065218280-ugkrbgaoik32f5mmi94sso4b0026j3cp.apps.googleusercontent.com",
+		"NUXT_PUBLIC_AUTH_WORKER_URL": "https://auth.ippoan.org"
 	},
 	"routes": [
 		{


### PR DESCRIPTION
## Summary

3 箇所修正:

1. `web/nuxt.config.ts` — `authWorkerUrl` のデフォルトフォールバックを `auth.mtamaramu.com` → `auth.ippoan.org`
2. `web/app/pages/index.vue` — LINE WORKS ログインの URL ハードコードを `config.public.authWorkerUrl` 参照に変更
3. `web/wrangler.jsonc` — `NUXT_PUBLIC_AUTH_WORKER_URL` 環境変数を本番 / staging 両方に明示設定:
   - production: `https://auth.ippoan.org`
   - staging: `https://auth-staging.ippoan.org`

## 背景

これまで `wrangler.jsonc` に `NUXT_PUBLIC_AUTH_WORKER_URL` が無く、`nuxt.config.ts` の旧ドメインデフォルト (`auth.mtamaramu.com`) に fallback していたため、auth フローが旧 auth-worker に飛んでしまっていた。

`ippoan/ci-workflows` main にも `check-old-auth-domain` ジョブを追加 (commit `bb6ecd2`)。今後同様の漏れを CI で fail させる。

## Test plan
- [x] 3 ファイル修正
- [ ] CI pass (新 check-old-auth-domain ジョブ通過確認)
- [ ] staging deploy 後、LINE WORKS ログインが auth-staging.ippoan.org 経由で動く
- [ ] 本番 deploy 後、auth.ippoan.org 経由で動く