### PR TITLE
feat(server): device 経路を device JWT (/alc-proxy) + claim provisioning に (Refs ippoan/rust-alc-api#434 caller #5)

### DIFF
--- a/web/server/api/devices/register-fcm-token.put.ts
+++ b/web/server/api/devices/register-fcm-token.put.ts
@@ -1,8 +1,3 @@
-export default defineEventHandler(async (event): Promise<unknown> => {
-  const config = useRuntimeConfig()
-  const body = await readBody(event)
-  return $fetch(`${config.public.apiBase}/api/devices/register-fcm-token`, {
-    method: 'PUT',
-    body,
-  })
-})
+// AlcoholChecker の FCM token 登録 (device 経路)。device JWT Bearer があれば
+// auth-worker /alc-proxy 経由、無ければ直叩き fallback (Refs ippoan/rust-alc-api#434 caller #5)。
+export default createDeviceProxyHandler('/api/devices/register-fcm-token')

--- a/web/server/api/devices/register/claim.post.ts
+++ b/web/server/api/devices/register/claim.post.ts
@@ -1,3 +1,4 @@
-// AlcoholChecker 端末登録 (pairing 前、認証なし public 経路)。lockdown 対応で
-// auth-worker /alc-internal-proxy 経由に forward する (Refs ippoan/rust-alc-api#434 caller #5)。
-export default createInternalIngestHandler('/api/devices/register/claim')
+// AlcoholChecker 端末登録。rust に claim を forward (/alc-internal-proxy) し、即承認 flow
+// なら auth-worker /device/pair-internal で device credential を mint して claim レスポンスに
+// device_secret を merge する (Refs ippoan/rust-alc-api#434 caller #5 案B)。
+export default createClaimWithPairingHandler()

--- a/web/server/api/devices/report-version.put.ts
+++ b/web/server/api/devices/report-version.put.ts
@@ -1,8 +1,3 @@
-export default defineEventHandler(async (event): Promise<unknown> => {
-  const config = useRuntimeConfig()
-  const body = await readBody(event)
-  return $fetch(`${config.public.apiBase}/api/devices/report-version`, {
-    method: 'PUT',
-    body,
-  })
-})
+// AlcoholChecker のバージョン報告 (device 経路)。device JWT Bearer があれば
+// auth-worker /alc-proxy 経由、無ければ直叩き fallback (Refs ippoan/rust-alc-api#434 caller #5)。
+export default createDeviceProxyHandler('/api/devices/report-version')

--- a/web/server/api/devices/report-watchdog.put.ts
+++ b/web/server/api/devices/report-watchdog.put.ts
@@ -1,8 +1,3 @@
-export default defineEventHandler(async (event): Promise<unknown> => {
-  const config = useRuntimeConfig()
-  const body = await readBody(event)
-  return $fetch(`${config.public.apiBase}/api/devices/report-watchdog`, {
-    method: 'PUT',
-    body,
-  })
-})
+// AlcoholChecker の watchdog heartbeat (device 経路)。device JWT Bearer があれば
+// auth-worker /alc-proxy 経由、無ければ直叩き fallback (Refs ippoan/rust-alc-api#434 caller #5)。
+export default createDeviceProxyHandler('/api/devices/report-watchdog')

--- a/web/server/api/devices/settings/[deviceId].get.ts
+++ b/web/server/api/devices/settings/[deviceId].get.ts
@@ -1,5 +1,5 @@
-export default defineEventHandler(async (event): Promise<unknown> => {
-  const config = useRuntimeConfig()
-  const deviceId = getRouterParam(event, 'deviceId')
-  return $fetch(`${config.public.apiBase}/api/devices/settings/${deviceId}`)
-})
+// AlcoholChecker のデバイス設定取得 (device 経路)。device JWT Bearer があれば
+// auth-worker /alc-proxy 経由、無ければ直叩き fallback (Refs ippoan/rust-alc-api#434 caller #5)。
+export default createDeviceProxyHandler(
+  (event) => `/api/devices/settings/${getRouterParam(event, 'deviceId')}`,
+)

--- a/web/server/api/devices/trigger-update.post.ts
+++ b/web/server/api/devices/trigger-update.post.ts
@@ -1,10 +1,4 @@
-export default defineEventHandler(async (event): Promise<unknown> => {
-  const config = useRuntimeConfig()
-  const body = await readBody(event)
-  const auth = getHeader(event, 'Authorization') || ''
-  return $fetch(`${config.public.apiBase}/api/devices/trigger-update`, {
-    method: 'POST',
-    body,
-    headers: { Authorization: auth },
-  })
-})
+// OTA トリガー (admin 経路、require_tenant_header)。管理画面の browser JWT Bearer を
+// auth-worker /alc-proxy 経由で forward (introspect → X-Tenant-ID/X-User-* 注入)。
+// Bearer 無し時は直叩き fallback (Refs ippoan/rust-alc-api#434 caller #5)。
+export default createDeviceProxyHandler('/api/devices/trigger-update')

--- a/web/server/utils/device-pairing.ts
+++ b/web/server/utils/device-pairing.ts
@@ -1,0 +1,145 @@
+/**
+ * AlcoholChecker 端末登録 (claim) 時に device credential を provisioning する orchestration
+ * (Refs ippoan/rust-alc-api#434 caller #5、Phase C 案B)。
+ *
+ * フロー:
+ *   ① 端末 → alc-app /api/devices/register/claim (本 handler)
+ *   ② alc-app → auth-worker /alc-internal-proxy/api/devices/register/claim → rust
+ *        rust が device 登録し { success, tenant_id, device_id, settings_token } を返す
+ *   ③ tenant_id が取れたら alc-app → auth-worker /device/pair-internal (server-to-server,
+ *        X-Internal-Shared-Secret) で device credential (device_id + device_secret) を mint
+ *   ④ claim レスポンスに { auth_device_id, device_secret } を merge して端末へ返す
+ *
+ * 端末はこの device_secret を保存し、以降 `/device/token` で短命 device JWT を取得して
+ * device 経路 (report-version 等) を Authorization: Bearer で叩く。INTERNAL_SHARED_SECRET は
+ * 端末に焼かない (alc-app Worker だけが保持)。
+ *
+ * tenant_id が取れない flow (qr_permanent = 管理者承認待ち) では pairing をスキップし、rust の
+ * claim レスポンスをそのまま返す (credential は承認時に別途発行する想定)。
+ */
+import type { H3Event } from 'h3'
+import { buildInternalProxyForward } from './internal-proxy'
+
+/** auth-worker の device-uploader role (lib/device.ts DEVICE_ROLE と同値)。 */
+const DEVICE_ROLE_UPLOADER = 'device-uploader'
+
+export interface PairInternalForward {
+  url: string
+  init: RequestInit
+}
+
+/**
+ * auth-worker `/device/pair-internal` への server-to-server forward request を構築する
+ * (pure、テスト対象)。X-Internal-Shared-Secret で認証し tenant_id を明示渡しする。
+ */
+export function buildPairInternalForward(input: {
+  sharedSecret: string
+  tenantId: string
+  label: string
+  role?: string
+}): PairInternalForward {
+  return {
+    url: 'https://auth-internal.internal/device/pair-internal',
+    init: {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Internal-Shared-Secret': input.sharedSecret,
+      },
+      body: JSON.stringify({
+        tenant_id: input.tenantId,
+        label: input.label,
+        role: input.role ?? DEVICE_ROLE_UPLOADER,
+      }),
+    },
+  }
+}
+
+/** rust claim レスポンスの最小形 (provisioning に必要な field のみ)。 */
+interface ClaimResponse {
+  success?: boolean
+  tenant_id?: string | null
+  device_id?: string | null
+  settings_token?: string | null
+  [k: string]: unknown
+}
+
+interface PairInternalResponse {
+  device_id?: string
+  device_secret?: string
+}
+
+function cfEnv(event: H3Event): Record<string, unknown> {
+  return (event.context.cloudflare as { env?: Record<string, unknown> } | undefined)?.env ?? {}
+}
+
+async function resolveSecret(binding: unknown): Promise<string | null> {
+  if (typeof binding === 'string') return binding
+  if (binding && typeof (binding as { get?: unknown }).get === 'function') {
+    return (await (binding as { get(): Promise<string> }).get()) ?? null
+  }
+  return null
+}
+
+/**
+ * claim を rust に forward → 成功かつ tenant_id が取れたら device credential を mint して
+ * レスポンスに merge する Nitro server route handler。
+ */
+export function createClaimWithPairingHandler() {
+  return defineEventHandler(async (event): Promise<unknown> => {
+    const env = cfEnv(event)
+    const sharedSecret = await resolveSecret(env.INTERNAL_SHARED_SECRET)
+    if (!sharedSecret) {
+      throw createError({ statusCode: 503, statusMessage: 'INTERNAL_SHARED_SECRET binding が未設定です' })
+    }
+    const authWorker = env.AUTH_WORKER as { fetch: typeof fetch } | undefined
+    if (!authWorker) {
+      throw createError({ statusCode: 503, statusMessage: 'AUTH_WORKER service binding が未設定です' })
+    }
+
+    // ① claim を rust へ forward (public-ingest と同じ /alc-internal-proxy 経路)。
+    const parsed = await readBody(event).catch(() => undefined)
+    const { url, init } = buildInternalProxyForward({
+      sharedSecret,
+      rustPath: '/api/devices/register/claim',
+      method: 'POST',
+      contentType: parsed ? 'application/json' : undefined,
+      body: parsed ? JSON.stringify(parsed) : undefined,
+    })
+    const claimRes = await authWorker.fetch(url, init)
+    const claimText = await claimRes.text()
+    let claim: ClaimResponse
+    try {
+      claim = JSON.parse(claimText) as ClaimResponse
+    } catch {
+      // rust が JSON 以外を返した時はそのまま透過。
+      setResponseStatus(event, claimRes.status)
+      return claimText
+    }
+
+    setResponseStatus(event, claimRes.status)
+
+    // ② 即承認 flow (tenant_id あり) のみ device credential を mint して merge。
+    if (claimRes.ok && claim.success && claim.tenant_id) {
+      try {
+        const pair = buildPairInternalForward({
+          sharedSecret,
+          tenantId: claim.tenant_id,
+          label: (claim.device_id as string | undefined) || 'alc-device',
+        })
+        const pairRes = await authWorker.fetch(pair.url, pair.init)
+        if (pairRes.ok) {
+          const cred = (await pairRes.json()) as PairInternalResponse
+          if (cred.device_id && cred.device_secret) {
+            return { ...claim, auth_device_id: cred.device_id, device_secret: cred.device_secret }
+          }
+        }
+        // pairing 失敗は claim 自体を壊さない (端末は従来 X-Device-Token 経路で動作継続)。
+      } catch {
+        // 同上: provisioning 失敗時も claim レスポンスは返す。
+      }
+    }
+
+    return claim
+  })
+}

--- a/web/server/utils/device-proxy.ts
+++ b/web/server/utils/device-proxy.ts
@@ -1,0 +1,142 @@
+/**
+ * device JWT / browser JWT を伴う経路を auth-worker `/alc-proxy/*` に service binding で
+ * thin-forward する helper + claim 時の device credential provisioning
+ * (Refs ippoan/rust-alc-api#434 caller #5、Phase C 案B)。
+ *
+ * public-ingest (internal-proxy.ts) と違い、こちらは **JWT を持つ経路**:
+ *   - device 系 (#4 settings / #5 report-version / #6 report-watchdog / #7 register-fcm-token):
+ *     AlcoholChecker が `/device/token` で取得した **device JWT** を Authorization: Bearer で送る。
+ *   - admin 系 (#8 trigger-update): 管理画面の browser JWT を Authorization: Bearer で送る。
+ *
+ * auth-worker `/alc-proxy` が JWT introspect → X-Tenant-ID/X-User-* 注入 → OIDC mint して
+ * rust に forward する。alc-app は consumer proof (X-Alc-Proxy-Secret) + 元 origin
+ * (X-Alc-Proxy-Origin) を載せて service binding (AUTH_WORKER) に丸投げするだけ。
+ *
+ * **migration fallback**: Authorization が無い (= device JWT 未対応の旧 Android) リクエストは
+ * 従来どおり rust を直叩きする。lockdown (allUsers 削除) 前は直叩きも通るので非破壊。
+ */
+import type { H3Event } from 'h3'
+
+const ALC_PROXY_PREFIX = '/alc-proxy'
+const ALC_PROXY_BASE = 'https://alc-proxy.internal'
+
+export interface AlcProxyForward {
+  url: string
+  init: RequestInit
+}
+
+/**
+ * auth-worker `/alc-proxy<rustPath>` への forward request を構築する (pure、テスト対象)。
+ * JWT (device / browser) を Bearer に載せ、consumer proof secret と origin を付ける。
+ */
+export function buildAlcProxyForward(input: {
+  sharedSecret: string
+  origin: string
+  rustPath: string
+  method: string
+  token: string
+  search?: string
+  contentType?: string | null
+  body?: BodyInit | null
+}): AlcProxyForward {
+  const headers: Record<string, string> = {
+    'X-Alc-Proxy-Secret': input.sharedSecret,
+    'X-Alc-Proxy-Origin': input.origin,
+    Authorization: `Bearer ${input.token}`,
+  }
+  if (input.contentType) headers['Content-Type'] = input.contentType
+  const url = `${ALC_PROXY_BASE}${ALC_PROXY_PREFIX}${input.rustPath}${input.search ?? ''}`
+  const init: RequestInit = { method: input.method, headers }
+  if (input.body != null) init.body = input.body
+  return { url, init }
+}
+
+/** CF binding 群を取り出す。 */
+function cfEnv(event: H3Event): Record<string, unknown> {
+  return (event.context.cloudflare as { env?: Record<string, unknown> } | undefined)?.env ?? {}
+}
+
+/** Secrets Store binding (`.get()`) / 文字列 のいずれでも値を取り出す。 */
+async function resolveSecret(binding: unknown): Promise<string | null> {
+  if (typeof binding === 'string') return binding
+  if (binding && typeof (binding as { get?: unknown }).get === 'function') {
+    return (await (binding as { get(): Promise<string> }).get()) ?? null
+  }
+  return null
+}
+
+/** Authorization ヘッダーから Bearer token を取り出す (無ければ undefined)。 */
+function bearerToken(authHeader: string | undefined): string | undefined {
+  if (!authHeader) return undefined
+  const m = /^Bearer\s+(.+)$/i.exec(authHeader)
+  return m ? m[1] : undefined
+}
+
+/** backend レスポンスを event に転送する。 */
+async function streamJsonResponse(event: H3Event, res: Response): Promise<unknown> {
+  setResponseStatus(event, res.status)
+  const ct = res.headers.get('content-type')
+  if (ct) setHeader(event, 'content-type', ct)
+  const text = await res.text()
+  try {
+    return JSON.parse(text)
+  } catch {
+    return text
+  }
+}
+
+/**
+ * JWT 経路を `/alc-proxy` 経由で forward する Nitro server route handler を生成する。
+ * `rustPath` は固定文字列 or event から解決する関数 (settings の deviceId 埋め込み用)。
+ *
+ * Authorization Bearer があれば `/alc-proxy` 経由 (device/browser JWT)、無ければ
+ * rust 直叩き (migration fallback、lockdown 前のみ有効)。
+ */
+export function createDeviceProxyHandler(rustPathInput: string | ((event: H3Event) => string)) {
+  return defineEventHandler(async (event) => {
+    const rustPath = typeof rustPathInput === 'function' ? rustPathInput(event) : rustPathInput
+    const method = event.method
+
+    let body: string | undefined
+    let bodyContentType: string | undefined
+    if (method === 'POST' || method === 'PUT' || method === 'PATCH') {
+      const parsed = await readBody(event).catch(() => undefined)
+      if (parsed) {
+        body = JSON.stringify(parsed)
+        bodyContentType = 'application/json'
+      }
+    }
+
+    const token = bearerToken(getHeader(event, 'authorization'))
+
+    // ── Bearer あり: /alc-proxy 経由 (device JWT / browser JWT) ──
+    if (token) {
+      const env = cfEnv(event)
+      const sharedSecret = await resolveSecret(env.INTERNAL_SHARED_SECRET)
+      const authWorker = env.AUTH_WORKER as { fetch: typeof fetch } | undefined
+      if (sharedSecret && authWorker) {
+        const { url, init } = buildAlcProxyForward({
+          sharedSecret,
+          origin: getRequestURL(event).origin,
+          rustPath,
+          method,
+          token,
+          contentType: bodyContentType,
+          body,
+        })
+        return streamJsonResponse(event, await authWorker.fetch(url, init))
+      }
+      // binding 未設定は fallback に落とす (開発環境等)。
+    }
+
+    // ── Bearer なし or binding 未設定: rust 直叩き (migration fallback) ──
+    // native fetch を使う ($fetch は typed-routes 推論で動的 path に型エラーを出すため)。
+    const config = useRuntimeConfig()
+    const target = `${config.public.apiBase as string}${rustPath}`
+    const res = await fetch(target, {
+      method,
+      ...(body ? { body, headers: { 'Content-Type': 'application/json' } } : {}),
+    })
+    return streamJsonResponse(event, res)
+  })
+}

--- a/web/tests/server/device-proxy.test.ts
+++ b/web/tests/server/device-proxy.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest'
+import { buildAlcProxyForward } from '../../server/utils/device-proxy'
+import { buildPairInternalForward } from '../../server/utils/device-pairing'
+
+const SECRET = 'test-internal-shared-secret-32!!'
+
+describe('buildAlcProxyForward (rust-alc-api#434 caller #5, device/admin JWT 経路)', () => {
+  it('path を /alc-proxy<rustPath> に組み立て、JWT を Bearer・consumer proof・origin を載せる', () => {
+    const { url, init } = buildAlcProxyForward({
+      sharedSecret: SECRET,
+      origin: 'https://alc.ippoan.org',
+      rustPath: '/api/devices/report-version',
+      method: 'PUT',
+      token: 'device-jwt-abc',
+      contentType: 'application/json',
+      body: JSON.stringify({ device_id: 'd1', version_code: 5 }),
+    })
+    expect(url).toBe('https://alc-proxy.internal/alc-proxy/api/devices/report-version')
+    const h = init.headers as Record<string, string>
+    expect(h['Authorization']).toBe('Bearer device-jwt-abc')
+    expect(h['X-Alc-Proxy-Secret']).toBe(SECRET)
+    expect(h['X-Alc-Proxy-Origin']).toBe('https://alc.ippoan.org')
+    expect(h['Content-Type']).toBe('application/json')
+    expect(init.method).toBe('PUT')
+  })
+
+  it('GET (settings) は body 無しで deviceId 埋め込み path を組む', () => {
+    const { url, init } = buildAlcProxyForward({
+      sharedSecret: SECRET,
+      origin: 'https://alc.ippoan.org',
+      rustPath: '/api/devices/settings/dev-123',
+      method: 'GET',
+      token: 'jwt',
+    })
+    expect(url).toBe('https://alc-proxy.internal/alc-proxy/api/devices/settings/dev-123')
+    expect(init.body).toBeUndefined()
+  })
+})
+
+describe('buildPairInternalForward (rust-alc-api#434 caller #5, claim provisioning)', () => {
+  it('/device/pair-internal に X-Internal-Shared-Secret + tenant_id を載せ、role 既定は device-uploader', () => {
+    const { url, init } = buildPairInternalForward({
+      sharedSecret: SECRET,
+      tenantId: 'tenant-9',
+      label: 'alc-tablet',
+    })
+    expect(url).toBe('https://auth-internal.internal/device/pair-internal')
+    const h = init.headers as Record<string, string>
+    expect(h['X-Internal-Shared-Secret']).toBe(SECRET)
+    expect(init.method).toBe('POST')
+    const body = JSON.parse(init.body as string) as Record<string, unknown>
+    expect(body.tenant_id).toBe('tenant-9')
+    expect(body.label).toBe('alc-tablet')
+    expect(body.role).toBe('device-uploader')
+  })
+
+  it('role を明示できる', () => {
+    const { init } = buildPairInternalForward({
+      sharedSecret: SECRET,
+      tenantId: 't',
+      label: 'l',
+      role: 'device-kiosk',
+    })
+    const body = JSON.parse(init.body as string) as Record<string, unknown>
+    expect(body.role).toBe('device-kiosk')
+  })
+})


### PR DESCRIPTION
## 概要

rust-alc-api#434 lockdown 移行 **caller #5 (Android) 案B (device JWT) の alc-app Worker 側**。
AlcoholChecker の device 経路を lockdown 対応する (auth-worker#324 `/device/pair-internal` を consume)。

## 変更

### `server/utils/device-proxy.ts` (新規)
- `buildAlcProxyForward` (pure) + `createDeviceProxyHandler`
- Authorization Bearer (device JWT / admin browser JWT) があれば auth-worker `/alc-proxy` 経由
  (introspect → X-Tenant-ID/X-User-* 注入 → OIDC mint)、**無ければ rust 直叩き fallback**
  (lockdown 前のみ有効、非破壊 migration)。

### `server/utils/device-pairing.ts` (新規)
- `buildPairInternalForward` (pure) + `createClaimWithPairingHandler`
- claim を rust に forward (`/alc-internal-proxy`) → 即承認 flow (url/device_owner、rust が
  `tenant_id` を返す) で **auth-worker `/device/pair-internal` を server-to-server で叩いて
  device credential を mint** → claim レスポンスに `device_secret` を merge して端末へ返す。
- pairing 失敗は claim を壊さない (端末は従来 X-Device-Token 経路で継続)。

### route 書き換え
| route | handler |
|---|---|
| `devices/settings/[deviceId]` | `createDeviceProxyHandler` (deviceId 埋め込み) |
| `devices/report-version` / `report-watchdog` / `register-fcm-token` | `createDeviceProxyHandler` |
| `devices/trigger-update` (admin) | `createDeviceProxyHandler` (browser JWT) |
| `devices/register/claim` | `createClaimWithPairingHandler` |

## provisioning フロー

```
AlcoholChecker ──claim──▶ alc-app (createClaimWithPairingHandler)
  ──/alc-internal-proxy──▶ rust claim (device 登録 → tenant_id 返却)
  ──/device/pair-internal──▶ auth-worker (device credential mint)
  ──claim レスポンスに device_secret merge──▶ AlcoholChecker (保存)
AlcoholChecker ──device_id+device_secret──▶ /device/token ──▶ device JWT ──▶ Bearer で device 経路
```

端末には `INTERNAL_SHARED_SECRET` を焼かない (alc-app Worker だけが保持)。rust は claim
レスポンスで既に `tenant_id` + `settings_token` を返すため **rust 変更不要**。

## テスト

`tests/server/device-proxy.test.ts` 4 ケース追加 (計 8 pass): `/alc-proxy` path・Bearer/secret/origin
ヘッダ・GET body 無し / `/device/pair-internal` path・tenant_id・role 既定 device-uploader・role 明示。
`nuxi typecheck` 自ファイル clean。

## 後続 (caller #5 残り)

- **AlcoholChecker (Kotlin)**: claim レスポンスの `device_secret` 保存 → `/device/token` → Bearer 送信 (CCoW で build 不可、別 PR)
- `trigger-update-dev` (#9, X-Internal-Secret) / `fcm-dismiss-test` (#10) は dev/test 経路、後続
- Phase D: lockdown flip

Refs ippoan/rust-alc-api#434

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UioxVnUP66Qp4oVC7VUc7f)_