### PR TITLE
feat(kiosk): 「この端末をキオスクにする」self-pair UI (#434 P1)

### DIFF
--- a/web/app/components/DeviceRegistrationManager.vue
+++ b/web/app/components/DeviceRegistrationManager.vue
@@ -9,9 +9,31 @@ import {
 } from '~/utils/api'
 import type { TestFcmAllResult } from '~/utils/api'
 
-const { user } = useAuth()
+const { user, accessToken } = useAuth()
 const isDeveloper = computed(() => user.value?.email === 'm.tama.ramu@gmail.com')
 const registrationMode = ref<'dev' | 'owner'>('dev')
+
+// この端末をキオスクにする (#434 P1 / 方式1): ログイン中の access token で
+// device-kiosk credential を self-pair し端末に保存する。ログアウト後この端末は
+// device 認証 (/api/proxy) で動作し、通常の管理者セッションとは分離される。
+const { hasKioskCredential, setupAsKiosk } = useDeviceToken()
+const kioskName = ref('')
+const kioskSetupBusy = ref(false)
+const kioskSetupMsg = ref('')
+async function setupThisAsKiosk() {
+  const token = accessToken.value
+  if (!token) {
+    kioskSetupMsg.value = 'ログインが必要です'
+    return
+  }
+  kioskSetupBusy.value = true
+  kioskSetupMsg.value = ''
+  const ok = await setupAsKiosk(token, kioskName.value.trim() || 'kiosk')
+  kioskSetupBusy.value = false
+  kioskSetupMsg.value = ok
+    ? 'この端末をキオスクに設定しました。ログアウトすると device 認証で動作します。'
+    : 'キオスク設定に失敗しました'
+}
 
 const devices = ref<Device[]>([])
 const pending = ref<DeviceRegistrationRequest[]>([])
@@ -579,6 +601,34 @@ onMounted(() => refresh())
 <template>
   <div class="space-y-6">
     <p v-if="error" class="text-red-600 text-sm">{{ error }}</p>
+
+    <!-- この端末をキオスクにする (#434 P1 / 方式1) -->
+    <div class="bg-white rounded-xl shadow-sm p-4">
+      <h3 class="text-sm font-medium text-gray-800 mb-2">この端末をキオスクにする</h3>
+      <p class="text-xs text-gray-500 mb-3">
+        ログイン中の管理者権限でこの端末に device 認証 (device-kiosk) を発行します。
+        設定後ログアウトすると、この端末は X-Tenant-ID ではなく device 認証で API にアクセスします。
+      </p>
+      <p v-if="hasKioskCredential" class="text-xs text-green-600 mb-2">
+        ✓ この端末はキオスク設定済みです (再設定で credential を更新)
+      </p>
+      <div class="flex gap-2 items-center">
+        <input
+          v-model="kioskName"
+          type="text"
+          placeholder="端末名 (任意)"
+          class="flex-1 px-3 py-2 border border-gray-300 rounded-lg text-sm"
+        >
+        <button
+          class="px-3 py-2 rounded-lg text-sm font-medium bg-indigo-600 text-white disabled:opacity-50"
+          :disabled="kioskSetupBusy || !accessToken"
+          @click="setupThisAsKiosk"
+        >
+          {{ kioskSetupBusy ? '設定中…' : 'キオスクにする' }}
+        </button>
+      </div>
+      <p v-if="kioskSetupMsg" class="text-xs mt-2 text-gray-700">{{ kioskSetupMsg }}</p>
+    </div>
 
     <!-- 登録モード選択 (開発者のみ) -->
     <div v-if="isDeveloper" class="rounded-xl shadow-sm p-3" :class="registrationMode === 'dev' ? 'bg-indigo-50' : 'bg-amber-50'">

--- a/web/app/composables/useDeviceToken.ts
+++ b/web/app/composables/useDeviceToken.ts
@@ -130,6 +130,21 @@ export function useDeviceToken() {
     }
   }
 
+  /**
+   * この端末をキオスク化する (P1 / 方式1)。管理者がログイン済みの端末で 1 度だけ実行する。
+   * 現在の access token で `/device/pair` を叩いて device-kiosk credential を発行し、
+   * そのまま端末に保存する (self-pair)。以降この端末は (管理者ログアウト後) device JWT
+   * 経由で通信する。通常の管理者セッションは self-pair しないので分離は保たれる。
+   *
+   * @returns 成功時 true (credential 発行・保存済み)、失敗時 false
+   */
+  async function setupAsKiosk(adminToken: string, label: string): Promise<boolean> {
+    const cred = await pairKioskDevice(adminToken, label)
+    if (!cred) return false
+    storeKioskCredential(cred.device_id, cred.device_secret)
+    return true
+  }
+
   return {
     hasKioskCredential,
     kioskDeviceId: readonly(kioskDeviceId),
@@ -137,5 +152,6 @@ export function useDeviceToken() {
     clearKioskCredential,
     getDeviceJwt,
     pairKioskDevice,
+    setupAsKiosk,
   }
 }

--- a/web/tests/composables/useDeviceToken.test.ts
+++ b/web/tests/composables/useDeviceToken.test.ts
@@ -189,4 +189,30 @@ describe('useDeviceToken (#434 step 3c)', () => {
       expect(await useDeviceToken().pairKioskDevice('admin-jwt', 'k')).toBeNull()
     })
   })
+
+  describe('setupAsKiosk (self-pair)', () => {
+    it('成功すると credential を発行・保存して true', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ device_id: 'd1', device_secret: 's1' }),
+      }))
+      const useDeviceToken = await load()
+      const { setupAsKiosk, hasKioskCredential } = useDeviceToken()
+
+      expect(await setupAsKiosk('admin-jwt', 'kiosk-1')).toBe(true)
+      expect(hasKioskCredential.value).toBe(true)
+      expect(localStorage.getItem('alc_kiosk_device_id')).toBe('d1')
+      expect(localStorage.getItem('alc_kiosk_device_secret')).toBe('s1')
+    })
+
+    it('pairing 失敗時は false で credential を保存しない', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, json: () => Promise.resolve({}) }))
+      const useDeviceToken = await load()
+      const { setupAsKiosk, hasKioskCredential } = useDeviceToken()
+
+      expect(await setupAsKiosk('admin-jwt', 'kiosk-1')).toBe(false)
+      expect(hasKioskCredential.value).toBe(false)
+      expect(localStorage.getItem('alc_kiosk_device_id')).toBeNull()
+    })
+  })
 })


### PR DESCRIPTION
## 概要

#434 P1（方式1）。管理者がログイン中の端末を 1 操作でキオスク化する **self-pair** を追加。別画面・QR 手渡し・auth-worker 新規エンドポイントは不要（既存 `/device/pair` を利用）。

## 動作

1. 管理者がその端末でログイン（access token あり）
2. 「デバイス管理」の **「この端末をキオスクにする」** を押す → 自動で `setupAsKiosk`（`/device/pair` で device-kiosk credential 発行 → `storeKioskCredential` 保存）
3. 管理者がログアウト → access token 消失 → `request()` が device JWT（`/api/proxy`）経由に切替

**通常認証との分離**: self-pair は明示操作した端末だけ。通常の管理者ログイン（devId 無し）は credential を持たず、`request()` も admin JWT がある間は proxy を使わない（transport 層で分離済み）。

## 変更

- **`useDeviceToken.ts`**: `setupAsKiosk(adminToken, label)` 追加（`pairKioskDevice` → `storeKioskCredential`、成否 boolean）。
- **`DeviceRegistrationManager.vue`**: 「この端末をキオスクにする」カード（端末名入力 + ボタン + 設定済み表示）。ログイン中の access token で実行。
- **tests**: `setupAsKiosk` の成功 / 失敗。

## 残り

- **網層ロックダウン**（B案 本丸 / rust-alc-api）: Cloud Run ingress 制限。これが完了するまで bare X-Tenant-ID 直叩きは塞がらない（#434 の実 close 条件）。
- 任意: 完全無人キオスク（ログイン無し）対応は方式2（auth-worker エンドポイント新設）が必要。今回は方式1（管理者セットアップ前提）。

Refs #434

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01G4V5MhG2JnKsMt4gtyXtm3)_