### PR TITLE
feat(server): fcm-dismiss-test / trigger-update-dev を proxy 経由に (Refs ippoan/rust-alc-api#434 caller #5)

### DIFF
--- a/web/server/api/devices/fcm-dismiss-test.post.ts
+++ b/web/server/api/devices/fcm-dismiss-test.post.ts
@@ -1,8 +1,3 @@
-export default defineEventHandler(async (event): Promise<unknown> => {
-  const config = useRuntimeConfig()
-  const body = await readBody(event)
-  return $fetch(`${config.public.apiBase}/api/devices/fcm-dismiss-test`, {
-    method: 'POST',
-    body,
-  })
-})
+// FCM dismiss test (public、rust は device_id lookup で tenant 解決)。lockdown 対応で
+// auth-worker /alc-internal-proxy 経由に forward (Refs ippoan/rust-alc-api#434 caller #5)。
+export default createInternalIngestHandler('/api/devices/fcm-dismiss-test')

--- a/web/server/api/devices/trigger-update-dev.post.ts
+++ b/web/server/api/devices/trigger-update-dev.post.ts
@@ -1,10 +1,6 @@
-export default defineEventHandler(async (event): Promise<unknown> => {
-  const config = useRuntimeConfig()
-  const body = await readBody(event)
-  const secret = getHeader(event, 'X-Internal-Secret') || ''
-  return $fetch(`${config.public.apiBase}/api/devices/trigger-update-dev`, {
-    method: 'POST',
-    body,
-    headers: { 'X-Internal-Secret': secret },
-  })
+// dev OTA push (CI/dev、rust は X-Internal-Secret = FCM_INTERNAL_SECRET で自前認証)。
+// lockdown 対応で auth-worker /alc-internal-proxy 経由に forward し、incoming X-Internal-Secret を
+// pass-through する (Refs ippoan/rust-alc-api#434 caller #5)。
+export default createInternalIngestHandler('/api/devices/trigger-update-dev', {
+  forwardInternalSecret: true,
 })

--- a/web/server/utils/internal-proxy.ts
+++ b/web/server/utils/internal-proxy.ts
@@ -45,9 +45,12 @@ export function buildInternalProxyForward(input: {
   search?: string
   contentType?: string | null
   body?: BodyInit | null
+  /** 追加で載せるヘッダー (例: dev OTA の X-Internal-Secret pass-through)。 */
+  extraHeaders?: Record<string, string>
 }): InternalProxyForward {
   const headers: Record<string, string> = {
     'X-Alc-Proxy-Secret': input.sharedSecret,
+    ...(input.extraHeaders ?? {}),
   }
   if (input.contentType) headers['Content-Type'] = input.contentType
   const url = `${INTERNAL_PROXY_BASE}${INTERNAL_PROXY_PREFIX}${input.rustPath}${input.search ?? ''}`
@@ -73,8 +76,15 @@ async function resolveSecret(binding: unknown): Promise<string | null> {
 /**
  * 固定 rustPath の public ingest 経路を `/alc-internal-proxy` 経由で forward する
  * Nitro server route handler を生成する。
+ *
+ * `forwardInternalSecret: true` の時は incoming request の `X-Internal-Secret` を
+ * pass-through する (dev OTA = trigger-update-dev 用。auth-worker 側 internal-secret クラスが
+ * これを rust に中継し、rust が FCM_INTERNAL_SECRET で検証する)。
  */
-export function createInternalIngestHandler(rustPath: string) {
+export function createInternalIngestHandler(
+  rustPath: string,
+  opts: { forwardInternalSecret?: boolean } = {},
+) {
   return defineEventHandler(async (event) => {
     const env = cfEnv(event)
     const sharedSecret = await resolveSecret(env.INTERNAL_SHARED_SECRET)
@@ -103,12 +113,19 @@ export function createInternalIngestHandler(rustPath: string) {
       }
     }
 
+    let extraHeaders: Record<string, string> | undefined
+    if (opts.forwardInternalSecret) {
+      const internalSecret = getHeader(event, 'x-internal-secret')
+      if (internalSecret) extraHeaders = { 'X-Internal-Secret': internalSecret }
+    }
+
     const { url, init } = buildInternalProxyForward({
       sharedSecret,
       rustPath,
       method,
       contentType,
       body,
+      extraHeaders,
     })
 
     const res = await authWorker.fetch(url, init)

--- a/web/tests/server/internal-proxy.test.ts
+++ b/web/tests/server/internal-proxy.test.ts
@@ -43,6 +43,18 @@ describe('buildInternalProxyForward (rust-alc-api#434 caller #5, public-ingest f
     expect(init.body).toBeUndefined()
   })
 
+  it('extraHeaders を載せる (X-Internal-Secret pass-through、dev OTA 用)', () => {
+    const { init } = buildInternalProxyForward({
+      sharedSecret: SECRET,
+      rustPath: '/api/devices/trigger-update-dev',
+      method: 'POST',
+      extraHeaders: { 'X-Internal-Secret': 'fcm-secret-xyz' },
+    })
+    const h = init.headers as Record<string, string>
+    expect(h['X-Alc-Proxy-Secret']).toBe(SECRET)
+    expect(h['X-Internal-Secret']).toBe('fcm-secret-xyz')
+  })
+
   it('search query を維持する', () => {
     const { url } = buildInternalProxyForward({
       sharedSecret: SECRET,


### PR DESCRIPTION
## 概要

rust-alc-api#434 caller #5 の残り edge endpoint (#9 / #10) を lockdown 対応する
(auth-worker#325 の allowlist 追加を consume)。これで caller #5 の alc-app route 移行が完了。

## 変更

| route | handler |
|---|---|
| `devices/fcm-dismiss-test` (#10) | `createInternalIngestHandler('/api/devices/fcm-dismiss-test')` (public-ingest) |
| `devices/trigger-update-dev` (#9) | `createInternalIngestHandler(..., { forwardInternalSecret: true })` |

- `trigger-update-dev` は incoming `X-Internal-Secret` を `/alc-internal-proxy` に pass-through
  し、auth-worker (internal-secret クラス) が rust に中継 → rust が FCM_INTERNAL_SECRET で検証。
- `buildInternalProxyForward` に `extraHeaders`、`createInternalIngestHandler` に
  `forwardInternalSecret` option を追加。

## テスト

`tests/server/internal-proxy.test.ts` に 1 ケース追加 (計 9 pass、extraHeaders pass-through)。
`nuxi typecheck` 自ファイル clean。

Refs ippoan/rust-alc-api#434

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01UioxVnUP66Qp4oVC7VUc7f)_