### PR TITLE
feat(proxy): createAuthWorkerProxyHandler (方式B) に切替えて SA key を排除

### DIFF
--- a/.claude/skills/alc-app-map/SKILL.md
+++ b/.claude/skills/alc-app-map/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: alc-app-map
-generated-from: alc-app:79f580782bd5116fd68b780471a1cf25abc636a5
+generated-from: alc-app:81472061c7cb50fefcaeb33965ec69ad5749df20
 paths: [web/, cf-alc-signaling/]
 description: yhonda-ohishi-alc/alc-app (業務用アルコールチェッカーシステム / 複合 repo) の構造ナビゲーション。タニタ FC-1200 + NFC + 顔認証による本人確認付きアルコール測定 + 遠隔点呼。web/ (Nuxt 4 PWA on Workers)・cf-alc-signaling/ (WebRTC signaling DO)・fc1200-wasm (秘匿) の区画、WebSerial/WebRTC/顔認証の composable 配置、秘匿ファイル・テストの gotcha を 1 枚にまとめる。トリガー:「alc-app」「アルコールチェッカー」「FC-1200」「fc1200」「点呼」「遠隔点呼」「顔認証」「NFC bridge」「WebRTC signaling」「cf-alc-signaling」「alc.ippoan.org」等。
 ---
@@ -39,7 +39,7 @@ description: yhonda-ohishi-alc/alc-app (業務用アルコールチェッカー�
 | **components** | `Tenko*.vue` (多数: Kiosk/VideoCall/RemoteAdminView/ScheduleManager 等) `*Dashboard.vue` `FaceAuth.vue` `AlcMeasurement.vue` `Device*.vue` | 点呼 UI / ダッシュボード / 測定 / デバイス管理 |
 | **utils** | `web/app/utils/{api,env,face-approval,face-db,fc1200,human-config,license,offline-queue,video-store}.ts` | API client / 顔 DB (IndexedDB) / FC-1200 / human 設定 / オフラインキュー |
 | **worker** | `web/app/workers/face-detect.worker.ts` | 顔検出 Web Worker (@vladmandic/human) |
-| **server route** | `web/server/api/{proxy/[...path],tenko-call/*,devices/*,github-checksum.get}.ts` | **proxy/** = identity proxy (`createIdentityProxyHandler`、#434 step 2): cookie/Bearer JWT を AUTH_WORKER service binding で introspect → X-Tenant-ID + X-User-ID/Email/Role を注入して rust-alc-api へ転送。点呼コール / デバイス (FCM token / version / watchdog / claim) / NFC bridge checksum |
+| **server route** | `web/server/api/{proxy/[...path],tenko-call/*,devices/*,github-checksum.get}.ts` | **proxy/** = auth-worker proxy (`createAuthWorkerProxyHandler`、#434 step 3 / 方式 B): cookie/Bearer JWT + X-Alc-Proxy-Secret (=INTERNAL_SHARED_SECRET) を AUTH_WORKER service binding 経由で auth-worker `/alc-proxy/*` に thin-forward。introspect / ACL / OIDC mint / X-Tenant-ID + X-User-* 注入は auth-worker 側に集約 (SA key 排除)。点呼コール / デバイス (FCM token / version / watchdog / claim) / NFC bridge checksum |
 | **型 (生成)** | `web/app/types/generated/*` (91 file) + `web/app/types/index.ts` | rust-alc-api models.rs から **ts-rs 自動生成** (`Backend` namespace)。手動編集禁止。フロント固有型は index.ts に手動定義 |
 | **middleware** | `web/app/middleware/auth.global.ts` | 全ルート認証ガード |
 

--- a/web/package.json
+++ b/web/package.json
@@ -15,7 +15,7 @@
     "test:e2e": "playwright test"
   },
   "dependencies": {
-    "@ippoan/auth-client": "^0.2.75",
+    "@ippoan/auth-client": "dev",
     "@nuxtjs/tailwindcss": "^6.14.0",
     "@vite-pwa/nuxt": "^1.1.1",
     "@vladmandic/human": "^3.3.6",

--- a/web/server/api/proxy/[...path].ts
+++ b/web/server/api/proxy/[...path].ts
@@ -1,25 +1,21 @@
 /**
- * REST API proxy: `/api/proxy/<path>` → rust-alc-api `/api/<path>`
+ * REST API proxy: `/api/proxy/<path>` → auth-worker `/alc-proxy/*` → rust-alc-api `/api/<path>`
  *
- * #434 step 2 consumer 横展開 (carins #38 / nuxt_dtako_logs と同型)。
- * introspect 検証 → X-Tenant-ID + X-User-ID/Email/Role 注入を
- * @ippoan/auth-client/server の createIdentityProxyHandler に集約する。
+ * #434 step 3 (方式 B): introspect / ACL / OIDC mint / identity 注入を
+ * auth-worker `/alc-proxy/*` に集約し、consumer は createAuthWorkerProxyHandler で
+ * service binding (AUTH_WORKER) に thin-forward するだけ。旧 createIdentityProxyHandler
+ * (方式 A) を置換。consumer は X-Alc-Proxy-Secret (=INTERNAL_SHARED_SECRET、consumer
+ * proof) + X-Alc-Proxy-Origin + browser JWT のみ。auth-worker (#308) が
+ * X-Alc-Proxy-Secret を constant-time 検証してから JWT 検証 + ACL + OIDC mint +
+ * X-Tenant-ID/X-User-* 注入を行う。
  *
- * 旧版 (kiosk-proxy 手組み + introspectToken 直叩き、device-kiosk role のみ許可) を
- * 置換する。rust-alc-api は #441 で JWT 検証を撤去し注入 identity を信頼する dumb
- * backend になったため、X-Tenant-ID だけでなく X-User-ID/Email/Role も載せないと
- * AuthUser 必須 handler が 500 になる。createIdentityProxyHandler は introspect
- * 結果から X-User-* も載せてこれを解消する。
- *
- * - browser JWT は cookie (`logi_auth_token`) / Bearer のどちらでも受ける。
- *   キオスク端末は device JWT を Bearer で送る (= 段階移行で従来 caller を壊さない)。
- * - introspect は AUTH_WORKER service binding (worker-to-worker, in-process) で
- *   叩くので外部 req を増やさない。
- * - INTERNAL_SHARED_SECRET は Secrets Store binding (.get()) のため route 側で
- *   resolve してから渡す。
+ * - browser JWT は cookie (logi_auth_token) / Bearer のどちらでも受ける。キオスク端末は
+ *   device JWT を Bearer で送る (方式 B でも Authorization は素通しされ維持される)。
+ * - AUTH_WORKER service binding は方式 B では必須 (未設定は 503)。
+ * - INTERNAL_SHARED_SECRET は Secrets Store binding (.get()) のため route 側で resolve。
  */
 import type { H3Event } from 'h3'
-import { createIdentityProxyHandler } from '@ippoan/auth-client/server'
+import { createAuthWorkerProxyHandler } from '@ippoan/auth-client/server'
 
 function cfEnv(event: H3Event): Record<string, unknown> {
   return (event.context.cloudflare as { env?: Record<string, unknown> } | undefined)?.env ?? {}
@@ -36,8 +32,6 @@ async function resolveSecret(binding: unknown): Promise<string | null> {
 
 export default defineEventHandler(async (event) => {
   const env = cfEnv(event)
-  const config = useRuntimeConfig(event)
-
   const sharedSecret = await resolveSecret(env.INTERNAL_SHARED_SECRET)
   if (!sharedSecret) {
     throw createError({
@@ -45,23 +39,17 @@ export default defineEventHandler(async (event) => {
       statusMessage: 'INTERNAL_SHARED_SECRET binding が未設定です',
     })
   }
-
-  const authWorkerUrl =
-    (config.public.authWorkerUrl as string) ||
-    (typeof env.NUXT_PUBLIC_AUTH_WORKER_URL === 'string' && env.NUXT_PUBLIC_AUTH_WORKER_URL
-      ? env.NUXT_PUBLIC_AUTH_WORKER_URL
-      : 'https://auth.ippoan.org')
   const authWorker = env.AUTH_WORKER as { fetch: typeof fetch } | undefined
+  if (!authWorker) {
+    throw createError({
+      statusCode: 503,
+      statusMessage: 'AUTH_WORKER service binding が未設定です',
+    })
+  }
 
-  const proxy = createIdentityProxyHandler({
-    backendUrl: (e) =>
-      (useRuntimeConfig(e).alcApiUrl as string) ||
-      (useRuntimeConfig(e).public.apiBase as string) ||
-      'https://alc-api.ippoan.org',
-    authWorkerUrl,
+  const proxy = createAuthWorkerProxyHandler({
     sharedSecret,
-    // AUTH_WORKER service binding 経由で introspect (worker-to-worker, in-process)。
-    introspectFetch: authWorker ? () => authWorker.fetch.bind(authWorker) : undefined,
+    authWorkerFetch: () => authWorker.fetch.bind(authWorker),
   })
   return proxy(event)
 })


### PR DESCRIPTION
## 概要

`web/server/api/proxy/[...path].ts` を #434 step 3 (方式 B) に切替える。
introspect / ACL / OIDC mint / identity (X-Tenant-ID + X-User-*) 注入を
auth-worker `/alc-proxy/*` に集約し、consumer は `createAuthWorkerProxyHandler`
で service binding (`AUTH_WORKER`) に thin-forward するだけにする。
方式 A (`createIdentityProxyHandler`) を置換し、SA key を consumer から排除。

## 変更点

- `web/server/api/proxy/[...path].ts`: `createIdentityProxyHandler` → `createAuthWorkerProxyHandler`
  - consumer は `X-Alc-Proxy-Secret` (= `INTERNAL_SHARED_SECRET`, consumer proof) +
    `X-Alc-Proxy-Origin` + browser JWT のみを載せる。auth-worker (#308) が
    `X-Alc-Proxy-Secret` を constant-time 検証してから JWT 検証 + ACL + OIDC mint +
    identity 注入を行う。
  - browser JWT は cookie (`logi_auth_token`) / Bearer 両対応。キオスク端末の device JWT
    (Bearer) は方式 B でも素通しされ維持される。
  - `INTERNAL_SHARED_SECRET` (Secrets Store binding) は route 側で `.get()` resolve、
    `AUTH_WORKER` service binding は方式 B では必須 (未設定は 503)。
- `web/package.json`: `@ippoan/auth-client` を `dev` dist-tag に。
- `.claude/skills/alc-app-map/SKILL.md`: proxy 説明を方式 B に更新 + `generated-from` bump。

## 検証

- `@ippoan/auth-client` を local copy に `file:` フォールバックして `npm install` →
  `nuxi typecheck` を実行。proxy route / `createAuthWorkerProxyHandler` 関連の型エラーは
  0 件 (残る TS2307 は fc1200-wasm スタブ未配置と file: link 先の `.vue` の vue 解決のみで、
  いずれも本変更と無関係)。
- 渡している引数 (`sharedSecret`: string, `authWorkerFetch`: bound fetch) が
  `AuthWorkerProxyOptions` の必須フィールドと一致することを目視確認。
- proxy 専用 test は存在しないため test 変更なし。

Refs ippoan/rust-alc-api#434


---
_Generated by [Claude Code](https://claude.ai/code/session_01MoQNRaoDQ1NqMB8bHPMzjK)_