### PR TITLE
feat(server): public ingest 経路を /alc-internal-proxy 経由に (Refs ippoan/rust-alc-api#434 caller #5)

### DIFF
--- a/web/server/api/devices/register/claim.post.ts
+++ b/web/server/api/devices/register/claim.post.ts
@@ -1,8 +1,3 @@
-export default defineEventHandler(async (event): Promise<unknown> => {
-  const config = useRuntimeConfig()
-  const body = await readBody(event)
-  return $fetch(`${config.public.apiBase}/api/devices/register/claim`, {
-    method: 'POST',
-    body,
-  })
-})
+// AlcoholChecker 端末登録 (pairing 前、認証なし public 経路)。lockdown 対応で
+// auth-worker /alc-internal-proxy 経由に forward する (Refs ippoan/rust-alc-api#434 caller #5)。
+export default createInternalIngestHandler('/api/devices/register/claim')

--- a/web/server/api/tenko-call/register.post.ts
+++ b/web/server/api/tenko-call/register.post.ts
@@ -1,8 +1,3 @@
-export default defineEventHandler(async (event): Promise<unknown> => {
-  const config = useRuntimeConfig()
-  const body = await readBody(event)
-  return $fetch(`${config.public.apiBase}/api/tenko-call/register`, {
-    method: 'POST',
-    body,
-  })
-})
+// TenkoCall 端末登録 (認証なし public 経路)。lockdown 対応で auth-worker
+// /alc-internal-proxy 経由に forward する (Refs ippoan/rust-alc-api#434 caller #5)。
+export default createInternalIngestHandler('/api/tenko-call/register')

--- a/web/server/api/tenko-call/tenko.post.ts
+++ b/web/server/api/tenko-call/tenko.post.ts
@@ -1,8 +1,3 @@
-export default defineEventHandler(async (event): Promise<unknown> => {
-  const config = useRuntimeConfig()
-  const body = await readBody(event)
-  return $fetch(`${config.public.apiBase}/api/tenko-call/tenko`, {
-    method: 'POST',
-    body,
-  })
-})
+// TenkoCall 点呼送信 (認証なし public 経路)。lockdown 対応で auth-worker
+// /alc-internal-proxy 経由に forward する (Refs ippoan/rust-alc-api#434 caller #5)。
+export default createInternalIngestHandler('/api/tenko-call/tenko')

--- a/web/server/utils/internal-proxy.ts
+++ b/web/server/utils/internal-proxy.ts
@@ -1,0 +1,125 @@
+/**
+ * public ingest 経路 (browser JWT も device JWT も持たない) を auth-worker
+ * `/alc-internal-proxy/*` に service binding で thin-forward する helper
+ * (Refs ippoan/rust-alc-api#434 caller #5、Phase B)。
+ *
+ * lockdown (`allUsers` 削除 = Cloud Run IAM) 後、TenkoCall の端末登録/点呼や
+ * AlcoholChecker の pairing 前端末登録は rust を直叩きできなくなる。これらは
+ * 認証情報を一切持たない public_router 経路 (tenant は body/registration_code から
+ * RLS / lookup で解決) なので `/alc-proxy` (browser JWT 必須) には乗らない。
+ *
+ * 代わりに alc-app Worker が **INTERNAL_SHARED_SECRET (consumer proof) を保持**し、
+ * `X-Alc-Proxy-Secret` を付けて auth-worker `/alc-internal-proxy` に丸投げする。
+ * OIDC mint (Cloud Run IAM 通過) は auth-worker 側で行う。auth-worker は
+ * public-ingest クラスとして **X-Tenant-ID を一切 forward しない** (auth-worker#323)
+ * ため、shared secret だけで tenant を詐称することはできない (#434 再現防止)。
+ *
+ * Android 端末には secret を焼かない (alc-app Worker だけが保持する)。
+ */
+import type { H3Event } from 'h3'
+
+/** auth-worker 側の route prefix。 */
+const INTERNAL_PROXY_PREFIX = '/alc-internal-proxy'
+/**
+ * service binding fetch は host を無視するが、path が `/alc-internal-proxy/...` で
+ * 始まる必要がある (auth-worker 側が prefix を slice して rust に転送するため)。
+ */
+const INTERNAL_PROXY_BASE = 'https://alc-internal-proxy.internal'
+
+export interface InternalProxyForward {
+  url: string
+  init: RequestInit
+}
+
+/**
+ * auth-worker `/alc-internal-proxy<rustPath>` への forward request を構築する
+ * (pure、ユニットテスト対象)。consumer proof secret だけを載せ、X-Tenant-ID 等の
+ * identity ヘッダーは載せない (public-ingest クラスのため auth-worker 側でも strip)。
+ */
+export function buildInternalProxyForward(input: {
+  sharedSecret: string
+  /** rust 側 path。例: '/api/tenko-call/register' */
+  rustPath: string
+  method: string
+  /** 例: '?x=1' / '' */
+  search?: string
+  contentType?: string | null
+  body?: BodyInit | null
+}): InternalProxyForward {
+  const headers: Record<string, string> = {
+    'X-Alc-Proxy-Secret': input.sharedSecret,
+  }
+  if (input.contentType) headers['Content-Type'] = input.contentType
+  const url = `${INTERNAL_PROXY_BASE}${INTERNAL_PROXY_PREFIX}${input.rustPath}${input.search ?? ''}`
+  const init: RequestInit = { method: input.method, headers }
+  if (input.body != null) init.body = input.body
+  return { url, init }
+}
+
+/** CF binding 群を取り出す。 */
+function cfEnv(event: H3Event): Record<string, unknown> {
+  return (event.context.cloudflare as { env?: Record<string, unknown> } | undefined)?.env ?? {}
+}
+
+/** Secrets Store binding (`.get()`) / 文字列 のいずれでも値を取り出す。 */
+async function resolveSecret(binding: unknown): Promise<string | null> {
+  if (typeof binding === 'string') return binding
+  if (binding && typeof (binding as { get?: unknown }).get === 'function') {
+    return (await (binding as { get(): Promise<string> }).get()) ?? null
+  }
+  return null
+}
+
+/**
+ * 固定 rustPath の public ingest 経路を `/alc-internal-proxy` 経由で forward する
+ * Nitro server route handler を生成する。
+ */
+export function createInternalIngestHandler(rustPath: string) {
+  return defineEventHandler(async (event) => {
+    const env = cfEnv(event)
+    const sharedSecret = await resolveSecret(env.INTERNAL_SHARED_SECRET)
+    if (!sharedSecret) {
+      throw createError({
+        statusCode: 503,
+        statusMessage: 'INTERNAL_SHARED_SECRET binding が未設定です',
+      })
+    }
+    const authWorker = env.AUTH_WORKER as { fetch: typeof fetch } | undefined
+    if (!authWorker) {
+      throw createError({
+        statusCode: 503,
+        statusMessage: 'AUTH_WORKER service binding が未設定です',
+      })
+    }
+
+    const method = event.method
+    let body: string | undefined
+    let contentType: string | undefined
+    if (method === 'POST' || method === 'PUT' || method === 'PATCH') {
+      const parsed = await readBody(event).catch(() => undefined)
+      if (parsed) {
+        body = JSON.stringify(parsed)
+        contentType = 'application/json'
+      }
+    }
+
+    const { url, init } = buildInternalProxyForward({
+      sharedSecret,
+      rustPath,
+      method,
+      contentType,
+      body,
+    })
+
+    const res = await authWorker.fetch(url, init)
+    setResponseStatus(event, res.status)
+    const ct = res.headers.get('content-type')
+    if (ct) setHeader(event, 'content-type', ct)
+    const text = await res.text()
+    try {
+      return JSON.parse(text)
+    } catch {
+      return text
+    }
+  })
+}

--- a/web/tests/server/internal-proxy.test.ts
+++ b/web/tests/server/internal-proxy.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import { buildInternalProxyForward } from '../../server/utils/internal-proxy'
+
+const SECRET = 'test-internal-shared-secret-32!!'
+
+describe('buildInternalProxyForward (rust-alc-api#434 caller #5, public-ingest forward)', () => {
+  it('path を /alc-internal-proxy<rustPath> に組み立て、consumer proof secret を載せる', () => {
+    const { url, init } = buildInternalProxyForward({
+      sharedSecret: SECRET,
+      rustPath: '/api/tenko-call/register',
+      method: 'POST',
+      contentType: 'application/json',
+      body: JSON.stringify({ call_number: '001' }),
+    })
+    expect(url).toBe('https://alc-internal-proxy.internal/alc-internal-proxy/api/tenko-call/register')
+    const h = init.headers as Record<string, string>
+    expect(h['X-Alc-Proxy-Secret']).toBe(SECRET)
+    expect(h['Content-Type']).toBe('application/json')
+    expect(init.method).toBe('POST')
+    expect(init.body).toBe(JSON.stringify({ call_number: '001' }))
+  })
+
+  it('identity ヘッダー (X-Tenant-ID 等) は載せない (public-ingest、詐称防止)', () => {
+    const { init } = buildInternalProxyForward({
+      sharedSecret: SECRET,
+      rustPath: '/api/devices/register/claim',
+      method: 'POST',
+    })
+    const h = init.headers as Record<string, string>
+    expect(h['X-Tenant-ID']).toBeUndefined()
+    expect(h['Authorization']).toBeUndefined()
+    expect(h['X-User-ID']).toBeUndefined()
+  })
+
+  it('contentType / body 省略時はヘッダー・body を付けない', () => {
+    const { init } = buildInternalProxyForward({
+      sharedSecret: SECRET,
+      rustPath: '/api/tenko-call/tenko',
+      method: 'POST',
+    })
+    const h = init.headers as Record<string, string>
+    expect(h['Content-Type']).toBeUndefined()
+    expect(init.body).toBeUndefined()
+  })
+
+  it('search query を維持する', () => {
+    const { url } = buildInternalProxyForward({
+      sharedSecret: SECRET,
+      rustPath: '/api/tenko-call/register',
+      method: 'POST',
+      search: '?x=1',
+    })
+    expect(url).toBe('https://alc-internal-proxy.internal/alc-internal-proxy/api/tenko-call/register?x=1')
+  })
+})


### PR DESCRIPTION
## 概要

rust-alc-api#434 lockdown 移行 **caller #5 (Android) の Phase B**。

TenkoCall / AlcoholChecker が叩く alc-app Worker の **public 経路** (browser JWT も
device JWT も持たない) を、rust 直叩き (`$fetch config.public.apiBase`) から auth-worker
`/alc-internal-proxy` 経由の forward に切り替える。lockdown (`allUsers` 削除 = Cloud Run
IAM) 後、直叩きは 403 になるため。auth-worker#323 (merged) で追加した **public-ingest
クラス**を consume する。

## 変更

- **`server/utils/internal-proxy.ts` (新規)**
  - `buildInternalProxyForward` (pure) + `createInternalIngestHandler` factory
  - alc-app が `INTERNAL_SHARED_SECRET` (consumer proof) を保持し `X-Alc-Proxy-Secret`
    を付けて service binding (`AUTH_WORKER`) で `/alc-internal-proxy<rustPath>` に丸投げ。
    OIDC mint (Cloud Run IAM 通過) は auth-worker 側。
  - **identity ヘッダー (X-Tenant-ID / Authorization 等) は一切載せない** — public-ingest は
    auth-worker 側でも X-Tenant-ID を strip するので、shared secret だけで tenant 詐称は不能
    (#434 再現防止)。
- **public 3 route を 1 行 handler 化**: `tenko-call/register`, `tenko-call/tenko`,
  `devices/register/claim`

## 設計メモ

- **Android 端末には secret を焼かない** — alc-app Worker だけが `INTERNAL_SHARED_SECRET` を
  保持し proxy する。TenkoCall / AlcoholChecker は同じ alc-app URL を叩くだけなので **無改修**。
- proxy 経由は lockdown 前後どちらでも動く (OIDC は `allUsers` でも accept される) ため、
  直 fetch fallback は不要。
- 既存の `INTERNAL_SHARED_SECRET` (Secrets Store) + `AUTH_WORKER` (service binding) は
  staging/prod 両方に配線済 (`/api/proxy` と共用)。新 binding 不要。

## テスト

- `tests/server/internal-proxy.test.ts` 4 pass (path 組み立て / identity strip / body 省略 / query 維持)
- `nuxi typecheck`: 自ファイル由来の型エラーなし (file: link 由来の auth-client/vue-router ノイズは CI の `use_auth_client_dev` で解消)

## 後続 (caller #5 残り)

- **Phase C (Android)**: device 系 (#4-7) を device JWT で `/alc-proxy` 経由化 + admin (#8) / dev (#9)
- **Phase D**: lockdown flip (prod secret 投入 + IAM + `allUsers` 削除)

Refs ippoan/rust-alc-api#434

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UioxVnUP66Qp4oVC7VUc7f)_