### PR TITLE
feat(kiosk): device JWT transport 切替 + pairing データ層 (#434 step 3b/P1)

### DIFF
--- a/web/app/composables/useDeviceToken.ts
+++ b/web/app/composables/useDeviceToken.ts
@@ -100,11 +100,42 @@ export function useDeviceToken() {
     }
   }
 
+  /**
+   * 管理者 (operator session) が auth-worker `/device/pair` で device-kiosk
+   * credential を発行する (P1 pairing の管理者側)。返り値の credential を QR 等で
+   * kiosk に渡し、kiosk 側で `storeKioskCredential` する想定。device_secret は
+   * 1 回限り (auth-worker は hash のみ保持) なので呼び出し側で即配布する。
+   *
+   * @param adminToken 管理者の access token (rust-alc-api / auth-worker 共有 JWT_SECRET)
+   * @param label      運用識別ラベル (端末名等)
+   * @returns 失敗時は null
+   */
+  async function pairKioskDevice(
+    adminToken: string,
+    label: string,
+  ): Promise<{ device_id: string; device_secret: string } | null> {
+    if (!adminToken) return null
+    try {
+      const res = await fetch(`${authWorkerUrl}/device/pair`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${adminToken}` },
+        body: JSON.stringify({ label, role: 'device-kiosk' }),
+      })
+      if (!res.ok) return null
+      const data = (await res.json()) as { device_id?: string; device_secret?: string }
+      if (!data.device_id || !data.device_secret) return null
+      return { device_id: data.device_id, device_secret: data.device_secret }
+    } catch {
+      return null
+    }
+  }
+
   return {
     hasKioskCredential,
     kioskDeviceId: readonly(kioskDeviceId),
     storeKioskCredential,
     clearKioskCredential,
     getDeviceJwt,
+    pairKioskDevice,
   }
 }

--- a/web/app/pages/index.vue
+++ b/web/app/pages/index.vue
@@ -25,6 +25,9 @@ initApi(
   () => accessToken.value,
   () => deviceTenantId.value,
   () => refreshAccessToken(),
+  // キオスク: device credential があれば device JWT を mint して proxy 経由に切替 (#434 3b)。
+  // 無ければ null → 従来の X-Tenant-ID 直 fetch に fallback (非破壊)。
+  () => useDeviceToken().getDeviceJwt(),
 )
 
 // 顔データ同期 (singleton)

--- a/web/app/utils/api.ts
+++ b/web/app/utils/api.ts
@@ -26,6 +26,9 @@ let apiBase = ''
 let getAccessToken: (() => string | null) | null = null
 let getDeviceTenantId: (() => string | null) | null = null
 let tokenRefresher: (() => Promise<void>) | null = null
+// キオスク device JWT getter (#434 3b)。設定されていて admin JWT が無い時、
+// JSON リクエストを same-origin proxy (/api/proxy) 経由に切替える。
+let getKioskDeviceJwt: (() => Promise<string | null>) | null = null
 
 // JSON 経路の transport (ヘッダー付与 + 401→refresh→retry single-flight) は
 // @ippoan/auth-client の createAuthFetch に集約 (Refs ippoan/auth-worker#257)。
@@ -37,11 +40,13 @@ export function initApi(
   tokenGetter?: () => string | null,
   tenantGetter?: () => string | null,
   refresher?: () => Promise<void>,
+  deviceJwtGetter?: () => Promise<string | null>,
 ) {
   apiBase = baseUrl.replace(/\/$/, '')
   getAccessToken = tokenGetter || null
   getDeviceTenantId = tenantGetter || null
   tokenRefresher = refresher || null
+  getKioskDeviceJwt = deviceJwtGetter || null
   authFetch = apiBase
     ? createAuthFetch({
         baseUrl: apiBase,
@@ -76,7 +81,28 @@ function buildAuthHeaders(): Record<string, string> {
 
 async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
   if (!authFetch) throw new Error('API 未初期化: initApi() を呼んでください')
+  // キオスク: admin JWT が無く device JWT があれば same-origin proxy (/api/proxy, #434)
+  // 経由にする。proxy が device JWT を introspect 検証して X-Tenant-ID に変換する。
+  // device JWT が無ければ従来の X-Tenant-ID 直 fetch に fallback (段階移行で非破壊)。
+  if (!getAccessToken?.() && getKioskDeviceJwt) {
+    const jwt = await getKioskDeviceJwt()
+    if (jwt) return proxyRequest<T>(path, jwt, options)
+  }
   return authFetch<T>(path, options)
+}
+
+/** device JWT を Bearer に載せて same-origin proxy (/api/proxy) に転送する。 */
+async function proxyRequest<T>(path: string, jwt: string, options: RequestInit): Promise<T> {
+  const proxyPath = path.replace(/^\/api\//, '/api/proxy/')
+  const headers = new Headers(options.headers)
+  headers.set('Authorization', `Bearer ${jwt}`)
+  const res = await fetch(proxyPath, { ...options, headers })
+  if (!res.ok) {
+    const body = await res.text()
+    throw new Error(`API エラー (${res.status}): ${body || res.statusText}`)
+  }
+  if (res.status === 204) return undefined as T
+  return (await res.json()) as T
 }
 
 /** 測定結果を保存 */

--- a/web/tests/composables/useDeviceToken.test.ts
+++ b/web/tests/composables/useDeviceToken.test.ts
@@ -145,4 +145,48 @@ describe('useDeviceToken (#434 step 3c)', () => {
     expect(localStorage.getItem('alc_kiosk_device_id')).toBeNull()
     expect(await getDeviceJwt()).toBeNull()
   })
+
+  describe('pairKioskDevice (管理者側 /device/pair)', () => {
+    it('adminToken 空は fetch せず null', async () => {
+      const fetchMock = vi.fn()
+      vi.stubGlobal('fetch', fetchMock)
+      const useDeviceToken = await load()
+      expect(await useDeviceToken().pairKioskDevice('', 'kiosk-1')).toBeNull()
+      expect(fetchMock).not.toHaveBeenCalled()
+    })
+
+    it('role=device-kiosk で発行し credential を返す', async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ device_id: 'd1', device_secret: 's1' }),
+      })
+      vi.stubGlobal('fetch', fetchMock)
+      const useDeviceToken = await load()
+      const cred = await useDeviceToken().pairKioskDevice('admin-jwt', 'kiosk-1')
+
+      expect(cred).toEqual({ device_id: 'd1', device_secret: 's1' })
+      const [url, init] = fetchMock.mock.calls[0]
+      expect(url).toBe('https://auth.ippoan.org/device/pair')
+      expect(init.headers.Authorization).toBe('Bearer admin-jwt')
+      expect(JSON.parse(init.body)).toEqual({ label: 'kiosk-1', role: 'device-kiosk' })
+    })
+
+    it('non-2xx は null', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, json: () => Promise.resolve({}) }))
+      const useDeviceToken = await load()
+      expect(await useDeviceToken().pairKioskDevice('admin-jwt', 'k')).toBeNull()
+    })
+
+    it('device_id / device_secret 欠落は null', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({ device_id: 'd1' }) }))
+      const useDeviceToken = await load()
+      expect(await useDeviceToken().pairKioskDevice('admin-jwt', 'k')).toBeNull()
+    })
+
+    it('fetch throw は null', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('net')))
+      const useDeviceToken = await load()
+      expect(await useDeviceToken().pairKioskDevice('admin-jwt', 'k')).toBeNull()
+    })
+  })
 })

--- a/web/tests/utils/api.test.ts
+++ b/web/tests/utils/api.test.ts
@@ -1850,3 +1850,67 @@ restoreNativeApis()
     })
   })
 })
+
+// #434 step 3b: キオスク device JWT があれば same-origin proxy (/api/proxy) 経由。
+// mock 専用 (live では proxy route は別 worker なので skip)。
+describe.skipIf(isLive)('device JWT proxy 経路 (#434 3b)', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', mockFetch)
+    mockFetch.mockReset()
+  })
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('admin JWT があれば proxy を使わず直 fetch する', async () => {
+    initApi(API_BASE, () => 'admin-jwt', undefined, undefined, () => Promise.resolve('dev-jwt'))
+    mockFetch.mockResolvedValueOnce(okJson([]))
+    await getEmployees()
+    const url = mockFetch.mock.calls[0][0] as string
+    expect(url).toBe(`${API_BASE}/api/employees`)
+    expect(url).not.toContain('/api/proxy/')
+  })
+
+  it('admin 無 + device JWT 有 → /api/proxy 経由 + Authorization Bearer', async () => {
+    initApi(API_BASE, undefined, undefined, undefined, () => Promise.resolve('dev-jwt'))
+    mockFetch.mockResolvedValueOnce(okJson([{ id: 'e1' }]))
+    const result = await getEmployees()
+    expect(result).toEqual([{ id: 'e1' }])
+    const [url, init] = mockFetch.mock.calls[0]
+    expect(url).toBe('/api/proxy/employees')
+    expect(new Headers(init.headers).get('Authorization')).toBe('Bearer dev-jwt')
+  })
+
+  it('admin 無 + device JWT null → 従来の直 fetch に fallback', async () => {
+    initApi(API_BASE, undefined, () => 'tid', undefined, () => Promise.resolve(null))
+    mockFetch.mockResolvedValueOnce(okJson([]))
+    await getEmployees()
+    const url = mockFetch.mock.calls[0][0] as string
+    expect(url).toBe(`${API_BASE}/api/employees`)
+    expect(url).not.toContain('/api/proxy/')
+  })
+
+  it('proxy 経由 204 は undefined を返す', async () => {
+    initApi(API_BASE, undefined, undefined, undefined, () => Promise.resolve('dev-jwt'))
+    mockFetch.mockResolvedValueOnce(ok204())
+    expect(await deleteEmployee(UUID1)).toBeUndefined()
+    expect(mockFetch.mock.calls[0][0]).toBe(`/api/proxy/employees/${UUID1}`)
+  })
+
+  it('proxy 非 2xx は API エラー (body) を throw', async () => {
+    initApi(API_BASE, undefined, undefined, undefined, () => Promise.resolve('dev-jwt'))
+    mockFetch.mockResolvedValueOnce(errResponse(403, 'forbidden'))
+    await expect(getEmployees()).rejects.toThrow('API エラー (403): forbidden')
+  })
+
+  it('proxy 非 2xx で body 空なら statusText を使う', async () => {
+    initApi(API_BASE, undefined, undefined, undefined, () => Promise.resolve('dev-jwt'))
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      statusText: 'Server Error',
+      text: () => Promise.resolve(''),
+    })
+    await expect(getEmployees()).rejects.toThrow('API エラー (500): Server Error')
+  })
+})


### PR DESCRIPTION
## 概要

#434 step 3b（キオスク経路を proxy に切替）と、P1 pairing の**管理者側データ層**を追加する。UI は後続。

## 変更

- **`app/utils/api.ts`**: `initApi` に第5引数 `deviceJwtGetter` を追加。`request()` で
  - **admin JWT 有** → 従来どおり rust-alc-api 直 fetch（rust が Authorization を直接検証）
  - **admin 無 + device JWT 有** → `proxyRequest` で same-origin `/api/proxy/<path>` に `Authorization: Bearer <device JWT>` で転送（proxy が introspect 検証 → X-Tenant-ID 変換）
  - **device JWT 無** → 従来の X-Tenant-ID 直 fetch に fallback
- **`app/pages/index.vue`**: `initApi` に `() => useDeviceToken().getDeviceJwt()` を配線。
- **`app/composables/useDeviceToken.ts`**: `pairKioskDevice(adminToken, label)` を追加。管理者 session で auth-worker `/device/pair`（role=`device-kiosk`）を叩き credential を発行（P1 管理者側）。返り値（`device_id`+`device_secret`）を QR 等で kiosk に渡す想定。
- **tests**: `api.test.ts` に proxy 経路（admin / device / fallback / 204 / error）、`useDeviceToken.test.ts` に `pairKioskDevice` を追加。

## 非破壊性

device credential を持つ端末は現状存在しない（pairing UI 未配線）ため `getDeviceJwt()` は常に `null` → 全 kiosk が従来の X-Tenant-ID 直 fetch のまま。**本 PR 単体では挙動を変えない**（3a/3c と同じ infra-first）。

## 残り（P1 の UI、後続 PR）

- 管理画面（`DeviceRegistrationManager.vue` 等）に「キオスク認証発行」を相乗り → `pairKioskDevice` 呼び出し → `device_id`+`device_secret` を **QR 表示**（backend を経由させない）
- kiosk セットアップ画面で QR スキャン → `storeKioskCredential` 保存
- **網層ロックダウン**（B案 本丸 / rust-alc-api）: これが完了するまで bare X-Tenant-ID 直叩きは塞がらない

Refs #434

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01G4V5MhG2JnKsMt4gtyXtm3)_