### PR TITLE
fix(proxy): bearerToken の型エラーを修正 (Type Check 復旧, #434)

### DIFF
--- a/web/server/utils/kiosk-proxy.ts
+++ b/web/server/utils/kiosk-proxy.ts
@@ -37,7 +37,8 @@ export function cfEnv(event: H3Event): Record<string, unknown> {
 export function bearerToken(authHeader: string | undefined): string {
   if (!authHeader) return ''
   const m = /^Bearer\s+(.+)$/i.exec(authHeader)
-  return m ? m[1] : ''
+  // noUncheckedIndexedAccess 下では m[1] は string | undefined なので ?? で string に固定。
+  return m?.[1] ?? ''
 }
 
 /**


### PR DESCRIPTION
## 概要

#46 で入った `server/utils/kiosk-proxy.ts` の `bearerToken` に型エラーがあり、`ci / Type Check` が fail していた（`ci / Type Check` は required check でないため #46/#47 とも auto-merge され、**main の typecheck が壊れた状態**になっていた）。fix-forward。

## 原因と修正

```ts
const m = /^Bearer\s+(.+)$/i.exec(authHeader)
return m ? m[1] : ''   // ❌ noUncheckedIndexedAccess 下で m[1] は string | undefined → TS2322
```

`m?.[1] ?? ''` に修正して戻り型 `string` に固定。

```
##[error]server/utils/kiosk-proxy.ts(40,14): error TS2322:
  Type 'string | undefined' is not assignable to type 'string'.
```

Refs #434

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01G4V5MhG2JnKsMt4gtyXtm3)_