### PR TITLE
fix(device-claim): App Links 未検証時にアプリを intent:// URI で起動するフォールバック追加 (Refs ippoan/rust-alc-api#480)

### DIFF
--- a/web/app/pages/device-claim.vue
+++ b/web/app/pages/device-claim.vue
@@ -22,6 +22,15 @@ const flowType = ref<DeviceFlowType | ''>('')
 const errorMessage = ref('')
 let pollingTimer: ReturnType<typeof setInterval> | null = null
 
+// Android App Links (autoVerify) はサイドロード配布 (Play 経由でない) だと自動検証が
+// 効かず、ブラウザ (Chrome) でこのページが開かれてしまうことがある。window.Android
+// bridge が無ければブラウザ経由と判断し、intent:// URI で AlcoholChecker アプリを
+// package 明示で確実に起動するフォールバックボタンを出す (autoVerify のドメイン検証に
+// 依存しない経路)。Chrome for Developers: https://developer.chrome.com/docs/android/intents
+const ANDROID_PACKAGE = 'com.example.alcoholchecker'
+const hasAndroidBridge = ref(true) // SSR/初期描画中はボタンを出さない (hydration mismatch 回避)
+const appIntentUrl = ref('')
+
 async function submit() {
   if (!token.value) {
     errorMessage.value = '登録トークンが指定されていません'
@@ -100,6 +109,7 @@ onMounted(async () => {
   }
 
   const android = (window as any).Android
+  hasAndroidBridge.value = !!android
   if (android?.getPhoneNumber) {
     try {
       const number = android.getPhoneNumber()
@@ -111,6 +121,12 @@ onMounted(async () => {
     window.addEventListener('phone-number', ((e: CustomEvent) => {
       if (e.detail && !phoneNumber.value) phoneNumber.value = e.detail
     }) as EventListener)
+  } else {
+    // ブラウザ経由 (App Links 未検証等) — アプリ起動用 intent:// URI を組み立てる
+    const url = new URL(window.location.href)
+    const rest = `${url.host}${url.pathname}${url.search}`
+    const fallback = encodeURIComponent(url.href)
+    appIntentUrl.value = `intent://${rest}#Intent;scheme=https;package=${ANDROID_PACKAGE};S.browser_fallback_url=${fallback};end`
   }
 })
 
@@ -122,6 +138,17 @@ onUnmounted(() => stopPolling())
     <div class="bg-white rounded-2xl shadow-lg p-8 w-full max-w-sm">
       <h1 class="text-lg font-bold text-gray-800 mb-2 text-center">端末登録</h1>
       <p class="text-xs text-gray-500 text-center mb-6">デバイス名を入力して登録してください。電話番号は任意です。</p>
+
+      <!-- App Links (autoVerify) が効かずブラウザで開かれた場合のフォールバック -->
+      <div v-if="!hasAndroidBridge && appIntentUrl" class="mb-4 p-3 bg-amber-50 border border-amber-200 rounded-lg text-center">
+        <p class="text-xs text-amber-700 mb-2">ブラウザで開かれています。電話番号の自動入力にはアプリでの表示が必要です。</p>
+        <a
+          :href="appIntentUrl"
+          class="inline-block px-4 py-2 bg-green-600 text-white rounded-lg text-sm font-medium hover:bg-green-700"
+        >
+          AlcoholChecker アプリで開く
+        </a>
+      </div>
 
       <!-- 入力フォーム -->
       <div v-if="status === 'form' || status === 'error'" class="space-y-4">


### PR DESCRIPTION
## 背景

AlcoholChecker 側 (ippoan/AlcoholChecker#7) で App Links の intent-filter に `alc-staging.ippoan.org` を追加し、Digital Asset Links (`.well-known/assetlinks.json`) も Google の検証 API で正しく認識されることを確認したが、実機で依然として「QR を読んでも Chrome が開いてしまいアプリが起動しない、電話番号も表示されない」現象が報告された。

## 原因

Android の App Links 自動検証 (`autoVerify="true"`) は、Google Play 経由でインストールされたアプリでないと確実に動作しないことがある（AlcoholChecker は GitHub Releases 配布のサイドロード APK）。ドメイン検証自体（Digital Asset Links）は正しくても、端末側の自動検証タイミング・設定次第でリンクがアプリに紐付かず、ブラウザ (Chrome) で開かれてしまう。ブラウザ経由だと `window.Android` bridge が存在しないため、電話番号自動取得 (`android.getPhoneNumber()`) も動作しない。

## 修正内容

`device-claim.vue` の `onMounted` で `window.Android` の有無をチェックし、無ければブラウザ経由と判定。`intent://` URI (package を明示指定、`S.browser_fallback_url` でアプリ未インストール時は自ページに留まる) で AlcoholChecker アプリの起動を試みる「アプリで開く」ボタンを表示する。この経路は autoVerify のドメイン検証結果に依存しないため、サイドロード配布でも確実にアプリを起動できる。

参考: [Android Intents with Chrome | Chrome for Developers](https://developer.chrome.com/docs/android/intents)

## 動作確認

- `npx nuxi typecheck` — 本変更に起因するエラー無し
- `npx vitest run` — 34 files / 1021 passed（`device-claim.vue` は `coverage_100.toml` 未登録）

Refs ippoan/rust-alc-api#480

---
_Generated by [Claude Code](https://claude.ai/code/session_0127V338YCEACT9o7W9xL6Q9)_