### PR TITLE
ci: add Release Wave caller with rollback dispatch types

### DIFF
--- a/.github/workflows/release-wave.yml
+++ b/.github/workflows/release-wave.yml
@@ -1,0 +1,29 @@
+name: Release Wave
+
+# Release Wave 機構の caller (薄い ~10 行 wrapper)。
+# ci-dashboard から repository_dispatch で flip / rollback event を
+# 受けて、ci-workflows の release-wave-handler.yml reusable に処理を委譲する。
+#
+# 親 issue: ippoan/ci-dashboard#137 / #237
+# Reusable: ippoan/ci-workflows/.github/workflows/release-wave-handler.yml
+# Repo config: ippoan/ci-workflows/config/release-wave-targets.yaml の
+#              `ippoan/alc-app` entry (platform=cloudflare-workers)
+
+on:
+  repository_dispatch:
+    types:
+      - release-wave-flip
+      - release-wave-rollback
+      - release-wave-traffic-rollback   # frontend 単独 rollback (cloudflare-workers)
+      - release-wave-backend-rollback    # backend 単独 rollback (cloudrun)
+
+permissions:
+  contents: write     # tag push (stage 時)
+  id-token: write     # WIF (cloudrun path 用、本 repo は CF だが reusable
+                      # parse 時 caller permissions check が要る)
+  packages: read      # @ippoan/* GitHub Packages dep install (npm_scope=@ippoan)
+
+jobs:
+  handler:
+    uses: ippoan/ci-workflows/.github/workflows/release-wave-handler.yml@main
+    secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,8 @@ permissions:
   contents: write
   packages: read
   pull-requests: write
+  id-token: write   # frontend-ci.yml 内蔵の secret-verify job が要求 (未宣言だと
+                    # gcp_secret_verify_* を渡さない caller でも startup_failure)
 
 jobs:
   ci:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,14 @@ jobs:
       working_directory: web
       install_command: 'npm install'
       has_integration: true
+      # integration test は rust-alc-api コンテナ (docker-compose.test.yml の
+      # api サービス) を相手に走る。Release Wave の frontend↔backend
+      # compatibility edge を記録するため backend repo と image env を配線する。
+      # compat machinery が test 前に backend SHA を解決し
+      # API_IMAGE=ghcr.io/ippoan/rust-alc-api:<sha> を export して、その image で
+      # integration を回す (truthful 突合)。docker-compose は ${API_IMAGE} を読む。
+      compat_backend_repo: 'ippoan/rust-alc-api'
+      compat_backend_image_env: 'API_IMAGE'
       use_auth_client_dev: true
       pre_install_script: |
         mkdir -p ../fc1200-wasm/pkg

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,11 @@ jobs:
     uses: ippoan/ci-workflows/.github/workflows/frontend-ci.yml@main
     with:
       working_directory: web
+      # 内蔵 secret-verify job は wrangler 設定を repo root で autodetect する
+      # (working_directory を見ない)。本 repo の wrangler.jsonc は web/ 配下
+      # なので明示 path を渡さないと "wrangler config not found" で落ちる。
+      # secrets.required は [] なので verify は 0 件で trivial pass。
+      gcp_secret_verify_wrangler_path: 'web/wrangler.jsonc'
       install_command: 'npm install'
       has_integration: true
       # integration test は rust-alc-api コンテナ (docker-compose.test.yml の

--- a/web/wrangler.jsonc
+++ b/web/wrangler.jsonc
@@ -11,6 +11,12 @@
 		"enabled": true,
 		"head_sampling_rate": 1
 	},
+	// frontend-ci.yml の secret-verify job が secret backup の auditability の
+	// ため明示宣言を要求する。他 CF worker repo (nuxt-notify / nuxt-trouble) に
+	// 揃えて空配列を宣言する。
+	"secrets": {
+		"required": []
+	},
 	"env": {
 		"staging": {
 			"name": "alc-app-staging",


### PR DESCRIPTION
## 概要

`alc-app` は `ippoan/ci-workflows` の `release-wave-targets.yaml` に
参加登録済み (platform=cloudflare-workers, preview-alc.ippoan.org) だが
`.github/workflows/release-wave.yml` caller が無く、Release Wave の
`repository_dispatch` event を一切受けられない状態だった。

caller を新規追加し、`release-wave-flip` / `release-wave-rollback` に加えて
`release-wave-traffic-rollback` / `release-wave-backend-rollback` を
最初から列挙する。GitHub は caller の `on.repository_dispatch.types` に
列挙された event でしか起動しないため、これが無いと単独 rollback が
no-op になる (ci-workflows#89)。

handler 本体 (ci-workflows#88) と ci-dashboard 側 dispatcher (#196/#197) は
実装済み。本 caller はそれに委譲するだけの薄い wrapper。

Refs ippoan/ci-workflows#89


---
_Generated by [Claude Code](https://claude.ai/code/session_01FsF7NnDhwhiFC5aGGSV8nS)_