### PR TITLE
fix(devices): 端末登録の公開APIが lockdown 後 apiBase 直叩きで Failed to fetch になる問題を修正 (Refs ippoan/rust-alc-api#480)

### DIFF
--- a/web/app/utils/api.ts
+++ b/web/app/utils/api.ts
@@ -125,6 +125,28 @@ async function proxyRequest<T>(path: string, jwt: string, options: RequestInit):
 }
 
 /**
+ * 端末登録前 (認証情報が一切無い) の public ingest 経路専用。alc-app 自身の Nitro server
+ * route (`server/api/devices/register/{request,status/[code],claim}`) を same-origin で
+ * 叩く。これらの route は auth-worker `/alc-internal-proxy` 経由で rust に forward される
+ * (Refs ippoan/rust-alc-api#480)。
+ *
+ * `request()` の X-Tenant-ID 直 fetch fallback をここで使うと、rust-alc-api の Cloud Run
+ * IAM lockdown 後は直叩きが 403 (CORS ヘッダー無し) になり「Failed to fetch」になる —
+ * この関数はその bug を踏まないための専用経路。
+ */
+async function publicIngestRequest<T>(path: string, options: RequestInit = {}): Promise<T> {
+  const headers = new Headers(options.headers)
+  if (options.body && !headers.has('Content-Type')) headers.set('Content-Type', 'application/json')
+  const res = await fetch(path, { ...options, headers })
+  if (!res.ok) {
+    const body = await res.text()
+    throw new Error(`API エラー (${res.status}): ${body || res.statusText}`)
+  }
+  if (res.status === 204) return undefined as T
+  return (await res.json()) as T
+}
+
+/**
  * blob / FormData 系の raw fetch を認証付きで投げ Response をそのまま返す (#434 step 3d)。
  * admin browser JWT or device JWT があれば same-origin proxy (/api/proxy) 経由
  * (proxy が X-Tenant-ID 注入 + OIDC mint)。どちらも無ければ従来の `${apiBase}` 直叩き
@@ -701,20 +723,21 @@ export async function getTenkoCallDrivers(): Promise<TenkoCallDriver[]> {
 
 // ============ Device Registration ============
 
-// 公開API (認証不要)
+// 公開API (認証不要、端末登録前なので admin/device JWT が無い。same-origin Nitro
+// server route 経由で叩く。Refs ippoan/rust-alc-api#480)
 export async function createDeviceRegistrationRequest(deviceName?: string): Promise<CreateRegistrationResponse> {
-  return request<CreateRegistrationResponse>('/api/devices/register/request', {
+  return publicIngestRequest<CreateRegistrationResponse>('/api/devices/register/request', {
     method: 'POST',
     body: JSON.stringify({ device_name: deviceName }),
   })
 }
 
 export async function checkDeviceRegistrationStatus(code: string): Promise<RegistrationStatusResponse> {
-  return request<RegistrationStatusResponse>(`/api/devices/register/status/${code}`)
+  return publicIngestRequest<RegistrationStatusResponse>(`/api/devices/register/status/${code}`)
 }
 
 export async function claimDeviceRegistration(data: ClaimRegistrationRequest): Promise<ClaimRegistrationResponse> {
-  return request<ClaimRegistrationResponse>('/api/devices/register/claim', {
+  return publicIngestRequest<ClaimRegistrationResponse>('/api/devices/register/claim', {
     method: 'POST',
     body: JSON.stringify(data),
   })

--- a/web/app/utils/api.ts
+++ b/web/app/utils/api.ts
@@ -136,7 +136,7 @@ async function proxyRequest<T>(path: string, jwt: string, options: RequestInit):
  */
 async function publicIngestRequest<T>(path: string, options: RequestInit = {}): Promise<T> {
   const headers = new Headers(options.headers)
-  if (options.body && !headers.has('Content-Type')) headers.set('Content-Type', 'application/json')
+  if (options.body) headers.set('Content-Type', 'application/json')
   const res = await fetch(path, { ...options, headers })
   if (!res.ok) {
     const body = await res.text()

--- a/web/server/api/devices/register/request.post.ts
+++ b/web/server/api/devices/register/request.post.ts
@@ -1,0 +1,3 @@
+// QR一時 / URL 端末登録の起点 (認証なし public 経路)。lockdown 対応で auth-worker
+// /alc-internal-proxy 経由に forward する (Refs ippoan/rust-alc-api#480)。
+export default createInternalIngestHandler('/api/devices/register/request')

--- a/web/server/api/devices/register/status/[code].get.ts
+++ b/web/server/api/devices/register/status/[code].get.ts
@@ -1,0 +1,5 @@
+// QR一時登録のステータス確認 (認証なし public 経路、ポーリング用)。lockdown 対応で
+// auth-worker /alc-internal-proxy 経由に forward する (Refs ippoan/rust-alc-api#480)。
+export default createInternalIngestHandler(
+  (event) => `/api/devices/register/status/${getRouterParam(event, 'code')}`,
+)

--- a/web/server/utils/internal-proxy.ts
+++ b/web/server/utils/internal-proxy.ts
@@ -74,18 +74,20 @@ async function resolveSecret(binding: unknown): Promise<string | null> {
 }
 
 /**
- * 固定 rustPath の public ingest 経路を `/alc-internal-proxy` 経由で forward する
- * Nitro server route handler を生成する。
+ * 固定 (または event から解決する) rustPath の public ingest 経路を `/alc-internal-proxy`
+ * 経由で forward する Nitro server route handler を生成する。`rustPath` は固定文字列 or
+ * event から解決する関数 (device-claim status の `[code]` 埋め込み用)。
  *
  * `forwardInternalSecret: true` の時は incoming request の `X-Internal-Secret` を
  * pass-through する (dev OTA = trigger-update-dev 用。auth-worker 側 internal-secret クラスが
  * これを rust に中継し、rust が FCM_INTERNAL_SECRET で検証する)。
  */
 export function createInternalIngestHandler(
-  rustPath: string,
+  rustPathInput: string | ((event: H3Event) => string),
   opts: { forwardInternalSecret?: boolean } = {},
 ) {
   return defineEventHandler(async (event) => {
+    const rustPath = typeof rustPathInput === 'function' ? rustPathInput(event) : rustPathInput
     const env = cfEnv(event)
     const sharedSecret = await resolveSecret(env.INTERNAL_SHARED_SECRET)
     if (!sharedSecret) {

--- a/web/tests/helpers/api-test-env.ts
+++ b/web/tests/helpers/api-test-env.ts
@@ -187,8 +187,12 @@ function installLiveIdentityFetch() {
   const rewriteProxyUrl = (url: string): string => {
     const marker = '/api/proxy/'
     const i = url.indexOf(marker)
-    if (i === -1) return url
-    return `${API_BASE}/api/${url.slice(i + marker.length)}`
+    if (i !== -1) return `${API_BASE}/api/${url.slice(i + marker.length)}`
+    // 端末登録前の public ingest (same-origin Nitro route、Refs rust-alc-api#480)。
+    // live 統合テストには Nuxt server が無いため、rust-alc-api を直叩きする
+    // (本番の auth-worker /alc-internal-proxy 経由の検証は各 repo の unit test 側で担保)。
+    if (url.startsWith('/api/devices/register/')) return `${API_BASE}${url}`
+    return url
   }
   const wrapped = (async (input: RequestInfo | URL, init: RequestInit = {}) => {
     const headers = new Headers(

--- a/web/tests/utils/api.test.ts
+++ b/web/tests/utils/api.test.ts
@@ -790,6 +790,26 @@ describe('api', () => {
       })
     })
 
+    it.skipIf(isLive)('claimDeviceRegistration surfaces non-2xx as API エラー', async () => {
+      stubResponse(errResponse(503, 'INTERNAL_SHARED_SECRET binding が未設定です'))
+      await expect(
+        claimDeviceRegistration({ registration_code: 'DUMMY-CLAIM-CODE' } as any),
+      ).rejects.toThrow('API エラー (503)')
+    })
+
+    it.skipIf(isLive)('claimDeviceRegistration falls back to statusText when body is empty', async () => {
+      stubResponse(errResponse(500))
+      await expect(
+        claimDeviceRegistration({ registration_code: 'DUMMY-CLAIM-CODE' } as any),
+      ).rejects.toThrow('API エラー (500): Error')
+    })
+
+    it.skipIf(isLive)('checkDeviceRegistrationStatus handles 204 (no content)', async () => {
+      stubResponse(ok204())
+      const result = await checkDeviceRegistrationStatus(SEED_REG_CODE)
+      expect(result).toBeUndefined()
+    })
+
     it('createDeviceUrlToken with opts', async () => {
       stubOk({})
       await callApi(() => createDeviceUrlToken('dev', { is_device_owner: true, is_dev_device: true }))

--- a/web/tests/utils/api.test.ts
+++ b/web/tests/utils/api.test.ts
@@ -597,7 +597,6 @@ describe('api', () => {
       ['getTimecardCardByCardId', () => getTimecardCardByCardId(SEED_CARD_NFC), `/api/timecard/cards/by-card/${SEED_CARD_NFC}`],
       ['listDevices', () => listDevices(), '/api/devices'],
       ['listPendingDeviceRegistrations', () => listPendingDeviceRegistrations(), '/api/devices/pending'],
-      ['checkDeviceRegistrationStatus', () => checkDeviceRegistrationStatus(SEED_REG_CODE), `/api/devices/register/status/${SEED_REG_CODE}`],
       ['getDeviceSettings', () => getDeviceSettings(SEED_DEVICE_ID), `/api/devices/settings/${SEED_DEVICE_ID}`],
       ['getCarryingItems', () => getCarryingItems(), '/api/carrying-items'],
       ['getDriverInfo', () => getDriverInfo(TEST_EMPLOYEE_ID), `/api/tenko/driver-info/${TEST_EMPLOYEE_ID}`],
@@ -708,8 +707,6 @@ describe('api', () => {
       ['createFailure', () => createFailure(createEquipmentFailureBody as any), '/api/tenko/equipment-failures'],
       ['createTimecardCard', () => createTimecardCard({ card_id: `NFC-POST-${Date.now()}`, employee_id: TEST_EMPLOYEE_ID } as any), '/api/timecard/cards'],
       ['punchTimecard', () => punchTimecard(SEED_CARD_NFC), '/api/timecard/punch'],
-      ['createDeviceRegistrationRequest', () => createDeviceRegistrationRequest(), '/api/devices/register/request'],
-      ['claimDeviceRegistration', () => claimDeviceRegistration({ registration_code: 'DUMMY-CLAIM-CODE' } as any), '/api/devices/register/claim'],
       ['createDeviceUrlToken', () => createDeviceUrlToken(), '/api/devices/register/create-token'],
       ['createPermanentQr', () => createPermanentQr(), '/api/devices/register/create-permanent-qr'],
       ['createDeviceOwnerToken', () => createDeviceOwnerToken(), '/api/devices/register/create-device-owner-token'],
@@ -761,6 +758,35 @@ describe('api', () => {
       assertMock(() => {
         const body = JSON.parse(mockFetch.mock.calls[0][1].body)
         expect(body.device_name).toBe('My Device')
+      })
+    })
+
+    // 端末登録前の public ingest 系 (認証情報なし) は same-origin Nitro server route
+    // (server/api/devices/register/*) を叩く — rust-alc-api の apiBase に直接 fetch すると
+    // Cloud Run IAM lockdown 後は 403 (CORS ヘッダー無し) で "Failed to fetch" になる
+    // (Refs ippoan/rust-alc-api#480)。
+    it.skipIf(isLive)('createDeviceRegistrationRequest uses same-origin path (not apiBase)', async () => {
+      stubOk({})
+      await callApi(() => createDeviceRegistrationRequest('My Device'))
+      assertMock(() => {
+        expect(mockFetch.mock.calls[0][0]).toBe('/api/devices/register/request')
+      })
+    })
+
+    it.skipIf(isLive)('checkDeviceRegistrationStatus uses same-origin path (not apiBase)', async () => {
+      stubOk({})
+      await callApi(() => checkDeviceRegistrationStatus(SEED_REG_CODE))
+      assertMock(() => {
+        expect(mockFetch.mock.calls[0][0]).toBe(`/api/devices/register/status/${SEED_REG_CODE}`)
+      })
+    })
+
+    it.skipIf(isLive)('claimDeviceRegistration uses same-origin path (not apiBase)', async () => {
+      stubOk({})
+      await callApi(() => claimDeviceRegistration({ registration_code: 'DUMMY-CLAIM-CODE' } as any))
+      assertMock(() => {
+        expect(mockFetch.mock.calls[0][0]).toBe('/api/devices/register/claim')
+        expect(mockFetch.mock.calls[0][1].method).toBe('POST')
       })
     })
 


### PR DESCRIPTION
## 背景

`?role=admin` の「QRコードで端末登録 (即承認)」からデバイス名を入力して登録すると **Failed to fetch** になる不具合を報告いただき調査。

## 原因

`createDeviceRegistrationRequest` / `checkDeviceRegistrationStatus` / `claimDeviceRegistration` は端末登録前 (admin/device JWT を持たない) の public ingest 経路のため、既存の共通 `request()` は認証情報が無いと `X-Tenant-ID` 直 fetch fallback で **`apiBase` (rust-alc-api の Cloud Run URL) を直接叩いていた**。

ippoan/rust-alc-api#434 の lockdown (Cloud Run IAM で `allUsers` invoker 削除) 後は、この直叩きが Google Front End レベルで 403 になり、CORS ヘッダーも付かないため、ブラウザからは「Failed to fetch」としてしか観測できない。

調査の過程で、`server/api/devices/register/claim.post.ts` は既に auth-worker `/alc-internal-proxy` 経由の proxy 対応 (lockdown 対応) 済みだったが、**フロントエンドが一切この Nitro server route を経由しておらず、実質デッドコード化していた**ことも判明した (`request()` が同名 path で `apiBase` に直接飛んでいたため)。

## 修正内容

1. `server/api/devices/register/request.post.ts` / `server/api/devices/register/status/[code].get.ts` を新規追加し、`claim.post.ts` と同じ `/alc-internal-proxy` 経由の public ingest handler (`createInternalIngestHandler`) に対応させた
   - `internal-proxy.ts` の `rustPath` 引数を関数渡し可能に拡張 (`status/[code]` の動的解決用)
2. `app/utils/api.ts` の該当 3 関数を、`apiBase` 直叩きの `request()` ではなく same-origin の Nitro server route を叩く新設の `publicIngestRequest()` に変更
3. テストを新仕様 (same-origin path) に合わせて更新。live 統合テスト用ヘルパー (`api-test-env.ts`) にも `/api/devices/register/*` の URL 書き換えを追加 (Nuxt server が無い live テスト環境向け)

## 動作確認

- `npx nuxi typecheck` — 本変更に起因するエラー無し
- `npx vitest run` — 34 files / 1018 passed (mock モード)

## 実機確認のお願い

alc-app 側 (Worker) に `INTERNAL_SHARED_SECRET` / `AUTH_WORKER` service binding が実際に設定されていることを前提にしている (`createInternalIngestHandler` は未設定時 503 を返す)。デプロイ後、実際に QR / URL 経由の端末登録が 200 で通ることの確認をお願いします。

Refs ippoan/rust-alc-api#480

---
_Generated by [Claude Code](https://claude.ai/code/session_0127V338YCEACT9o7W9xL6Q9)_