### PR TITLE
test(api): live integration で dumb-backend 向け identity ヘッダ注入 (rust-alc-api#434)

### DIFF
--- a/web/tests/helpers/api-test-env.ts
+++ b/web/tests/helpers/api-test-env.ts
@@ -158,6 +158,40 @@ export const jwtToken = isLive ? makeJwt() : null
 let liveReady = false
 
 /**
+ * live 時: rust-alc-api は #441 で dumb backend 化し、`require_tenant_header` が
+ * `X-Tenant-ID` + `X-User-ID/Email/Role` を要求する (本番は server proxy =
+ * `createIdentityProxyHandler` が introspect 検証して注入する)。integration テストは
+ * proxy を介さず backend を直叩きするため、ここで proxy の代わりに検証済み相当の
+ * identity ヘッダをテスト用 claim (= makeJwt と同値、seed.sql の admin) から注入する
+ * (Refs rust-alc-api#434)。`createAuthFetch` は JWT がある時 `Bearer` のみ送り
+ * X-Tenant-ID を付けない設計なので、これが無いと全 authed endpoint が 401 になる。
+ *
+ * globalThis.fetch を冪等にラップする (二重ラップは Symbol guard で防ぐ)。
+ */
+const LIVE_IDENTITY_FETCH = Symbol.for('alc-app:live-identity-fetch')
+function installLiveIdentityFetch() {
+  if (!isLive) return
+  const current = globalThis.fetch as typeof fetch & { [LIVE_IDENTITY_FETCH]?: true }
+  if (current[LIVE_IDENTITY_FETCH]) return
+  const base = current
+  const wrapped = (async (input: RequestInfo | URL, init: RequestInit = {}) => {
+    const headers = new Headers(
+      init.headers ?? (input instanceof Request ? input.headers : undefined),
+    )
+    headers.set('X-Tenant-ID', TEST_TENANT_ID)
+    headers.set('X-User-ID', TEST_USER_ID)
+    headers.set('X-User-Email', 'test@example.com')
+    headers.set('X-User-Role', 'admin')
+    if (input instanceof Request) {
+      return base(new Request(input, { headers }))
+    }
+    return base(input, { ...init, headers })
+  }) as typeof fetch & { [LIVE_IDENTITY_FETCH]?: true }
+  wrapped[LIVE_IDENTITY_FETCH] = true
+  globalThis.fetch = wrapped
+}
+
+/**
  * live 時: happy-dom の FormData/Blob を Node.js native に戻す。
  * happy-dom は setupFiles より先に環境を適用するため、save-native では間に合わない。
  * undici + node:buffer から直接取得する。
@@ -174,6 +208,9 @@ export function restoreNativeApis() {
   const undici = require('undici')
   globalThis.FormData = undici.FormData
   globalThis.fetch = undici.fetch
+  // undici fetch に差し替えた後も identity 注入ラッパーを被せ直す
+  // (FormData テストは setupApi より先に restoreNativeApis だけ呼ぶため必須)。
+  installLiveIdentityFetch()
 }
 
 export async function setupApi() {
@@ -183,6 +220,7 @@ export async function setupApi() {
       liveReady = true
     }
     initApi(API_BASE, () => jwtToken!)
+    installLiveIdentityFetch()
   } else {
     vi.stubGlobal('fetch', mockFetch)
     initApi(API_BASE, undefined, () => 'test-tenant')


### PR DESCRIPTION
## 概要

alc-app の **live API Integration が全 authed endpoint で 401**（`createAuthFetch` → `API エラー (401)`）になっていた問題を修正する。

### 原因

rust-alc-api は #441 で **JWT 検証を撤去した dumb backend** になり、`require_tenant_header` が `X-Tenant-ID` + `X-User-ID/Email/Role` を要求する（本番は server proxy = `createIdentityProxyHandler` が introspect 検証して注入）。

`app/utils/api.ts` の `createAuthFetch` は **JWT がある時は `Bearer` のみ送り `X-Tenant-ID` を付けない**設計（注入は proxy の役割）。だが live integration テストは **proxy を介さず backend を直叩き**（`API_BASE_URL=コンテナ`）するため、`require_tenant_header` が `X-Tenant-ID` 不在で 401。

> pre-existing / **non-blocking**（API Integration は required check ではないため #52 等は merge 済み）。repin とは無関係。

### 修正

`tests/helpers/api-test-env.ts` の **live モードで `globalThis.fetch` を冪等にラップ**し、proxy の代わりにテスト用 claim（= `makeJwt` と同値、`seed.sql` の admin）由来の `X-Tenant-ID` / `X-User-ID` / `X-User-Email` / `X-User-Role` を注入する。

- `restoreNativeApis`（undici fetch 差し替え）後 と `setupApi` の両方で適用（FormData テストは `setupApi` より先に `restoreNativeApis` のみ呼ぶため）。
- `Symbol` guard で二重ラップ防止。
- **mock モードは `isLive` ガードで不変**（required の Vitest + Coverage に影響なし）。

### 検証

- mock vitest `tests/utils/api.test.ts`: **233 passed / 2 skipped**（ローカル実行）。
- `nuxi typecheck`: `api-test-env.ts` 由来エラー 0（残るは `fc1200-wasm` stub と file:link の環境要因のみ）。
- live は docker コンテナ必須のためローカル不可 → CI の `ci / API Integration` で検証。

Refs ippoan/rust-alc-api#434

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019bihe6n6P8Pds5grZzR4ga)_