### PR TITLE
ci: per-job permission for cap-catalog-extract (security HIGH#3)

### DIFF
--- a/.github/workflows/cap-catalog-extract.yml
+++ b/.github/workflows/cap-catalog-extract.yml
@@ -4,9 +4,12 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+
+# Per-job permission パターン (Refs ippoan/cap-catalog#29 retroactive 改善):
+# top-level は read のみ。auto-merge job 側で write を明示 elevate する。
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
+
 jobs:
   extract:
     uses: ippoan/ci-workflows/.github/workflows/catalog-extract.yml@main
@@ -16,5 +19,8 @@ jobs:
   auto-merge:
     needs: [extract]
     if: github.event_name == 'pull_request'
+    permissions:
+      contents: write
+      pull-requests: write
     uses: ippoan/ci-workflows/.github/workflows/auto-merge.yml@main
     secrets: inherit


### PR DESCRIPTION
## Summary

`cap-catalog-extract.yml` の top-level `permissions: contents: write` + `pull-requests: write` を `contents: read` に絞り、`auto-merge` job 側で必要な write を明示 elevate する (security review HIGH#3、ippoan/cap-catalog#29 retroactive 改善)。

これにより `extract` job (= 外部 org `ippoan/ci-workflows` の `catalog-extract.yml` reusable を呼ぶ trust boundary) は read だけ持ち、`auto-merge.yml` だけが write を持つ最小権限になる。

## Test plan

- [ ] PR の `extract / extract (ts)` job が green
- [ ] PR の `auto-merge / Auto Merge` job が green

Refs ippoan/cap-catalog#29

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SCw8qoH9AdPa3ZCeTYCGnL

---
_Generated by [Claude Code](https://claude.ai/code/session_01SCw8qoH9AdPa3ZCeTYCGnL)_