### PR TITLE
fix(deps): @ippoan/auth-client を stable ^0.2.78 に pin (Refs ippoan/rust-alc-api#434)

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -15,7 +15,7 @@
     "test:e2e": "playwright test"
   },
   "dependencies": {
-    "@ippoan/auth-client": "dev",
+    "@ippoan/auth-client": "^0.2.78",
     "@nuxtjs/tailwindcss": "^6.14.0",
     "@vite-pwa/nuxt": "^1.1.1",
     "@vladmandic/human": "^3.3.6",


### PR DESCRIPTION
## 不具合

prod tag release が `Type Check` で `Cannot find module '@ippoan/auth-client/server'` で全滅。

## 原因

`use-auth-client-dev` action(main 済み)は **非 tag では `@dev` overlay / `v*` tag(prod)では package.json の stable pin を使用**。consumer が `web/package.json` で `"dev"` 固定だったため prod tag に stable pin が無く失敗。

## 修正

`web/package.json` の `@ippoan/auth-client` を `"dev"` → `"^0.2.78"`。staging(PR/main)は action が `@dev` を overlay、prod(`v*` tag)はこの stable pin を使う。

Refs ippoan/rust-alc-api#434

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MoQNRaoDQ1NqMB8bHPMzjK)_