### PR TITLE
feat(proxy): キオスク用 server proxy を新設 (#434 Option ① / B案)

### DIFF
--- a/web/server/api/proxy/[...path].ts
+++ b/web/server/api/proxy/[...path].ts
@@ -1,0 +1,105 @@
+/**
+ * キオスク API proxy: `/api/proxy/<path>` → rust-alc-api `/api/<path>`
+ *
+ * #434 Option ① (proxy + service binding) の本体。キオスク端末 (device JWT,
+ * role=device-kiosk) からの呼び出しを:
+ *   leg A: auth-worker `/auth/introspect` を **CF service binding** で叩いて検証
+ *          (device JWT の署名 + ACL を auth-worker に集約。rust 側では検証しない)
+ *   leg B: 検証済み tenant_id を `X-Tenant-ID` に載せて rust-alc-api へ転送
+ *          (device JWT 自体は転送しない)。proxy 真正性は Cloud Run の網層
+ *          ロックダウンで担保するため `X-Tenant-Proxy-Secret` は使わない (#434 B案)。
+ * の 2 段で中継する。
+ *
+ * 管理者経路 (rust-alc-api 署名の Google OAuth JWT) は proxy を経由せず `utils/api.ts`
+ * から直 fetch で良い (rust-alc-api が Authorization を直接検証できるため)。本 route は
+ * キオスク (bare X-Tenant-ID を device JWT 経由に置き換える) 専用。
+ *
+ * NOTE: 本 route は step 3a (infra) として先行投入する。実際にキオスクが device JWT
+ * を送るよう切替えるのは step 3b/3c (utils/api.ts + useAuth の device JWT 配線)。
+ * 切替前は caller が居ないため inert。本 PR 単体では既存挙動を一切変えない。
+ */
+import {
+  buildTargetUrl,
+  classifyProxyResponse,
+  introspectToken,
+  parseJsonBody,
+} from '@ippoan/auth-client/server'
+import {
+  bearerToken,
+  buildKioskForwardHeaders,
+  cfEnv,
+  DEVICE_ROLE_KIOSK,
+  resolveSecret,
+} from '../../utils/kiosk-proxy'
+
+export default defineEventHandler(async (event) => {
+  const env = cfEnv(event)
+  const config = useRuntimeConfig(event)
+
+  // introspect の認証に使う shared secret (auth-worker resolveAllSharedSecrets と対)。
+  const sharedSecret = await resolveSecret(env.INTERNAL_SHARED_SECRET)
+  if (!sharedSecret) {
+    throw createError({ statusCode: 503, statusMessage: 'INTERNAL_SHARED_SECRET binding 未設定' })
+  }
+
+  // leg A は公開 HTTP ではなく CF service binding (worker-to-worker) で叩く。
+  const authWorker = env.AUTH_WORKER as { fetch: typeof fetch } | undefined
+  if (!authWorker) {
+    throw createError({ statusCode: 503, statusMessage: 'AUTH_WORKER service binding 未設定' })
+  }
+
+  const token = bearerToken(getHeader(event, 'authorization'))
+  const result = await introspectToken({
+    authWorkerUrl: (config.public.authWorkerUrl as string) || 'https://auth.ippoan.org',
+    sharedSecret,
+    token,
+    origin: getRequestURL(event).origin,
+    fetchImpl: (input, init) =>
+      authWorker.fetch(input as Parameters<typeof fetch>[0], init as RequestInit),
+  })
+
+  // device-kiosk role の有効な device JWT 以外は 401 (bare X-Tenant-ID 直叩きを拒否)。
+  if (!result.active || result.role !== DEVICE_ROLE_KIOSK) {
+    throw createError({ statusCode: 401, statusMessage: 'Unauthorized' })
+  }
+
+  const path = getRouterParam(event, 'path') || ''
+  const backendUrl = (config.public.apiBase as string) || 'https://alc-api.ippoan.org'
+  const url = buildTargetUrl(backendUrl, '/api/', path, getQuery(event))
+
+  const headers = buildKioskForwardHeaders({
+    contentType: getHeader(event, 'content-type'),
+    tenantId: result.tenant_id,
+  })
+
+  const method = event.method
+  const fetchOptions: RequestInit = { method, headers }
+  if (['POST', 'PUT', 'PATCH'].includes(method)) {
+    try {
+      const body = await readBody(event)
+      if (body) {
+        fetchOptions.body = JSON.stringify(body)
+        headers['Content-Type'] = 'application/json'
+      }
+    } catch {
+      // body なし (DELETE 等)
+    }
+  }
+
+  const response = await fetch(url, fetchOptions)
+
+  const responseContentType = response.headers.get('content-type')
+  if (responseContentType) setHeader(event, 'content-type', responseContentType)
+  const contentDisposition = response.headers.get('content-disposition')
+  if (contentDisposition) setHeader(event, 'content-disposition', contentDisposition)
+  setResponseStatus(event, response.status)
+
+  switch (classifyProxyResponse(response.status, responseContentType, path)) {
+    case 'binary':
+      return new Uint8Array(await response.arrayBuffer())
+    case 'empty':
+      return null
+    case 'json':
+      return parseJsonBody(await response.text())
+  }
+})

--- a/web/server/utils/kiosk-proxy.ts
+++ b/web/server/utils/kiosk-proxy.ts
@@ -1,0 +1,60 @@
+import type { H3Event } from 'h3'
+
+/**
+ * キオスク proxy (`server/api/proxy/[...path].ts`) のヘルパー群。
+ *
+ * #434 で確定した Option ① (proxy + service binding) / B案 の alc-app 側実装。
+ * キオスク端末は device JWT (role=device-kiosk) を `Authorization: Bearer` で
+ * 送り、proxy が auth-worker `/auth/introspect` で検証 (leg A、service binding)
+ * してから rust-alc-api に検証済み `X-Tenant-ID` を注入して転送する (leg B)。
+ * **device JWT 自体は rust-alc-api に転送しない** (検証は auth-worker に集約)。
+ *
+ * leg B には proxy 真正性の証明 (X-Tenant-Proxy-Secret) を **載せない** (B案)。
+ * proxy 以外からの bare X-Tenant-ID 直叩き (= #434 の穴) は、rust-alc-api の
+ * Cloud Run を網層でロックダウン (ingress 制限 + CF Worker / 内部のみ到達可) して
+ * 塞ぐ方針 (issue #434 の "future" 前倒し)。網層ロックダウン完了までは X-Tenant-ID
+ * 直叩きが残る点に注意。
+ */
+
+/** alc-app キオスク端末用 device role (auth-worker `DEVICE_ROLE_KIOSK` と一致)。 */
+export const DEVICE_ROLE_KIOSK = 'device-kiosk'
+
+/** Secrets Store binding (`.get()`) / 文字列 のいずれでも値を取り出す。 */
+export async function resolveSecret(binding: unknown): Promise<string | null> {
+  if (typeof binding === 'string') return binding
+  if (binding && typeof (binding as { get?: unknown }).get === 'function') {
+    return (await (binding as { get(): Promise<string> }).get()) ?? null
+  }
+  return null
+}
+
+/** CF Worker の binding/env (service binding / secrets store / vars) を取り出す。 */
+export function cfEnv(event: H3Event): Record<string, unknown> {
+  return (event.context.cloudflare as { env?: Record<string, unknown> } | undefined)?.env ?? {}
+}
+
+/** `Authorization: Bearer <jwt>` から JWT を取り出す。無ければ空文字。 */
+export function bearerToken(authHeader: string | undefined): string {
+  if (!authHeader) return ''
+  const m = /^Bearer\s+(.+)$/i.exec(authHeader)
+  return m ? m[1] : ''
+}
+
+/**
+ * rust-alc-api への転送ヘッダーを組む。
+ *
+ * - `Authorization` は **転送しない** (device JWT は proxy で消費済み、Option ①)。
+ * - `X-Tenant-ID` は introspect で得た verified tenant のみ (端末は詐称不能)。
+ *
+ * proxy 真正性の証明 (X-Tenant-Proxy-Secret) は **載せない** (B案)。bare X-Tenant-ID
+ * 直叩きは rust-alc-api の Cloud Run 網層ロックダウンで塞ぐ。
+ */
+export function buildKioskForwardHeaders(input: {
+  contentType?: string | null
+  tenantId: string
+}): Record<string, string> {
+  const headers: Record<string, string> = {}
+  if (input.contentType) headers['Content-Type'] = input.contentType
+  headers['X-Tenant-ID'] = input.tenantId
+  return headers
+}

--- a/web/tests/server/kiosk-proxy.test.ts
+++ b/web/tests/server/kiosk-proxy.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest'
+import {
+  DEVICE_ROLE_KIOSK,
+  resolveSecret,
+  cfEnv,
+  bearerToken,
+  buildKioskForwardHeaders,
+} from '../../server/utils/kiosk-proxy'
+
+describe('kiosk-proxy helpers (#434 B案)', () => {
+  it('DEVICE_ROLE_KIOSK は auth-worker の role 文字列と一致', () => {
+    expect(DEVICE_ROLE_KIOSK).toBe('device-kiosk')
+  })
+
+  describe('resolveSecret', () => {
+    it('文字列はそのまま返す', async () => {
+      expect(await resolveSecret('plain-secret')).toBe('plain-secret')
+    })
+
+    it('Secrets Store binding (.get()) から値を取り出す', async () => {
+      const binding = { get: async () => 'from-store' }
+      expect(await resolveSecret(binding)).toBe('from-store')
+    })
+
+    it('.get() が null/undefined を返したら null', async () => {
+      expect(await resolveSecret({ get: async () => null })).toBeNull()
+      expect(await resolveSecret({ get: async () => undefined })).toBeNull()
+    })
+
+    it('未設定 (undefined/null/数値) は null', async () => {
+      expect(await resolveSecret(undefined)).toBeNull()
+      expect(await resolveSecret(null)).toBeNull()
+      expect(await resolveSecret(123)).toBeNull()
+    })
+  })
+
+  describe('cfEnv', () => {
+    it('event.context.cloudflare.env を返す', () => {
+      const env = { AUTH_WORKER: {}, INTERNAL_SHARED_SECRET: 'x' }
+      const event = { context: { cloudflare: { env } } } as never
+      expect(cfEnv(event)).toBe(env)
+    })
+
+    it('cloudflare コンテキストが無ければ空オブジェクト', () => {
+      expect(cfEnv({ context: {} } as never)).toEqual({})
+    })
+  })
+
+  describe('bearerToken', () => {
+    it('Bearer prefix を剥がす (大文字小文字無視)', () => {
+      expect(bearerToken('Bearer abc.def.ghi')).toBe('abc.def.ghi')
+      expect(bearerToken('bearer xyz')).toBe('xyz')
+    })
+
+    it('Bearer 以外 / 欠落は空文字', () => {
+      expect(bearerToken(undefined)).toBe('')
+      expect(bearerToken('')).toBe('')
+      expect(bearerToken('Basic abc')).toBe('')
+    })
+  })
+
+  describe('buildKioskForwardHeaders', () => {
+    it('検証済み X-Tenant-ID のみ載せる (Authorization / proxy secret は載せない)', () => {
+      const headers = buildKioskForwardHeaders({
+        contentType: 'application/json',
+        tenantId: '11111111-1111-1111-1111-111111111111',
+      })
+      expect(headers).toEqual({
+        'Content-Type': 'application/json',
+        'X-Tenant-ID': '11111111-1111-1111-1111-111111111111',
+      })
+      expect(headers).not.toHaveProperty('Authorization')
+      expect(headers).not.toHaveProperty('X-Tenant-Proxy-Secret')
+    })
+
+    it('contentType 無しなら Content-Type を省く', () => {
+      const headers = buildKioskForwardHeaders({ tenantId: 'tid' })
+      expect(headers).toEqual({ 'X-Tenant-ID': 'tid' })
+    })
+  })
+})

--- a/web/wrangler.jsonc
+++ b/web/wrangler.jsonc
@@ -17,6 +17,26 @@
 	"secrets": {
 		"required": []
 	},
+	// キオスク proxy (server/api/proxy/[...path].ts, #434 Option ① / B案) 用。
+	// leg A: auth-worker /auth/introspect を service binding (worker-to-worker) で
+	// 叩いて device JWT を検証する。INTERNAL_SHARED_SECRET は introspect の認証用
+	// (carins / ref-files / cc-relay と同じ CF Secrets Store entry を物理共有)。
+	// leg B (rust-alc-api への X-Tenant-ID 転送) には proxy 真正性 secret を載せない。
+	// bare X-Tenant-ID 直叩きは Cloud Run の網層ロックダウンで塞ぐ方針なので
+	// TENANT_PROXY_SECRET binding は持たない (#434 B案)。
+	"services": [
+		{
+			"binding": "AUTH_WORKER",
+			"service": "auth-worker"
+		}
+	],
+	"secrets_store_secrets": [
+		{
+			"binding": "INTERNAL_SHARED_SECRET",
+			"store_id": "bd7bc91a3e5f4111add4acf6cb4b8733",
+			"secret_name": "INTERNAL_SHARED_SECRET"
+		}
+	],
 	"env": {
 		"staging": {
 			"name": "alc-app-staging",
@@ -31,7 +51,22 @@
 				"NUXT_PUBLIC_STAGING_TENANT_ID": "11111111-1111-1111-1111-111111111111",
 				"NUXT_PUBLIC_GOOGLE_CLIENT_ID": "747065218280-ugkrbgaoik32f5mmi94sso4b0026j3cp.apps.googleusercontent.com",
 				"NUXT_PUBLIC_AUTH_WORKER_URL": "https://auth-staging.ippoan.org"
-			}
+			},
+			// named env は top-level binding を継承しないので再宣言する。
+			// staging は auth-worker-staging を叩く。
+			"services": [
+				{
+					"binding": "AUTH_WORKER",
+					"service": "auth-worker-staging"
+				}
+			],
+			"secrets_store_secrets": [
+				{
+					"binding": "INTERNAL_SHARED_SECRET",
+					"store_id": "bd7bc91a3e5f4111add4acf6cb4b8733",
+					"secret_name": "INTERNAL_SHARED_SECRET"
+				}
+			]
 		}
 	},
 	"vars": {


### PR DESCRIPTION
## 概要

#434 (X-Tenant-ID 単独経路の無認証アクセス) 対策の **step 3a**。キオスク端末の bare `X-Tenant-ID` 直叩きを **device JWT 経由**に置き換えるための alc-app server proxy を新設する。

確定アーキテクチャは [#issuecomment-4805593597](https://github.com/ippoan/rust-alc-api/issues/434#issuecomment-4805593597) の Option ①。ただし leg B の真正性担保は **B案**（`TENANT_PROXY_SECRET` を使わず、Cloud Run の網層ロックダウンで塞ぐ）に確定。

## 変更

- **`web/server/api/proxy/[...path].ts`** (新規) — `/api/proxy/<path>` → rust-alc-api `/api/<path>`
  - **leg A**: device JWT を `Authorization: Bearer` で受け、auth-worker `/auth/introspect` を **CF service binding (`AUTH_WORKER`)** 経由で検証。`role === device-kiosk` 以外は 401。検証は `@ippoan/auth-client/server` の `introspectToken`（`fetchImpl` に service binding を注入）に集約。
  - **leg B**: 検証済み `tenant_id` を `X-Tenant-ID` で rust-alc-api に転送。**device JWT 自体は転送しない**（rust-alc-api の `AppClaims` は `email`/`name` 必須・`sub: Uuid` で device JWT と非互換なため、検証は auth-worker に集約）。
- **`web/server/utils/kiosk-proxy.ts`** (新規) — `resolveSecret` / `cfEnv` / `bearerToken` / `buildKioskForwardHeaders` の pure helper。
- **`web/wrangler.jsonc`** — `AUTH_WORKER` service binding（prod=`auth-worker` / staging=`auth-worker-staging`）+ `INTERNAL_SHARED_SECRET`（introspect 認証用、carins / ref-files と同じ CF Secrets Store entry を共有）を追加。
- **`web/tests/server/kiosk-proxy.test.ts`** (新規) — helper の回帰テスト。

## B案: なぜ X-Tenant-Proxy-Secret を載せないか

leg B（proxy → Cloud Run）は worker-to-worker の service binding が使えない（rust-alc-api は Cloud Run）。当初案は `X-Tenant-Proxy-Secret`（constant-time）で proxy 真正性を証明する設計だったが、**B案では secret を持たず、rust-alc-api の Cloud Run を網層でロックダウン**（ingress 制限 + CF Worker / 内部のみ到達可）して bare `X-Tenant-ID` 直叩きを塞ぐ方針に確定。

## 非破壊性

本 route は **step 3a (infra) の先行投入**。キオスク (`utils/api.ts`) を proxy 経由に切替えるのは **step 3b**、device JWT mint は **step 3c**。切替前は caller が居ないため inert で、本 PR 単体では既存挙動を一切変えない。

## 残ステップ (本 PR スコープ外)

- **step 3b**: `web/app/utils/api.ts` のキオスク X-Tenant-ID 経路を `/api/proxy` 経由に変更
- **step 3c**: device 再 pairing (device-kiosk role) → `/device/token` で device JWT mint → `useAuth` 配線
- **網層ロックダウン**: rust-alc-api Cloud Run の ingress 制限 + CF Worker からの到達経路確立（B案の本丸。これが完了するまで bare X-Tenant-ID 直叩きは残る点に注意）
- **step 4**: nuxt-pwa-carins / nuxt-items の対応

Refs #434

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01G4V5MhG2JnKsMt4gtyXtm3)_