### PR TITLE
feat(device): settings 取得に X-Device-Token を送る — Phase B (rust-alc-api#388)

### DIFF
--- a/web/app/components/DeviceRegistration.vue
+++ b/web/app/components/DeviceRegistration.vue
@@ -38,7 +38,7 @@ function startPolling() {
       const res = await checkDeviceRegistrationStatus(registrationCode.value)
       if (res.status === 'approved' && res.tenant_id && res.device_id) {
         stopPolling()
-        activateDevice(res.tenant_id, res.device_id)
+        activateDevice(res.tenant_id, res.device_id, res.settings_token)
         status.value = 'approved'
       } else if (res.status === 'expired') {
         stopPolling()

--- a/web/app/components/TenkoRemoteAdminView.vue
+++ b/web/app/components/TenkoRemoteAdminView.vue
@@ -291,13 +291,13 @@ function connectWatchSocket() {
   }
 }
 
-const { deviceId } = useAuth()
+const { deviceId, deviceSettingsToken } = useAuth()
 
 onMounted(async () => {
   // 着信通知モード: ルーム読み込みより先に管理者IDを復元 (requestCall で id_input スキップするため)
   if (props.initialRoomId && !authenticatedManagerId.value && deviceId.value) {
     try {
-      const settings = await getDeviceSettings(deviceId.value)
+      const settings = await getDeviceSettings(deviceId.value, deviceSettingsToken.value)
       if (settings.last_login_employee_id) {
         setManagerId(settings.last_login_employee_id)
       }

--- a/web/app/composables/useAuth.ts
+++ b/web/app/composables/useAuth.ts
@@ -12,6 +12,7 @@ function decodeJwtPayload(base64url: string): any {
 const REFRESH_TOKEN_KEY = 'alc_refresh_token'
 const DEVICE_TENANT_KEY = 'alc_device_tenant_id'
 const DEVICE_ID_KEY = 'alc_device_id'
+const DEVICE_SETTINGS_TOKEN_KEY = 'alc_device_settings_token'
 
 // シングルトン state (composable の外で定義して複数コンポーネント間で共有)
 const user = ref<AuthUser | null>(null)
@@ -23,6 +24,10 @@ const deviceTenantId = ref<string | null>(
 )
 const deviceId = ref<string | null>(
   isClient ? localStorage.getItem(DEVICE_ID_KEY) : null,
+)
+// settings 取得用の device 保有 token (Refs rust-alc-api#388)。承認時に backend が発行
+const deviceSettingsToken = ref<string | null>(
+  isClient ? localStorage.getItem(DEVICE_SETTINGS_TOKEN_KEY) : null,
 )
 
 let initialized = false
@@ -307,9 +312,10 @@ export function useAuth() {
   }
 
   /** 端末をテナントにアクティベート */
-  function activateDevice(tenantId: string, devId?: string) {
+  function activateDevice(tenantId: string, devId?: string, settingsToken?: string) {
     deviceTenantId.value = tenantId
     if (devId) deviceId.value = devId
+    if (settingsToken) deviceSettingsToken.value = settingsToken
     if (isClient) {
       localStorage.setItem(DEVICE_TENANT_KEY, tenantId)
       if (devId) {
@@ -320,6 +326,9 @@ export function useAuth() {
           android.setDeviceId(devId)
         }
       }
+      if (settingsToken) {
+        localStorage.setItem(DEVICE_SETTINGS_TOKEN_KEY, settingsToken)
+      }
     }
   }
 
@@ -327,9 +336,11 @@ export function useAuth() {
   function deactivateDevice() {
     deviceTenantId.value = null
     deviceId.value = null
+    deviceSettingsToken.value = null
     if (isClient) {
       localStorage.removeItem(DEVICE_TENANT_KEY)
       localStorage.removeItem(DEVICE_ID_KEY)
+      localStorage.removeItem(DEVICE_SETTINGS_TOKEN_KEY)
       const android = (window as any).Android
       if (android?.setDeviceId) {
         android.setDeviceId('')
@@ -390,6 +401,7 @@ export function useAuth() {
     isLoading: readonly(isLoading),
     deviceTenantId: readonly(deviceTenantId),
     deviceId: readonly(deviceId),
+    deviceSettingsToken: readonly(deviceSettingsToken),
     isDeviceActivated,
     init,
     loginWithGoogleRedirect,

--- a/web/app/pages/device-claim.vue
+++ b/web/app/pages/device-claim.vue
@@ -43,7 +43,7 @@ async function submit() {
 
     if (res.flow_type === 'url' && res.device_id && res.tenant_id) {
       // URLフロー: 即アクティベート
-      activateDevice(res.tenant_id, res.device_id)
+      activateDevice(res.tenant_id, res.device_id, res.settings_token)
       status.value = 'activated'
     } else if (res.flow_type === 'qr_permanent') {
       // QR永久: 承認待ち
@@ -66,7 +66,7 @@ function startPolling() {
       const res = await checkDeviceRegistrationStatus(token.value)
       if (res.status === 'approved' && res.tenant_id && res.device_id) {
         stopPolling()
-        activateDevice(res.tenant_id, res.device_id)
+        activateDevice(res.tenant_id, res.device_id, res.settings_token)
         status.value = 'activated'
       } else if (res.status === 'rejected') {
         stopPolling()

--- a/web/app/types/index.ts
+++ b/web/app/types/index.ts
@@ -838,6 +838,8 @@ export interface RegistrationStatusResponse {
   device_id?: string
   tenant_id?: string
   device_name?: string
+  /** 承認時に発行される device 保有 token (approved 時のみ、Refs rust-alc-api#388) */
+  settings_token?: string
 }
 
 export interface ClaimRegistrationRequest {
@@ -852,6 +854,8 @@ export interface ClaimRegistrationResponse {
   device_id?: string
   tenant_id?: string
   message?: string
+  /** 即時登録フローで発行される device 保有 token (Refs rust-alc-api#388) */
+  settings_token?: string
 }
 
 export interface CreateTokenResponse {

--- a/web/app/utils/api.ts
+++ b/web/app/utils/api.ts
@@ -708,8 +708,16 @@ export async function deleteDevice(id: string): Promise<void> {
   return request<void>(`/api/devices/${id}`, { method: 'DELETE' })
 }
 
-export async function getDeviceSettings(deviceId: string): Promise<DeviceSettingsResponse> {
-  return request<DeviceSettingsResponse>(`/api/devices/settings/${deviceId}`)
+export async function getDeviceSettings(
+  deviceId: string,
+  settingsToken?: string | null,
+): Promise<DeviceSettingsResponse> {
+  // 承認時に発行された device 保有 token を X-Device-Token で送る (Refs rust-alc-api#388)。
+  // 未発行の旧端末は従来どおりヘッダ無しで呼べる (backend 側が移行期互換)
+  const options: RequestInit = settingsToken
+    ? { headers: { 'X-Device-Token': settingsToken } }
+    : {}
+  return request<DeviceSettingsResponse>(`/api/devices/settings/${deviceId}`, options)
 }
 
 export async function updateDeviceCallSettings(

--- a/web/tests/composables/useAuth.test.ts
+++ b/web/tests/composables/useAuth.test.ts
@@ -124,6 +124,21 @@ describe('useAuth', () => {
       expect(localStorage.getItem('alc_device_id')).toBeNull()
     })
 
+    it('should store settings_token on activate and clear on deactivate (Refs rust-alc-api#388)', async () => {
+      const { useAuth } = await import('~/composables/useAuth')
+      const { activateDevice, deactivateDevice, deviceSettingsToken } = useAuth()
+
+      activateDevice('tenant-123', 'dev-456', 'token-abc')
+
+      expect(deviceSettingsToken.value).toBe('token-abc')
+      expect(localStorage.getItem('alc_device_settings_token')).toBe('token-abc')
+
+      deactivateDevice()
+
+      expect(deviceSettingsToken.value).toBeNull()
+      expect(localStorage.getItem('alc_device_settings_token')).toBeNull()
+    })
+
     it('should call Android.setDeviceId("") on deactivate', async () => {
       const mockSetDeviceId = vi.fn()
       ;(window as any).Android = { setDeviceId: mockSetDeviceId }

--- a/web/tests/utils/api.test.ts
+++ b/web/tests/utils/api.test.ts
@@ -609,6 +609,25 @@ describe('api', () => {
         })
       },
     )
+
+    // live は SEED device に settings_token が未発行のため token 付き呼び出しが 401 になる
+    it.skipIf(isLive)('getDeviceSettings sends X-Device-Token when provided (Refs rust-alc-api#388)', async () => {
+      stubOk({ call_enabled: true, status: 'active', always_on: false })
+      await callApi(() => getDeviceSettings(SEED_DEVICE_ID, 'tok-123'))
+      assertMock(() => {
+        const headers = mockFetch.mock.calls[0][1].headers as Record<string, string>
+        expect(headers['X-Device-Token']).toBe('tok-123')
+      })
+    })
+
+    it.skipIf(isLive)('getDeviceSettings omits X-Device-Token when not provided', async () => {
+      stubOk({ call_enabled: true, status: 'active', always_on: false })
+      await callApi(() => getDeviceSettings(SEED_DEVICE_ID))
+      assertMock(() => {
+        const headers = mockFetch.mock.calls[0][1].headers as Record<string, string>
+        expect(headers['X-Device-Token']).toBeUndefined()
+      })
+    })
   })
 
   // ============================================================


### PR DESCRIPTION
backend の device 保有 token 導入 (ippoan/rust-alc-api#400, Phase A) に対応するクライアント側 (**Phase B**)。

Refs ippoan/rust-alc-api#388

## 変更内容

| ファイル | 内容 |
|---|---|
| `composables/useAuth.ts` | `activateDevice(tenantId, devId?, settingsToken?)` — token を localStorage (`alc_device_settings_token`) に保存、`deactivateDevice` で削除、`deviceSettingsToken` state を公開 |
| `utils/api.ts` | `getDeviceSettings(deviceId, settingsToken?)` — token があれば `X-Device-Token` ヘッダを付与。無ければ従来どおり (旧端末互換) |
| `DeviceRegistration.vue` | status ポーリング (approved) の `settings_token` を activateDevice へ |
| `pages/device-claim.vue` | 即時登録 (url / device_owner) response の token を activateDevice へ (2 箇所) |
| `TenkoRemoteAdminView.vue` | 保存済み token を付けて settings 取得 |
| `types/index.ts` | `RegistrationStatusResponse` / `ClaimRegistrationResponse` に `settings_token?` |

## 互換性

- backend response に `settings_token` が無ければ何も保存・送信しない = **Phase A (rust-alc-api#400) のマージ前後どちらでも安全に merge 可能**
- token 未保存の既存端末はヘッダ無しで従来どおり動作 (backend 側が移行期互換)

## テスト

- useAuth: activate で保存 / deactivate で削除 (1 件追加、70 件 pass)
- api: `X-Device-Token` 送信あり/なし (2 件追加、mock モード。live は SEED device に token 未発行のため skipIf)
- `check_coverage_100.mjs`: **29 ファイル 100% 維持** (useAuth.ts / api.ts とも gate 対象) をローカル確認

## 残り (Phase B の Android 分 / Phase C)

- AlcoholChecker (Android) の同対応はリポジトリが本セッションのスコープ外のため別途
- Phase C (backend で token 未送信を 401 化) はクライアント普及後に判断 (rust-alc-api#388 参照)

https://claude.ai/code/session_01Y62YGiPFyFQ7LkamqjdAaQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y62YGiPFyFQ7LkamqjdAaQ)_