### PR TITLE
test(api): live identity 注入を「有効 Bearer 時のみ」に限定し negative テストを復旧 (rust-alc-api#434)

### DIFF
--- a/web/tests/helpers/api-test-env.ts
+++ b/web/tests/helpers/api-test-env.ts
@@ -174,14 +174,23 @@ function installLiveIdentityFetch() {
   const current = globalThis.fetch as typeof fetch & { [LIVE_IDENTITY_FETCH]?: true }
   if (current[LIVE_IDENTITY_FETCH]) return
   const base = current
+  // proxy (createIdentityProxyHandler) を忠実に模倣する: introspect 成功相当 =
+  // **有効な Bearer (= テスト JWT) を持つリクエストにだけ** identity を注入する。
+  // 無効/不在 Bearer は注入せず backend に 401 させる → 無認証/無効トークンで
+  // 401 を期待する negative テスト (reject 系 / 401 token refresh 群) の意図を保つ。
+  // refresh テストも「無効 Bearer → 401 → refresher が有効 JWT に差替 → retry で
+  // 有効 Bearer → 注入 → 200」と正しく成立する。
+  const validBearer = `Bearer ${jwtToken}`
   const wrapped = (async (input: RequestInfo | URL, init: RequestInit = {}) => {
     const headers = new Headers(
       init.headers ?? (input instanceof Request ? input.headers : undefined),
     )
-    headers.set('X-Tenant-ID', TEST_TENANT_ID)
-    headers.set('X-User-ID', TEST_USER_ID)
-    headers.set('X-User-Email', 'test@example.com')
-    headers.set('X-User-Role', 'admin')
+    if (headers.get('Authorization') === validBearer) {
+      headers.set('X-Tenant-ID', TEST_TENANT_ID)
+      headers.set('X-User-ID', TEST_USER_ID)
+      headers.set('X-User-Email', 'test@example.com')
+      headers.set('X-User-Role', 'admin')
+    }
     if (input instanceof Request) {
       return base(new Request(input, { headers }))
     }


### PR DESCRIPTION
## 概要

#53 で入れた live fetch ラッパーが **全リクエストに無条件で** `X-Tenant-ID` + `X-User-*` を注入していたため、**無認証/無効トークンで 401 を期待する negative テストが 200 になって fail** していた:

- `authentication headers › should reject without any auth` → `AssertionError: promise resolved [...] instead of rejecting`
- `401 token refresh › should refresh token and retry on 401` → `expected vi.fn() to be called 1 times, but got 0 times`（401 が起きないので refresher 未発火）
- `401 token refresh › should not attempt refresh when ...` → `expected to throw 'API エラー (401)'`

つまり 401 の解消（CRUD）は成功したが、401 を**意図的に誘発する**テスト群を巻き込んでいた。

## 修正

proxy（`createIdentityProxyHandler`）を忠実に模倣し、**`Authorization` が有効なテスト JWT（= `jwtToken`）の時だけ** identity を注入する条件に変更:

| ケース | 挙動 |
|---|---|
| positive（有効 Bearer） | 注入 → 200 |
| negative（無/無効 Bearer） | 非注入 → backend 401（reject 維持）|
| refresh テスト | 無効 Bearer → 401 → refresher が有効 JWT に差替 → retry で有効 Bearer → 注入 → 200 |

これは実 proxy の「introspect 成功時のみ identity 注入、失敗時は 401」と同じ意味論。

## 検証

- mock vitest `tests/utils/api.test.ts`: **233 passed / 2 skipped**（ローカル）。mock は `isLive` ガードで不変。
- live は CI `ci / API Integration` で検証（docker 必須のためローカル不可）。

Refs ippoan/rust-alc-api#434

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019bihe6n6P8Pds5grZzR4ga)_