### PR TITLE
ci: deploy alc-app via CI so it reports Release Wave traffic split

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,4 +47,17 @@ jobs:
       integration_test_command: 'npx vitest run tests/utils/api.test.ts'
       integration_env: 'TEST_LIVE=1 API_BASE_URL=http://localhost:18080'
       cache_dependency_path: web/package-lock.json
+      # Release Wave の deploy 面に乗せる。frontend-ci の deploy-staging (PR) /
+      # deploy-release (v* tag) が wrangler deploy 後に version 配分を
+      # ci-dashboard /webhooks/release-wave/traffic-report へ報告し、
+      # /release-wave の「Traffic (version split)」表に alc-app 行が出る。
+      # 手動 `cd web && npm run deploy` (= nuxt build && wrangler deploy) を
+      # そのまま CI 化したもの。NUXT_PUBLIC_* は wrangler.jsonc の vars
+      # (prod = top-level / staging = env.staging.vars) で runtime 注入され、
+      # nitro preset も nuxt.config で cloudflare_module 固定なので build 時の
+      # env 注入は不要。release_no_traffic=true (default) により release の
+      # `wrangler deploy` は `wrangler versions upload` (no-traffic) に置換され、
+      # flip は Release Wave / wrangler versions deploy で明示的に 100% へ。
+      deploy_staging_script: 'npm run build && npx wrangler deploy --env staging'
+      deploy_release_script: 'npm run build && npx wrangler deploy'
     secrets: inherit


### PR DESCRIPTION
## 概要

ci-dashboard の `/release-wave` 「Traffic (version split)」表に **alc-app の行が出ない**問題を修正する。

### 原因

Traffic 表は dashboard がライブ取得しているのではなく、各 repo の CI deploy job が deploy 後に version 配分を `/webhooks/release-wave/traffic-report` へ報告して `traffic::<repo>` として保存される（`ci-dashboard/src/release-wave/traffic.ts`）。その報告は `frontend-ci.yml` の `deploy-staging` / `deploy-release` job が `deploy_*_script` を実行した時にだけ発火する。

alc-app の `test.yml` には `deploy_staging_script` / `deploy_release_script` が無く（compat 配線・integration はあるが deploy script が欠落）、手動 `cd web && npm run deploy` で CI を迂回していたため、traffic-report が一度も飛ばず表に出ていなかった。表に出ている auth-worker / nuxt-notify / nuxt-pwa-carins / nuxt-trouble はいずれも deploy script を持つ。

## 変更

`test.yml` に deploy script を追加（手動デプロイ `nuxt build && wrangler deploy` をそのまま CI 化）:

```yaml
deploy_staging_script: 'npm run build && npx wrangler deploy --env staging'
deploy_release_script: 'npm run build && npx wrangler deploy'
```

- `NUXT_PUBLIC_*` は `wrangler.jsonc` の `vars`（prod=top-level / staging=`env.staging.vars`）で runtime 注入されるため build 時の env 注入は不要
- nitro preset は `nuxt.config.ts` で `cloudflare_module` 固定
- `release_no_traffic: true`（frontend-ci default）により release の `wrangler deploy` は `wrangler versions upload`（no-traffic）に置換される。flip は Release Wave / `wrangler versions deploy <id>@100%` で明示的に実施

## 効果

- PR ごとに `deploy-staging` → `alc-app-staging` 自動デプロイ（rust-alc-api CLAUDE.md が記載する想定挙動を実現）
- **次の `v*` tag リリースで `deploy-release` が走り、traffic-report が飛んで Traffic (version split) 表に alc-app 行が出る**

Refs ippoan/ci-dashboard#137

---
_Generated by [Claude Code](https://claude.ai/code/session_01D4p3x1R28rpnhYkupp4HsN)_