### PR TITLE
feat(kiosk): device JWT 取得 composable useDeviceToken (#434 step 3c core)

### DIFF
--- a/web/app/composables/useDeviceToken.ts
+++ b/web/app/composables/useDeviceToken.ts
@@ -1,0 +1,110 @@
+/**
+ * キオスク端末用 device JWT の取得 (#434 step 3c の中核)。
+ *
+ * auth-worker の device pairing (`/device/pair`, role=device-kiosk) で発行された
+ * **device credential** (`device_id` + `device_secret`) を localStorage に保持し、
+ * runtime で auth-worker `/device/token` に提示して **短命 device JWT** (1h) を
+ * mint する。キオスクはこの device JWT を `Authorization: Bearer` で alc-app の
+ * server proxy (`/api/proxy/*`, #434 Option ①) に送る。
+ *
+ * - credential (device_id + device_secret) は pairing で 1 度だけ取得・保存する。
+ *   device_secret は auth-worker 側では hash 保存・再取得不可。
+ * - device JWT は 1h なので expiry の 60s 手前まで cache を再利用する。
+ * - credential 無し / mint 失敗時は null を返す (呼び出し側は従来の X-Tenant-ID
+ *   経路に fallback できる = 段階移行で非破壊)。
+ *
+ * NOTE: 既存の `useAuth` が持つ `alc_device_id` は **rust-alc-api の devices
+ * テーブル id** であり、ここで扱う auth-worker の device credential とは別系統。
+ * 混同を避けるため別 localStorage key (`alc_kiosk_device_*`) を使う。
+ */
+import { ref, computed, readonly } from 'vue'
+
+const KIOSK_DEVICE_ID_KEY = 'alc_kiosk_device_id'
+const KIOSK_DEVICE_SECRET_KEY = 'alc_kiosk_device_secret'
+
+/** device JWT 再利用の手前マージン (ms)。expiry ギリギリの token を返さない。 */
+const REFRESH_BEFORE_MS = 60_000
+/** expires_in 欠落時の fallback TTL (秒、auth-worker DEVICE_JWT_TTL_SECONDS と同値)。 */
+const DEFAULT_TTL_SECONDS = 3600
+
+const isClient = typeof window !== 'undefined'
+
+const kioskDeviceId = ref<string | null>(
+  isClient ? localStorage.getItem(KIOSK_DEVICE_ID_KEY) : null,
+)
+const kioskDeviceSecret = ref<string | null>(
+  isClient ? localStorage.getItem(KIOSK_DEVICE_SECRET_KEY) : null,
+)
+
+// 短命 device JWT の cache (module スコープ = 全 caller で共有)。
+let cachedJwt: string | null = null
+let cachedExpMs = 0
+
+export function useDeviceToken() {
+  const config = useRuntimeConfig()
+  const authWorkerUrl = (config.public.authWorkerUrl as string) || 'https://auth.ippoan.org'
+
+  const hasKioskCredential = computed(() => !!kioskDeviceId.value && !!kioskDeviceSecret.value)
+
+  /** pairing で得た device credential を保存する (device JWT cache は破棄)。 */
+  function storeKioskCredential(id: string, secret: string): void {
+    kioskDeviceId.value = id
+    kioskDeviceSecret.value = secret
+    cachedJwt = null
+    cachedExpMs = 0
+    if (isClient) {
+      localStorage.setItem(KIOSK_DEVICE_ID_KEY, id)
+      localStorage.setItem(KIOSK_DEVICE_SECRET_KEY, secret)
+    }
+  }
+
+  /** device credential と device JWT cache を破棄する (端末退役・revoke 後)。 */
+  function clearKioskCredential(): void {
+    kioskDeviceId.value = null
+    kioskDeviceSecret.value = null
+    cachedJwt = null
+    cachedExpMs = 0
+    if (isClient) {
+      localStorage.removeItem(KIOSK_DEVICE_ID_KEY)
+      localStorage.removeItem(KIOSK_DEVICE_SECRET_KEY)
+    }
+  }
+
+  /**
+   * device JWT を返す。cache が有効ならそれ、無ければ `/device/token` で mint。
+   * credential 未保存 / mint 失敗時は null (呼び出し側は X-Tenant-ID 経路に fallback)。
+   */
+  async function getDeviceJwt(): Promise<string | null> {
+    const id = kioskDeviceId.value
+    const secret = kioskDeviceSecret.value
+    if (!id || !secret) return null
+
+    const nowMs = Date.now()
+    if (cachedJwt && cachedExpMs - REFRESH_BEFORE_MS > nowMs) return cachedJwt
+
+    try {
+      const res = await fetch(`${authWorkerUrl}/device/token`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ device_id: id, device_secret: secret }),
+      })
+      if (!res.ok) return null
+      const data = (await res.json()) as { access_token?: string; expires_in?: number }
+      if (!data.access_token) return null
+      const ttl = typeof data.expires_in === 'number' ? data.expires_in : DEFAULT_TTL_SECONDS
+      cachedJwt = data.access_token
+      cachedExpMs = nowMs + ttl * 1000
+      return cachedJwt
+    } catch {
+      return null
+    }
+  }
+
+  return {
+    hasKioskCredential,
+    kioskDeviceId: readonly(kioskDeviceId),
+    storeKioskCredential,
+    clearKioskCredential,
+    getDeviceJwt,
+  }
+}

--- a/web/tests/composables/useDeviceToken.test.ts
+++ b/web/tests/composables/useDeviceToken.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// useDeviceToken はモジュールスコープに credential ref + JWT cache を持つ
+// シングルトンなので、テスト毎に resetModules + dynamic import で分離する。
+type Mod = typeof import('~/composables/useDeviceToken')
+
+async function load(): Promise<Mod['useDeviceToken']> {
+  const mod = await import('~/composables/useDeviceToken')
+  return mod.useDeviceToken
+}
+
+const ID = 'dev-abc'
+const SECRET = 'sec-xyz'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.restoreAllMocks()
+  vi.resetModules()
+  localStorage.clear()
+})
+
+describe('useDeviceToken (#434 step 3c)', () => {
+  it('credential 未保存なら hasKioskCredential=false / getDeviceJwt=null (fetch しない)', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    const useDeviceToken = await load()
+    const { hasKioskCredential, getDeviceJwt } = useDeviceToken()
+
+    expect(hasKioskCredential.value).toBe(false)
+    expect(await getDeviceJwt()).toBeNull()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('storeKioskCredential で localStorage に保存し hasKioskCredential=true', async () => {
+    const useDeviceToken = await load()
+    const { storeKioskCredential, hasKioskCredential } = useDeviceToken()
+
+    storeKioskCredential(ID, SECRET)
+
+    expect(hasKioskCredential.value).toBe(true)
+    expect(localStorage.getItem('alc_kiosk_device_id')).toBe(ID)
+    expect(localStorage.getItem('alc_kiosk_device_secret')).toBe(SECRET)
+  })
+
+  it('起動時に localStorage から credential を復元する', async () => {
+    localStorage.setItem('alc_kiosk_device_id', ID)
+    localStorage.setItem('alc_kiosk_device_secret', SECRET)
+
+    const useDeviceToken = await load()
+    expect(useDeviceToken().hasKioskCredential.value).toBe(true)
+  })
+
+  it('getDeviceJwt は /device/token を叩いて access_token を返す', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ access_token: 'jwt-1', expires_in: 3600 }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const useDeviceToken = await load()
+    const { storeKioskCredential, getDeviceJwt } = useDeviceToken()
+    storeKioskCredential(ID, SECRET)
+
+    expect(await getDeviceJwt()).toBe('jwt-1')
+
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe('https://auth.ippoan.org/device/token')
+    expect(init.method).toBe('POST')
+    expect(JSON.parse(init.body)).toEqual({ device_id: ID, device_secret: SECRET })
+  })
+
+  it('cache が効く (有効期限内は再 mint しない)', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ access_token: 'jwt-1', expires_in: 3600 }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const useDeviceToken = await load()
+    const { storeKioskCredential, getDeviceJwt } = useDeviceToken()
+    storeKioskCredential(ID, SECRET)
+
+    await getDeviceJwt()
+    await getDeviceJwt()
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('expires_in 欠落時も fallback TTL で cache する', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ access_token: 'jwt-1' }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const useDeviceToken = await load()
+    const { storeKioskCredential, getDeviceJwt } = useDeviceToken()
+    storeKioskCredential(ID, SECRET)
+
+    expect(await getDeviceJwt()).toBe('jwt-1')
+    await getDeviceJwt()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('non-2xx は null', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, json: () => Promise.resolve({}) }))
+    const useDeviceToken = await load()
+    const { storeKioskCredential, getDeviceJwt } = useDeviceToken()
+    storeKioskCredential(ID, SECRET)
+    expect(await getDeviceJwt()).toBeNull()
+  })
+
+  it('access_token 欠落は null', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({ expires_in: 10 }) }))
+    const useDeviceToken = await load()
+    const { storeKioskCredential, getDeviceJwt } = useDeviceToken()
+    storeKioskCredential(ID, SECRET)
+    expect(await getDeviceJwt()).toBeNull()
+  })
+
+  it('fetch throw は null', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network')))
+    const useDeviceToken = await load()
+    const { storeKioskCredential, getDeviceJwt } = useDeviceToken()
+    storeKioskCredential(ID, SECRET)
+    expect(await getDeviceJwt()).toBeNull()
+  })
+
+  it('clearKioskCredential で credential + cache を破棄', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ access_token: 'jwt-1', expires_in: 3600 }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const useDeviceToken = await load()
+    const { storeKioskCredential, clearKioskCredential, getDeviceJwt, hasKioskCredential } = useDeviceToken()
+    storeKioskCredential(ID, SECRET)
+    await getDeviceJwt()
+
+    clearKioskCredential()
+
+    expect(hasKioskCredential.value).toBe(false)
+    expect(localStorage.getItem('alc_kiosk_device_id')).toBeNull()
+    expect(await getDeviceJwt()).toBeNull()
+  })
+})


### PR DESCRIPTION
## 概要

#434 step 3c の中核。キオスク端末が auth-worker の **device credential**（`device_id` + `device_secret`, role=`device-kiosk`、`/device/pair` で発行）から **短命 device JWT**（1h、`/device/token`）を mint する composable を追加する。

step 3a で入れた server proxy (`/api/proxy/*`) は leg A で device JWT を `Authorization: Bearer` で受けて auth-worker introspect 検証する。本 composable はその device JWT を kiosk 側で用意する部分。

## 変更

- **`web/app/composables/useDeviceToken.ts`**（新規）
  - `storeKioskCredential(id, secret)` / `clearKioskCredential()` / `hasKioskCredential` — credential を localStorage (`alc_kiosk_device_*`) に保持。既存 `useAuth` の `alc_device_id`（= rust-alc-api devices テーブル id）とは**別系統**。
  - `getDeviceJwt()` — auth-worker `/device/token` に提示して device JWT を mint、expiry 60s 手前まで cache 再利用。credential 無し / mint 失敗時は `null`（呼び出し側は従来の X-Tenant-ID 経路に fallback できる = 段階移行で非破壊）。
- **`web/tests/composables/useDeviceToken.test.ts`**（新規）— credential 有無 / cache / `expires_in` 欠落 / non-2xx / token 欠落 / throw / clear の回帰テスト。

## 非破壊性

**未配線**（caller は step 3b の transport 切替で繋ぐ）なので、本 PR 単体では既存挙動を一切変えない。

## 残ステップ

- **step 3b**: `web/app/utils/api.ts` のキオスク経路を「device JWT があれば `/api/proxy` 経由・無ければ従来の X-Tenant-ID 直 fetch」に切替（段階移行）。
- **pairing UX**: 管理者が `/device/pair` で device-kiosk credential を発行し kiosk に配布する UX（要設計判断）。
- **網層ロックダウン**（B案 本丸）: rust-alc-api Cloud Run の ingress 制限。

Refs #434

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01G4V5MhG2JnKsMt4gtyXtm3)_