### PR TITLE
fix(config): NUXT_PUBLIC_SIGNALING_URL を staging/prod 両方に明示設定 (Refs ippoan/rust-alc-api#480)

### DIFF
--- a/web/wrangler.jsonc
+++ b/web/wrangler.jsonc
@@ -52,7 +52,11 @@
 				"NUXT_ALC_API_URL": "https://rust-alc-api-staging-566bls5vfq-an.a.run.app",
 				"NUXT_PUBLIC_STAGING_TENANT_ID": "11111111-1111-1111-1111-111111111111",
 				"NUXT_PUBLIC_GOOGLE_CLIENT_ID": "747065218280-ugkrbgaoik32f5mmi94sso4b0026j3cp.apps.googleusercontent.com",
-				"NUXT_PUBLIC_AUTH_WORKER_URL": "https://auth-staging.ippoan.org"
+				"NUXT_PUBLIC_AUTH_WORKER_URL": "https://auth-staging.ippoan.org",
+				// 未設定だと nuxt.config.ts のデフォルト (http://localhost:8787) にフォールバックし、
+				// 管理画面の一斉テスト/着信テストが ERR_CONNECTION_REFUSED になる。cf-alc-signaling は
+				// 単一環境運用なので prod と同じ URL (Refs ippoan/rust-alc-api#480)。
+				"NUXT_PUBLIC_SIGNALING_URL": "https://alc-signaling.m-tama-ramu.workers.dev"
 			},
 			// named env は top-level binding を継承しないので再宣言する。
 			// staging は auth-worker-staging を叩く。
@@ -76,7 +80,8 @@
 		// /api/proxy が叩く rust-alc-api backend (server-only, #434 step 2)。
 		"NUXT_ALC_API_URL": "https://alc-api.ippoan.org",
 		"NUXT_PUBLIC_GOOGLE_CLIENT_ID": "747065218280-ugkrbgaoik32f5mmi94sso4b0026j3cp.apps.googleusercontent.com",
-		"NUXT_PUBLIC_AUTH_WORKER_URL": "https://auth.ippoan.org"
+		"NUXT_PUBLIC_AUTH_WORKER_URL": "https://auth.ippoan.org",
+		"NUXT_PUBLIC_SIGNALING_URL": "https://alc-signaling.m-tama-ramu.workers.dev"
 	},
 	"routes": [
 		{


### PR DESCRIPTION
## 背景

管理画面のブラウザコンソールで `localhost:8787` への `ERR_CONNECTION_REFUSED` が発生し、「一斉テスト」「着信テスト」ボタンが反応しないことが判明した。

## 原因

`nuxt.config.ts` の `runtimeConfig.public.signalingUrl` はデフォルト値が `http://localhost:8787` (ローカル開発用) だが、`wrangler.jsonc` の `env.staging.vars` に `NUXT_PUBLIC_SIGNALING_URL` が設定されておらず、staging デプロイでもこのローカル開発用デフォルト値がそのまま使われていた。

## 修正内容

`env.staging.vars` と top-level (`prod`) `vars` の両方に `NUXT_PUBLIC_SIGNALING_URL` を明示設定。cf-alc-signaling は単一環境運用のため両者とも同じ URL (`https://alc-signaling.m-tama-ramu.workers.dev`) を使う。

## 動作確認

- `npx wrangler deploy --dry-run --env staging` で JSONC 構文が正しくパースされることを確認 (build 未実行によるエラーのみ、想定内)

Refs ippoan/rust-alc-api#480

---
_Generated by [Claude Code](https://claude.ai/code/session_0127V338YCEACT9o7W9xL6Q9)_