### PR TITLE
ci: align staging/tag/wave env with auth-worker (ippoan standard)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,10 +2,13 @@ name: CI
 
 on:
   push:
+    # paths フィルタは付けない (auth-worker と同形)。GitHub Actions は tag push
+    # でも paths を評価するため、web/ を変更しない `v*` tag リリースで
+    # deploy-release / no-traffic upload / traffic-report が発火しなくなるのを防ぐ。
     branches: [main]
     tags: ['v*']
-    paths: ['web/**', '.github/workflows/test.yml', '.github/workflows/release-wave-retest.yml']
   pull_request:
+    # PR 側は無駄打ちを抑えるため paths を残す (push/tag は常に発火させる)。
     branches: [main]
     paths: ['web/**', '.github/workflows/test.yml', '.github/workflows/release-wave-retest.yml']
 
@@ -58,6 +61,10 @@ jobs:
       # env 注入は不要。release_no_traffic=true (default) により release の
       # `wrangler deploy` は `wrangler versions upload` (no-traffic) に置換され、
       # flip は Release Wave / wrangler versions deploy で明示的に 100% へ。
-      deploy_staging_script: 'npm run build && npx wrangler deploy --env staging'
-      deploy_release_script: 'npm run build && npx wrangler deploy'
+      # VersionBadge (@ippoan/auth-client) 用に稼働版数を注入 (auth-worker / ippoan
+      # 統一)。staging は commit SHA、release は tag (ref_name)。NUXT_PUBLIC_APP_VERSION
+      # は build 時に runtimeConfig.public.appVersion へ焼き込み、runtime も wrangler
+      # --var で上書きする (二重指定で確実に反映)。
+      deploy_staging_script: 'NUXT_PUBLIC_APP_VERSION=${{ github.sha }} npm run build && npx wrangler deploy --env staging --var NUXT_PUBLIC_APP_VERSION:${{ github.sha }}'
+      deploy_release_script: 'NUXT_PUBLIC_APP_VERSION=${{ github.ref_name }} npm run build && npx wrangler deploy --var NUXT_PUBLIC_APP_VERSION:${{ github.ref_name }}'
     secrets: inherit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,8 +28,12 @@
 
 ## デプロイ
 
-- **web (Cloudflare Workers)**: `cd web && npm run deploy` — `nuxt build && wrangler deploy`
-  - URL: https://alc-app.m-tama-ramu.workers.dev
+- **web (Cloudflare Workers)**: 通常運用は **CI 経由** (auth-worker / ippoan 標準と統一、#33)。
+  - PR → main: `test.yml` (frontend-ci.yml) の `deploy-staging` が staging に自動 deploy
+    - URL: https://alc-staging.ippoan.org (custom domain) / alc-app-staging.m-tama-ramu.workers.dev
+  - `v*` tag push: `deploy-release` が **no-traffic upload** (`wrangler versions upload`) → Release Wave / `wrangler versions deploy <id>@100%` で明示 flip
+    - URL: https://alc.ippoan.org (custom domain) / alc-app.m-tama-ramu.workers.dev
+  - 緊急時 fallback (手動): `cd web && npm run deploy` (= `nuxt build && wrangler deploy`)
 - **cf-alc-signaling (Cloudflare Workers)**: `cd cf-alc-signaling && wrangler deploy`
   - URL: https://alc-signaling.m-tama-ramu.workers.dev
   - シークレット不要 (現在 STUN P2P のみ。TURN は後日対応予定)

--- a/web/app/app.vue
+++ b/web/app/app.vue
@@ -1,11 +1,12 @@
 <script setup lang="ts">
-import { StagingFooter } from '@ippoan/auth-client'
+import { StagingFooter, VersionBadge } from '@ippoan/auth-client'
 
 const { init, isLoading } = useAuth()
 const { isAndroidApp } = useFingerprint()
 const config = useRuntimeConfig()
 const apiBase = config.public.apiBase as string
 const stagingTenantId = config.public.stagingTenantId as string
+const appVersion = config.public.appVersion as string
 
 onMounted(async () => {
   // --- リロード検知ログ ---
@@ -43,6 +44,7 @@ useHead({
     </div>
     <NuxtPage v-else />
     <StagingFooter :api-base="apiBase" :tenant-id="stagingTenantId" />
+    <VersionBadge :api-base="apiBase" :frontend-version="appVersion" />
   </div>
 </template>
 

--- a/web/nuxt.config.ts
+++ b/web/nuxt.config.ts
@@ -13,6 +13,7 @@ export default defineNuxtConfig({
       googleClientId: process.env.NUXT_PUBLIC_GOOGLE_CLIENT_ID || '',
       authWorkerUrl: process.env.NUXT_PUBLIC_AUTH_WORKER_URL || 'https://auth.ippoan.org',
       stagingTenantId: process.env.NUXT_PUBLIC_STAGING_TENANT_ID || '',
+      appVersion: process.env.NUXT_PUBLIC_APP_VERSION || 'dev',
     },
   },
 


### PR DESCRIPTION
## 概要

Issue #33 の残乖離を潰し、alc-app の staging / tag / Release Wave 環境を reference 実装 `ippoan/auth-worker` に揃える。

## 変更 (issue checklist 対応)

- [x] **1. `test.yml` の `on.push` から `paths` フィルタを撤去 (最優先)**
  - GitHub Actions は **tag push でも `paths` を評価する**ため、`web/` を変更しない `v*` tag リリースで `deploy-release` / no-traffic upload / traffic-report が発火しない懸念があった。
  - `push` は auth-worker と同形 (paths 無し) に。`pull_request` 側だけ `paths` を残し PR の無駄打ちは抑制。

- [x] **2. VersionBadge (`@ippoan/auth-client`) を採用**
  - `nuxt.config.ts` の `runtimeConfig.public` に `appVersion`（`NUXT_PUBLIC_APP_VERSION` → default `dev`）を追加
  - `app.vue` に `<VersionBadge :api-base="apiBase" :frontend-version="appVersion" />` を配置（既存 `StagingFooter` の隣）
  - `test.yml` の deploy script で `NUXT_PUBLIC_APP_VERSION` を注入（staging = `github.sha` / release = `github.ref_name`）。build 時の焼き込み + `wrangler --var` の二重指定。
  - 配線は既存 consumer `nuxt-pwa-carins` に準拠（auth-client は同 `^0.2.28`、`VersionBadge` を export 済み）。

- [x] **3. `CLAUDE.md` を CI デプロイ運用に更新**
  - 通常運用は CI 経由（PR→staging 自動 / `v*` tag→no-traffic release + Wave flip）。手動 `cd web && npm run deploy` は緊急時 fallback の位置づけに改めた。

- [x] **4. staging custom domain 確認**
  - `alc-staging.ippoan.org` は **HTTP 200** を返し配信済みを確認。DNS / Cloudflare 側の追加整備は不要。

## 参照

- 基準実装: `ippoan/auth-worker` / consumer `ippoan/nuxt-pwa-carins`
- reusable: `ippoan/ci-workflows`（`frontend-ci.yml`）

Refs #33
Refs ippoan/ci-dashboard#137

---
_Generated by [Claude Code](https://claude.ai/code/session_01TXfLjjv9cm5k6KzN5fYVYr)_