### PR TITLE
feat(auth): Google login via auth-worker, cookie session (#434 案A)

### DIFF
--- a/web/app/composables/useAuth.ts
+++ b/web/app/composables/useAuth.ts
@@ -1,4 +1,4 @@
-import type { AuthUser, AuthResponse, RefreshResponse } from '~/types'
+import type { AuthUser, RefreshResponse } from '~/types'
 import { isClient } from '~/utils/env'
 
 /** Base64url → UTF-8 JSON デコード (マルチバイト文字対応) */
@@ -49,6 +49,11 @@ export function useAuth() {
 
     // deviceTenantId はモジュールスコープで既に復元済み
 
+    // #434: auth-worker が logi_auth_token cookie でログインを保持するので、まず cookie を
+    // 消費してログイン状態を復元する (Google login 後の再訪・別タブ等)。cookie 無し /
+    // SSR では no-op。
+    consumeAuthCookie()
+
     // Refresh token があれば自動ログイン試行
     const refreshToken = isClient
       ? localStorage.getItem(REFRESH_TOKEN_KEY)
@@ -98,52 +103,46 @@ export function useAuth() {
 
   /** Google OAuth ログイン (Authorization Code Flow + prompt=login) */
   function loginWithGoogleRedirect(redirectAfterLogin?: string): void {
-    const clientId = config.public.googleClientId as string
+    if (!isClient) return
     const callbackUrl = `${window.location.origin}/auth/callback`
-
-    // CSRF 対策: state をランダム生成して sessionStorage に保存
-    const state = crypto.randomUUID()
-    sessionStorage.setItem('oauth_state', state)
     if (redirectAfterLogin) {
       sessionStorage.setItem('oauth_redirect', redirectAfterLogin)
     }
-
-    const params = new URLSearchParams({
-      client_id: clientId,
-      redirect_uri: callbackUrl,
-      response_type: 'code',
-      scope: 'openid email profile',
-      prompt: 'login',
-      max_age: '0',
-      state,
-    })
-
-    window.location.href = `https://accounts.google.com/o/oauth2/v2/auth?${params}`
+    // #434: Google OAuth は auth-worker が orchestrate する (rust は dumb backend)。
+    // auth-worker が Google と code 交換 → JWT 発行 → logi_auth_token cookie
+    // (Domain=.ippoan.org) で配布し callbackUrl へ戻す。client_id / CSRF state / code
+    // 交換は auth-worker が担う (HMAC state)。alc-app は戻ってきた cookie を読むだけ。
+    const authWorker = (config.public.authWorkerUrl as string).replace(/\/$/, '')
+    const params = new URLSearchParams({ redirect_uri: callbackUrl })
+    window.location.href = `${authWorker}/oauth/google/redirect?${params.toString()}`
   }
 
-  /** Google OAuth コールバック: authorization code をバックエンドと交換 */
-  async function handleGoogleCallback(code: string, state: string): Promise<void> {
-    // CSRF state 検証
-    const savedState = sessionStorage.getItem('oauth_state')
-    sessionStorage.removeItem('oauth_state')
-    if (!savedState || savedState !== state) {
-      throw new Error('不正なリクエスト (state mismatch)')
-    }
-
-    const callbackUrl = `${window.location.origin}/auth/callback`
-    const res = await fetch(`${apiBase}/api/auth/google/code`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ code, redirect_uri: callbackUrl }),
-    })
-
-    if (!res.ok) {
-      const body = await res.text().catch(() => '')
-      throw new Error(`ログイン失敗 (${res.status}): ${body}`)
-    }
-
-    const data: AuthResponse = await res.json()
-    setTokens(data)
+  /**
+   * auth-worker が配布した `logi_auth_token` cookie からログイン状態を確立する (#434)。
+   * cookie は HttpOnly でない (Domain=.ippoan.org / Secure / SameSite=Lax) ため JS から
+   * 読める。Google / auth-worker login 後の callback と init で呼ぶ。cookie 無しなら false。
+   */
+  function consumeAuthCookie(): boolean {
+    if (!isClient) return false
+    const raw = document.cookie.match(/(?:^|;\s*)logi_auth_token=([^;]+)/)?.[1]
+    if (!raw) return false
+    const token = decodeURIComponent(raw)
+    accessToken.value = token
+    try {
+      const parts = token.split('.')
+      if (!parts[1]) throw new Error('Invalid JWT')
+      const payload = decodeJwtPayload(parts[1])
+      const tenantId = payload.tenant_id || payload.org || ''
+      user.value = {
+        id: payload.sub || payload.user_id || '',
+        email: payload.email || '',
+        name: payload.name || '',
+        tenant_id: tenantId,
+        role: payload.role || 'viewer',
+      }
+      if (tenantId) activateDevice(tenantId)
+    } catch { /* デコード失敗してもログイン状態は維持 */ }
+    return true
   }
 
   /** Refresh token で access token を更新 */
@@ -178,24 +177,6 @@ export function useAuth() {
       }
     } catch {
       // デコード失敗してもログイン状態は維持
-    }
-
-    scheduleAutoRefresh()
-    startInactivityWatch()
-  }
-
-  /** トークンをセットして state を更新 */
-  function setTokens(data: AuthResponse) {
-    accessToken.value = data.access_token
-    user.value = data.user
-
-    if (isClient) {
-      localStorage.setItem(REFRESH_TOKEN_KEY, data.refresh_token)
-    }
-
-    // 初回ログイン時に端末をアクティベート
-    if (data.user.tenant_id) {
-      activateDevice(data.user.tenant_id)
     }
 
     scheduleAutoRefresh()
@@ -405,7 +386,7 @@ export function useAuth() {
     isDeviceActivated,
     init,
     loginWithGoogleRedirect,
-    handleGoogleCallback,
+    consumeAuthCookie,
     handleLineworksHash,
     refreshAccessToken,
     logout,

--- a/web/app/pages/auth/callback.vue
+++ b/web/app/pages/auth/callback.vue
@@ -1,32 +1,26 @@
 <script setup lang="ts">
-const { handleGoogleCallback, isAuthenticated } = useAuth()
+const { consumeAuthCookie, isAuthenticated } = useAuth()
 const route = useRoute()
 const error = ref<string | null>(null)
 
-onMounted(async () => {
-  const code = route.query.code as string
-  const state = route.query.state as string
+// #434: Google OAuth は auth-worker が orchestrate し、logi_auth_token cookie で
+// ログインを配布する。callback では cookie を消費するだけ (code 交換は auth-worker)。
+onMounted(() => {
   const queryError = route.query.error as string
-
   if (queryError) {
     error.value = `Google 認証エラー: ${queryError}`
     return
   }
 
-  if (!code || !state) {
-    error.value = '不正なコールバックです'
+  if (!consumeAuthCookie()) {
+    error.value = 'ログインに失敗しました (認証情報が見つかりません)'
     return
   }
 
-  try {
-    await handleGoogleCallback(code, state)
-    // ログイン成功 → リダイレクト先へ
-    const redirect = sessionStorage.getItem('oauth_redirect') || '/?role=admin'
-    sessionStorage.removeItem('oauth_redirect')
-    navigateTo(redirect)
-  } catch (e) {
-    error.value = e instanceof Error ? e.message : 'ログインに失敗しました'
-  }
+  // ログイン成功 → リダイレクト先へ
+  const redirect = sessionStorage.getItem('oauth_redirect') || '/?role=admin'
+  sessionStorage.removeItem('oauth_redirect')
+  navigateTo(redirect)
 })
 </script>
 

--- a/web/tests/composables/useAuth.test.ts
+++ b/web/tests/composables/useAuth.test.ts
@@ -690,24 +690,17 @@ describe('useAuth', () => {
   })
 
   describe('loginWithGoogleRedirect', () => {
-    it('should redirect to Google OAuth and store state in sessionStorage', async () => {
-      const mockUUID = '550e8400-e29b-41d4-a716-446655440000'
-      vi.stubGlobal('crypto', {
-        ...crypto,
-        randomUUID: () => mockUUID,
-      })
-
+    it('redirects to auth-worker /oauth/google/redirect with callback redirect_uri', async () => {
       const { useAuth } = await import('~/composables/useAuth')
       const { loginWithGoogleRedirect } = useAuth()
 
-      // Mock window.location
       const hrefSetter = vi.fn()
       const originalLocation = window.location
       Object.defineProperty(window, 'location', {
         value: {
           ...originalLocation,
           origin: 'https://example.com',
-          href: 'https://example.com',
+          href: '',
           set href(val: string) { hrefSetter(val) },
         },
         writable: true,
@@ -716,25 +709,22 @@ describe('useAuth', () => {
 
       loginWithGoogleRedirect('/dashboard')
 
-      expect(sessionStorage.getItem('oauth_state')).toBe(mockUUID)
       expect(sessionStorage.getItem('oauth_redirect')).toBe('/dashboard')
+      const url = hrefSetter.mock.calls[0]?.[0] as string
+      expect(url).toContain('/oauth/google/redirect')
+      expect(url).toContain(`redirect_uri=${encodeURIComponent('https://example.com/auth/callback')}`)
 
-      // Restore
       Object.defineProperty(window, 'location', { value: originalLocation, writable: true, configurable: true })
     })
 
     it('should not store redirect when not provided', async () => {
-      vi.stubGlobal('crypto', {
-        ...crypto,
-        randomUUID: () => 'test-uuid',
-      })
-
       const { useAuth } = await import('~/composables/useAuth')
       const { loginWithGoogleRedirect } = useAuth()
 
+      const hrefSetter = vi.fn()
       const originalLocation = window.location
       Object.defineProperty(window, 'location', {
-        value: { ...originalLocation, origin: 'https://example.com', href: '' },
+        value: { ...originalLocation, origin: 'https://example.com', href: '', set href(val: string) { hrefSetter(val) } },
         writable: true,
         configurable: true,
       })
@@ -742,128 +732,103 @@ describe('useAuth', () => {
       loginWithGoogleRedirect()
 
       expect(sessionStorage.getItem('oauth_redirect')).toBeNull()
+      expect(hrefSetter).toHaveBeenCalled()
 
       Object.defineProperty(window, 'location', { value: originalLocation, writable: true, configurable: true })
     })
-  })
 
-  describe('handleGoogleCallback', () => {
-    it('should exchange code for tokens', async () => {
-      sessionStorage.setItem('oauth_state', 'valid-state')
+    it('is a no-op on the server (isClient=false)', async () => {
+      envMock.isClient = false
+      const { useAuth } = await import('~/composables/useAuth')
+      const { loginWithGoogleRedirect } = useAuth()
 
-      const fakeJwt = createFakeJwtWithExp(defaultPayload, 3600)
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({
-          access_token: fakeJwt,
-          refresh_token: 'rt_new',
-          expires_in: 3600,
-          user: {
-            id: 'user-1',
-            email: 'test@example.com',
-            name: 'Test User',
-            tenant_id: 'tenant-1',
-            role: 'admin',
-          },
-        }),
+      const hrefSetter = vi.fn()
+      const originalLocation = window.location
+      Object.defineProperty(window, 'location', {
+        value: { ...originalLocation, origin: 'https://example.com', href: '', set href(val: string) { hrefSetter(val) } },
+        writable: true,
+        configurable: true,
       })
 
+      loginWithGoogleRedirect('/x')
+
+      expect(hrefSetter).not.toHaveBeenCalled()
+
+      Object.defineProperty(window, 'location', { value: originalLocation, writable: true, configurable: true })
+      envMock.isClient = true
+    })
+  })
+
+  describe('consumeAuthCookie', () => {
+    function setDocCookie(value: string) {
+      Object.defineProperty(document, 'cookie', { value, writable: true, configurable: true })
+    }
+    afterEach(() => setDocCookie(''))
+
+    it('returns false when no logi_auth_token cookie present', async () => {
+      setDocCookie('other=1')
       const { useAuth } = await import('~/composables/useAuth')
       const auth = useAuth()
+      expect(auth.consumeAuthCookie()).toBe(false)
+      expect(auth.isAuthenticated.value).toBe(false)
+    })
 
-      await auth.handleGoogleCallback('auth-code-123', 'valid-state')
+    it('returns false on the server (isClient=false)', async () => {
+      envMock.isClient = false
+      const fakeJwt = createFakeJwtWithExp(defaultPayload, 3600)
+      setDocCookie(`logi_auth_token=${fakeJwt}`)
+      const { useAuth } = await import('~/composables/useAuth')
+      const auth = useAuth()
+      expect(auth.consumeAuthCookie()).toBe(false)
+      envMock.isClient = true
+    })
 
+    it('establishes session and activates device from cookie JWT', async () => {
+      const fakeJwt = createFakeJwtWithExp(defaultPayload, 3600)
+      setDocCookie(`logi_auth_token=${fakeJwt}`)
+      const { useAuth } = await import('~/composables/useAuth')
+      const auth = useAuth()
+      expect(auth.consumeAuthCookie()).toBe(true)
       expect(auth.isAuthenticated.value).toBe(true)
       expect(auth.user.value?.email).toBe('test@example.com')
-      expect(localStorage.getItem('alc_refresh_token')).toBe('rt_new')
-      // setTokens also activates device
       expect(auth.deviceTenantId.value).toBe('tenant-1')
     })
 
-    it('should not activate device when tenant_id is empty', async () => {
-      sessionStorage.setItem('oauth_state', 'valid-state')
-
-      const fakeJwt = createFakeJwtWithExp({
-        ...defaultPayload,
-        tenant_id: '',
-      }, 3600)
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({
-          access_token: fakeJwt,
-          refresh_token: 'rt_new',
-          user: {
-            id: 'user-1',
-            email: 'test@example.com',
-            name: 'Test User',
-            tenant_id: '',
-            role: 'admin',
-          },
-        }),
-      })
-
+    it('does not activate device when tenant_id is empty', async () => {
+      const fakeJwt = createFakeJwtWithExp({ ...defaultPayload, tenant_id: '', org: '' }, 3600)
+      setDocCookie(`logi_auth_token=${fakeJwt}`)
       const { useAuth } = await import('~/composables/useAuth')
       const auth = useAuth()
-
-      await auth.handleGoogleCallback('code', 'valid-state')
-
-      expect(auth.isAuthenticated.value).toBe(true)
-      // tenant_id is empty → activateDevice not called
+      expect(auth.consumeAuthCookie()).toBe(true)
       expect(auth.deviceTenantId.value).toBeNull()
     })
 
-    it('should throw on state mismatch', async () => {
-      sessionStorage.setItem('oauth_state', 'correct-state')
-
+    it('keeps login state even when JWT payload is malformed', async () => {
+      setDocCookie('logi_auth_token=not-a-jwt')
       const { useAuth } = await import('~/composables/useAuth')
       const auth = useAuth()
-
-      await expect(
-        auth.handleGoogleCallback('code', 'wrong-state'),
-      ).rejects.toThrow('不正なリクエスト (state mismatch)')
+      expect(auth.consumeAuthCookie()).toBe(true)
+      expect(auth.accessToken.value).toBe('not-a-jwt')
     })
 
-    it('should throw when no saved state', async () => {
+    it('uses fallback claim fields (user_id / org) and defaults for missing email/name/role', async () => {
+      const fakeJwt = createFakeJwtWithExp({ user_id: 'uid-9', org: 'org-9' }, 3600)
+      setDocCookie(`logi_auth_token=${fakeJwt}`)
       const { useAuth } = await import('~/composables/useAuth')
       const auth = useAuth()
-
-      await expect(
-        auth.handleGoogleCallback('code', 'any-state'),
-      ).rejects.toThrow('不正なリクエスト (state mismatch)')
+      expect(auth.consumeAuthCookie()).toBe(true)
+      expect(auth.user.value).toEqual({ id: 'uid-9', email: '', name: '', tenant_id: 'org-9', role: 'viewer' })
+      expect(auth.deviceTenantId.value).toBe('org-9')
     })
 
-    it('should throw on API error', async () => {
-      sessionStorage.setItem('oauth_state', 'valid-state')
-
-      mockFetch.mockResolvedValueOnce({
-        ok: false,
-        status: 400,
-        text: () => Promise.resolve('Bad Request'),
-      })
-
+    it('defaults id to empty string when neither sub nor user_id present', async () => {
+      const fakeJwt = createFakeJwtWithExp({ org: 'org-2' }, 3600)
+      setDocCookie(`logi_auth_token=${fakeJwt}`)
       const { useAuth } = await import('~/composables/useAuth')
       const auth = useAuth()
-
-      await expect(
-        auth.handleGoogleCallback('bad-code', 'valid-state'),
-      ).rejects.toThrow('ログイン失敗 (400): Bad Request')
-    })
-
-    it('should handle text() failure in error response', async () => {
-      sessionStorage.setItem('oauth_state', 'valid-state')
-
-      mockFetch.mockResolvedValueOnce({
-        ok: false,
-        status: 500,
-        text: () => Promise.reject(new Error('read failed')),
-      })
-
-      const { useAuth } = await import('~/composables/useAuth')
-      const auth = useAuth()
-
-      await expect(
-        auth.handleGoogleCallback('bad-code', 'valid-state'),
-      ).rejects.toThrow('ログイン失敗 (500): ')
+      expect(auth.consumeAuthCookie()).toBe(true)
+      expect(auth.user.value?.id).toBe('')
+      expect(auth.user.value?.tenant_id).toBe('org-2')
     })
   })
 
@@ -1344,30 +1309,6 @@ describe('useAuth', () => {
       expect(auth.isAuthenticated.value).toBe(false)
     })
 
-    it('setTokens skips localStorage via handleGoogleCallback in SSR', async () => {
-      const { useAuth } = await import('~/composables/useAuth')
-      const auth = useAuth()
-
-      // Setup CSRF state
-      sessionStorage.setItem('oauth_state', 'test-state')
-
-      const jwt = createFakeJwt(defaultPayload)
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({
-          access_token: jwt,
-          refresh_token: 'rt-ssr',
-          user: { id: 'user-1', email: 'test@example.com', name: 'Test', tenant_id: 'tenant-1', role: 'admin' },
-        }),
-      })
-
-      await auth.handleGoogleCallback('code-1', 'test-state')
-
-      // Token is set in memory
-      expect(auth.isAuthenticated.value).toBe(true)
-      // But localStorage is not touched (isClient=false)
-      expect(localStorage.getItem('alc_refresh_token')).toBeNull()
-    })
   })
 
   describe('staging auth bypass', () => {


### PR DESCRIPTION
## 概要

ippoan/rust-alc-api#434 lockdown(`allUsers` 削除)に向け、alc-app の Google login が rust 直叩き(`/api/auth/google/code`)のままだと**ログイン不能**になる問題を、#434 設計どおり **auth-worker が JWT を発行する cookie session モデル**へ移行(案A)。

## 変更(`web/`)

- **`loginWithGoogleRedirect`**: `accounts.google.com` 直 → **auth-worker `/oauth/google/redirect?redirect_uri=…`**。Google との code 交換 / CSRF state / JWT 発行は auth-worker が担う(`google-redirect.ts` / `google-callback.ts`、既存)。alc-app は client_id / state を持たない。
- **`consumeAuthCookie`**(新規): auth-worker が配布する **`logi_auth_token` cookie**(`Domain=.ippoan.org`、非 HttpOnly = JS 可読)を読み、JWT payload から session を確立。`auth/callback.vue` と `init()` で消費。
- **削除**: `handleGoogleCallback`(rust `/api/auth/google/code` POST)と、呼び出し元が消えた `setTokens`。`auth/callback.vue` は `?code=` 交換 → cookie 消費に変更。

## なぜ cookie か
`alc.ippoan.org` は `.ippoan.org` 配下なので、auth-worker は token を URL fragment ではなく **共有 cookie で配布**する(`google-callback.ts` の `authCookieReachesHost` 分岐)。データ API も `/alc-proxy` が cookie を読むため、lockdown 後も一貫。

## 検証
- `useAuth` coverage **100% 維持**(`consumeAuthCookie` / `loginWithGoogleRedirect` の全分岐 + SSR no-op テスト追加)
- 全 **1031 pass** / 3 skip
- typecheck: 変更ファイル(`useAuth.ts` / `callback.vue`)はクリーン(出る error は sibling `auth-worker/packages/auth-client/*.vue` の local 環境依存で本変更と無関係)

## ⚠️ 残作業・注意
- **staging で実機ログイン検証してから prod lockdown に進むこと**(redirect + cookie の実フローはブラウザでしか確認できない)。
- `refresh` / `logout` はまだ rust 直叩き(`/api/auth/refresh` / `/api/auth/logout`)。lockdown 完全対応には別途これらの経路移行が必要(#434 残 item)。

Refs ippoan/rust-alc-api#434

---
_Generated by [Claude Code](https://claude.ai/code/session_01UioxVnUP66Qp4oVC7VUc7f)_