### PR TITLE
ci: report Release Wave compatibility against rust-alc-api

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,4 +32,8 @@ jobs:
       integration_test_command: 'npx vitest run tests/utils/api.test.ts'
       integration_env: 'TEST_LIVE=1 API_BASE_URL=http://localhost:18080'
       cache_dependency_path: web/package-lock.json
+      # Release Wave compatibility: integration test green 時に
+      # 「alc-app が rust-alc-api の現 prod image を相手に test した」ことを
+      # ci-dashboard に記録する (Refs ippoan/ci-dashboard#157)。
+      compat_backend_repo: ippoan/rust-alc-api
     secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,11 @@ permissions:
   contents: write
   packages: read
   pull-requests: write
+  # frontend-ci.yml の nested secret-verify job が id-token: write を要求する。
+  # `if:` で skip される run でも reusable parse 時に caller permissions が
+  # 検証されるため、宣言しないと startup_failure になる
+  # (ippoan/ci-workflows CLAUDE.md「startup_failure」参照)。
+  id-token: write
 
 jobs:
   ci:


### PR DESCRIPTION
## 概要

Release Wave compatibility (frontend ↔ backend image 突合, `ippoan/ci-dashboard#157`) の frontend consumer 配線の **リファレンス導入**。

`frontend-ci.yml` の keystone (`ippoan/ci-workflows#67`, merged) が提供する opt-in 入力 `compat_backend_repo` を指定する 1 行の caller 変更。

## 変更

`.github/workflows/test.yml` の `frontend-ci.yml` caller に追加:

```yaml
compat_backend_repo: ippoan/rust-alc-api
```

これにより integration test (docker-compose で GHCR `rust-alc-api:latest` + PostgreSQL を起動して実行) が green な時に、`report-frontend-compat` action が ci-dashboard の `frontend-test-report` webhook を打ち、`frontend::ippoan/alc-app` の `tested_against` に「rust-alc-api の現 prod image」を記録する。

`RELEASE_WAVE_WEBHOOK_SECRET` は `secrets: inherit` 経由で org secret を受け取る。backend record が無い (= 初回) 場合は report 側が no-op になるため、CI を壊さない。

## 効果

Release Wave 起動時の compatibility matrix で、alc-app が現 production の rust-alc-api image を test 済みかどうかが緑/赤で可視化される。これが本機構の最初の実データ供給元になる。

Refs ippoan/ci-dashboard#157

---
_Generated by [Claude Code](https://claude.ai/code/session_01DPNy9CVxrt1JgUZzDgAwYN)_