### PR TITLE
fix(api): fail-fast on uninitialized API before building FormData

### DIFF
--- a/web/app/utils/api.ts
+++ b/web/app/utils/api.ts
@@ -935,6 +935,10 @@ export async function deleteGuidanceRecord(id: string): Promise<void> {
 }
 
 export async function uploadGuidanceAttachment(recordId: string, file: File): Promise<GuidanceRecordAttachment> {
+  // FormData 構築前に未初期化を fail-fast する。Node の undici FormData は append 値の
+  // 型検証が厳格 (Node 24 で File を弾くケースあり) なので、proxyRawFetch まで進めると
+  // 'API 未初期化' ではなく append エラーで落ちる。proxyRawFetch fallback と同じ条件。
+  if (!apiBase && !getAccessToken?.() && !getKioskDeviceJwt) throw new Error('API 未初期化')
   const formData = new FormData()
   formData.append('file', file, file.name)
   const res = await proxyRawFetch(`/api/guidance-records/${recordId}/attachments`, {


### PR DESCRIPTION
## 概要

v0.0.12 tag の release run([#157](https://github.com/ippoan/alc-app/actions/runs/28349138292))が `ci / API Integration` job で fail した原因の修正。

## 失敗内容

```
FAIL tests/utils/api.test.ts > api > uploadGuidanceAttachment > should throw if API not initialized
AssertionError: expected [Function] to throw error including 'API 未初期化'
  but got 'FormData.append: Expected value ("Fil…'
```

## 原因

GitHub runner の **Node 20 → 24 移行**(ログに `running with Node 24 by default` / Node 20 deprecated)で undici の `FormData.append` の値型検証が厳格化し、happy-dom 由来の `File` を弾くようになった。`uploadGuidanceAttachment` は **init チェック(`proxyRawFetch` 内)より先に FormData を構築**していたため、未初期化テストで `API 未初期化` に到達する前に append エラーで落ちていた。

他の upload 系(`uploadFacePhoto` / `uploadReportAudio` / `uploadBlowVideo`)は append 値が **Blob**(Node 24 でも通る)なので影響なし。

## 修正

`uploadGuidanceAttachment` の FormData 構築前に、`proxyRawFetch` fallback と同条件の sync ガードを 1 行追加して fail-fast:

```ts
if (!apiBase && !getAccessToken?.() && !getKioskDeviceJwt) throw new Error('API 未初期化')
```

JWT(admin/device)or apiBase があれば従来どおり進む。完全未初期化時のみ FormData 構築前に throw する(= より fail-fast で正しい)。

## 検証

- `tests/utils/api.test.ts` 242 pass / 2 skip(live-only)
- `check_coverage_100.mjs`: 全 29 ファイル 100%、`app/utils/api.ts` は lines + branches とも 100% 維持

## 注意(release 再実行)

v0.0.12 tag は失敗 commit を指したままなので、本 PR merge 後に **v0.0.13 を打ち直す**と release が clean に通ります。

Refs ippoan/rust-alc-api#434

---
_Generated by [Claude Code](https://claude.ai/code/session_01UioxVnUP66Qp4oVC7VUc7f)_