### PR TITLE
ci: add cap-catalog extract workflow

### DIFF
--- a/.github/workflows/cap-catalog-extract.yml
+++ b/.github/workflows/cap-catalog-extract.yml
@@ -1,0 +1,14 @@
+name: cap-catalog extract
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+permissions:
+  contents: read
+jobs:
+  extract:
+    uses: ippoan/ci-workflows/.github/workflows/catalog-extract.yml@main
+    with:
+      language: ts
+      working_directory: web

--- a/.github/workflows/cap-catalog-extract.yml
+++ b/.github/workflows/cap-catalog-extract.yml
@@ -5,10 +5,16 @@ on:
   pull_request:
     branches: [main]
 permissions:
-  contents: read
+  contents: write
+  pull-requests: write
 jobs:
   extract:
     uses: ippoan/ci-workflows/.github/workflows/catalog-extract.yml@main
     with:
       language: ts
       working_directory: web
+  auto-merge:
+    needs: [extract]
+    if: github.event_name == 'pull_request'
+    uses: ippoan/ci-workflows/.github/workflows/auto-merge.yml@main
+    secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ on:
     # 永遠に来ず PR が "2 expected checks" で blocked になり管理者バイパス必須に
     # なるため、skill / CLAUDE.md など .claude 配下の変更でも CI を発火させる。
     branches: [main]
-    paths: ['web/**', '.claude/**', '.github/workflows/test.yml', '.github/workflows/release-wave-retest.yml']
+    paths: ['web/**', '.claude/**', '.github/workflows/test.yml', '.github/workflows/release-wave-retest.yml', '.github/workflows/cap-catalog-extract.yml']
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

`.github/workflows/cap-catalog-extract.yml` を追加し catalog-extract reusable を呼ぶ。`language: ts`, `working_directory: web`。

Refs #42
Refs ippoan/cap-catalog#29

---
_Generated by [Claude Code](https://claude.ai/code/session_017nhvYbgAG11YRxMeSzDwmz)_