### PR TITLE
fix(devices): device-claim.vue 経由の登録で kiosk device credential が保存されない問題を修正 (Refs ippoan/rust-alc-api#480)

### DIFF
--- a/web/app/components/DeviceRegistration.vue
+++ b/web/app/components/DeviceRegistration.vue
@@ -2,7 +2,7 @@
 import QRCode from 'qrcode'
 import { createDeviceRegistrationRequest, checkDeviceRegistrationStatus } from '~/utils/api'
 
-const { isDeviceActivated, activateDevice, loginWithGoogleRedirect } = useAuth()
+const { isDeviceActivated, activateFromRegistration, loginWithGoogleRedirect } = useAuth()
 
 const registrationCode = ref('')
 const qrDataUrl = ref('')
@@ -38,7 +38,7 @@ function startPolling() {
       const res = await checkDeviceRegistrationStatus(registrationCode.value)
       if (res.status === 'approved' && res.tenant_id && res.device_id) {
         stopPolling()
-        activateDevice(res.tenant_id, res.device_id, res.settings_token)
+        activateFromRegistration(res)
         status.value = 'approved'
       } else if (res.status === 'expired') {
         stopPolling()

--- a/web/app/composables/useAuth.ts
+++ b/web/app/composables/useAuth.ts
@@ -221,6 +221,30 @@ export function useAuth() {
     }
   }
 
+  /**
+   * device 登録 API (claim / status polling) のレスポンスを丸ごと受けて activate する
+   * 漏斗関数。tenant/device/settings_token に加え、含まれていれば kiosk device
+   * credential (auth_device_id/device_secret) も同時に保存する。
+   *
+   * activateDevice() を呼び出し箇所ごとに個別に呼ぶと credential 保存を忘れやすい
+   * (実際に device-claim.vue で発生した、Refs rust-alc-api#480)。呼び出し箇所は
+   * 必ずこちらを使うこと。credential が無ければ (旧 backend / qr_permanent 未承認等)
+   * activate 自体は非破壊で続行する。
+   */
+  function activateFromRegistration(res: {
+    tenant_id?: string
+    device_id?: string
+    settings_token?: string
+    auth_device_id?: string
+    device_secret?: string
+  }) {
+    if (!res.tenant_id) return
+    activateDevice(res.tenant_id, res.device_id, res.settings_token)
+    if (res.auth_device_id && res.device_secret) {
+      useDeviceToken().storeKioskCredential(res.auth_device_id, res.device_secret)
+    }
+  }
+
   /** 端末のアクティベーションを解除 */
   function deactivateDevice() {
     deviceTenantId.value = null
@@ -301,6 +325,7 @@ export function useAuth() {
     refreshAccessToken,
     logout,
     activateDevice,
+    activateFromRegistration,
     deactivateDevice,
     applyStagingBypass,
   }

--- a/web/app/pages/device-claim.vue
+++ b/web/app/pages/device-claim.vue
@@ -4,7 +4,7 @@ import type { DeviceFlowType } from '~/types'
 
 const config = useRuntimeConfig()
 const route = useRoute()
-const { activateDevice, accessToken, deviceTenantId, refreshAccessToken } = useAuth()
+const { activateFromRegistration, accessToken, deviceTenantId, refreshAccessToken } = useAuth()
 
 // API 初期化 (device-claim は index.vue を経由しない場合がある)
 initApi(
@@ -51,8 +51,8 @@ async function submit() {
     flowType.value = res.flow_type
 
     if (res.flow_type === 'url' && res.device_id && res.tenant_id) {
-      // URLフロー: 即アクティベート
-      activateDevice(res.tenant_id, res.device_id, res.settings_token)
+      // URLフロー: 即アクティベート (kiosk device credential も含めて保存、Refs rust-alc-api#480)
+      activateFromRegistration(res)
       status.value = 'activated'
     } else if (res.flow_type === 'qr_permanent') {
       // QR永久: 承認待ち
@@ -75,7 +75,7 @@ function startPolling() {
       const res = await checkDeviceRegistrationStatus(token.value)
       if (res.status === 'approved' && res.tenant_id && res.device_id) {
         stopPolling()
-        activateDevice(res.tenant_id, res.device_id, res.settings_token)
+        activateFromRegistration(res)
         status.value = 'activated'
       } else if (res.status === 'rejected') {
         stopPolling()

--- a/web/app/types/index.ts
+++ b/web/app/types/index.ts
@@ -840,6 +840,9 @@ export interface RegistrationStatusResponse {
   device_name?: string
   /** 承認時に発行される device 保有 token (approved 時のみ、Refs rust-alc-api#388) */
   settings_token?: string
+  /** 承認時に発行される kiosk device credential (approved 時のみ、Refs rust-alc-api#480) */
+  auth_device_id?: string
+  device_secret?: string
 }
 
 export interface ClaimRegistrationRequest {
@@ -856,6 +859,9 @@ export interface ClaimRegistrationResponse {
   message?: string
   /** 即時登録フローで発行される device 保有 token (Refs rust-alc-api#388) */
   settings_token?: string
+  /** 即時登録フローで発行される kiosk device credential (Refs rust-alc-api#480) */
+  auth_device_id?: string
+  device_secret?: string
 }
 
 export interface CreateTokenResponse {

--- a/web/server/api/devices/register/status/[code].get.ts
+++ b/web/server/api/devices/register/status/[code].get.ts
@@ -1,5 +1,5 @@
 // QR一時登録のステータス確認 (認証なし public 経路、ポーリング用)。lockdown 対応で
 // auth-worker /alc-internal-proxy 経由に forward する (Refs ippoan/rust-alc-api#480)。
-export default createInternalIngestHandler(
-  (event) => `/api/devices/register/status/${getRouterParam(event, 'code')}`,
-)
+// approved かつ tenant_id が取れたら device credential も mint して merge する
+// (QR永久登録のポーリング承認フローでも kiosk credential が保存されるようにする)。
+export default createStatusWithPairingHandler()

--- a/web/server/utils/device-pairing.ts
+++ b/web/server/utils/device-pairing.ts
@@ -82,6 +82,38 @@ async function resolveSecret(binding: unknown): Promise<string | null> {
 }
 
 /**
+ * rust レスポンス (claim or status) に tenant_id があれば device credential を mint し、
+ * レスポンスへ { auth_device_id, device_secret } を merge して返す共通処理 (pure 相当、
+ * fetch は注入された authWorker 経由)。mint 失敗時は元レスポンスをそのまま返す
+ * (provisioning 失敗で claim/status 自体を壊さない、非破壊 fallback)。
+ */
+async function mintAndMergeCredential(
+  sharedSecret: string,
+  authWorker: { fetch: typeof fetch },
+  res: ClaimResponse,
+): Promise<ClaimResponse> {
+  const tenantId = res.tenant_id
+  if (!tenantId) return res
+  try {
+    const pair = buildPairInternalForward({
+      sharedSecret,
+      tenantId,
+      label: (res.device_id as string | undefined) || 'alc-device',
+    })
+    const pairRes = await authWorker.fetch(pair.url, pair.init)
+    if (pairRes.ok) {
+      const cred = (await pairRes.json()) as PairInternalResponse
+      if (cred.device_id && cred.device_secret) {
+        return { ...res, auth_device_id: cred.device_id, device_secret: cred.device_secret }
+      }
+    }
+  } catch {
+    // pairing 失敗は呼び出し元のレスポンスをそのまま返す。
+  }
+  return res
+}
+
+/**
  * claim を rust に forward → 成功かつ tenant_id が取れたら device credential を mint して
  * レスポンスに merge する Nitro server route handler。
  */
@@ -121,25 +153,57 @@ export function createClaimWithPairingHandler() {
 
     // ② 即承認 flow (tenant_id あり) のみ device credential を mint して merge。
     if (claimRes.ok && claim.success && claim.tenant_id) {
-      try {
-        const pair = buildPairInternalForward({
-          sharedSecret,
-          tenantId: claim.tenant_id,
-          label: (claim.device_id as string | undefined) || 'alc-device',
-        })
-        const pairRes = await authWorker.fetch(pair.url, pair.init)
-        if (pairRes.ok) {
-          const cred = (await pairRes.json()) as PairInternalResponse
-          if (cred.device_id && cred.device_secret) {
-            return { ...claim, auth_device_id: cred.device_id, device_secret: cred.device_secret }
-          }
-        }
-        // pairing 失敗は claim 自体を壊さない (端末は従来 X-Device-Token 経路で動作継続)。
-      } catch {
-        // 同上: provisioning 失敗時も claim レスポンスは返す。
-      }
+      return mintAndMergeCredential(sharedSecret, authWorker, claim)
     }
 
     return claim
+  })
+}
+
+/**
+ * QR永久登録の承認状態確認 (ポーリング用) を rust に forward → status が approved かつ
+ * tenant_id が取れたら device credential を mint して merge する Nitro server route
+ * handler (Refs ippoan/rust-alc-api#480)。
+ *
+ * claim.post.ts と同じ pairing ロジックを共有する。フロントは approved を検知した時点で
+ * polling を止めるため通常は 1 回しか mint されないが、理論上は approved 応答が複数回
+ * 届くと credential も複数回 mint される (dormant credential が残るだけで実害は小さい)。
+ * 冪等化は将来課題。
+ */
+export function createStatusWithPairingHandler() {
+  return defineEventHandler(async (event): Promise<unknown> => {
+    const env = cfEnv(event)
+    const sharedSecret = await resolveSecret(env.INTERNAL_SHARED_SECRET)
+    if (!sharedSecret) {
+      throw createError({ statusCode: 503, statusMessage: 'INTERNAL_SHARED_SECRET binding が未設定です' })
+    }
+    const authWorker = env.AUTH_WORKER as { fetch: typeof fetch } | undefined
+    if (!authWorker) {
+      throw createError({ statusCode: 503, statusMessage: 'AUTH_WORKER service binding が未設定です' })
+    }
+
+    const code = getRouterParam(event, 'code')
+    const { url, init } = buildInternalProxyForward({
+      sharedSecret,
+      rustPath: `/api/devices/register/status/${code}`,
+      method: 'GET',
+    })
+    const statusRes = await authWorker.fetch(url, init)
+    const statusText = await statusRes.text()
+    let status: ClaimResponse
+    try {
+      status = JSON.parse(statusText) as ClaimResponse
+    } catch {
+      setResponseStatus(event, statusRes.status)
+      return statusText
+    }
+
+    setResponseStatus(event, statusRes.status)
+
+    if (statusRes.ok && status.status === 'approved' && status.tenant_id) {
+      return mintAndMergeCredential(sharedSecret, authWorker, status)
+    }
+
+    return status
   })
 }

--- a/web/tests/composables/useAuth.test.ts
+++ b/web/tests/composables/useAuth.test.ts
@@ -159,6 +159,43 @@ describe('useAuth', () => {
       expect(mockSetDeviceId).toHaveBeenCalledWith('')
       delete (window as any).Android
     })
+
+    it('activateFromRegistration should activate device and store kiosk credential when present (Refs rust-alc-api#480)', async () => {
+      const { useAuth } = await import('~/composables/useAuth')
+      const { activateFromRegistration, deviceTenantId, deviceId } = useAuth()
+
+      activateFromRegistration({
+        tenant_id: 'tenant-reg',
+        device_id: 'dev-reg',
+        settings_token: 'token-reg',
+        auth_device_id: 'auth-dev-reg',
+        device_secret: 'secret-reg',
+      })
+
+      expect(deviceTenantId.value).toBe('tenant-reg')
+      expect(deviceId.value).toBe('dev-reg')
+      const { useDeviceToken } = await import('~/composables/useDeviceToken')
+      const { kioskDeviceId } = useDeviceToken()
+      expect(kioskDeviceId.value).toBe('auth-dev-reg')
+    })
+
+    it('activateFromRegistration should activate device without credential when absent', async () => {
+      const { useAuth } = await import('~/composables/useAuth')
+      const { activateFromRegistration, deviceTenantId } = useAuth()
+
+      activateFromRegistration({ tenant_id: 'tenant-nocred' })
+
+      expect(deviceTenantId.value).toBe('tenant-nocred')
+    })
+
+    it('activateFromRegistration should be a no-op when tenant_id is missing', async () => {
+      const { useAuth } = await import('~/composables/useAuth')
+      const { activateFromRegistration, deviceTenantId } = useAuth()
+
+      activateFromRegistration({})
+
+      expect(deviceTenantId.value).toBeNull()
+    })
   })
 
   describe('session refresh (cookie)', () => {


### PR DESCRIPTION
## 概要

Android native の Device Owner 自動登録フローには kiosk device credential (`auth_device_id`/`device_secret`) の保存を実装済みだったが、通常の Web (device-claim.vue / DeviceRegistration.vue) 経由の登録フローには同じ配線が漏れていた。`useAuth.ts` の `activateDevice()` が credential を一切保存しない設計だったため。

呼び出し箇所ごとに個別に `useDeviceToken()` を呼ぶ設計は同じバグを再生産しやすいため、`activateDevice()` をラップする単一の漏斗関数 `activateFromRegistration()` を新設し、`device-claim.vue` / `DeviceRegistration.vue` の全呼び出し箇所をこちらに統一した。

QR永久登録の承認確認ポーリング (`GET /api/devices/register/status/:code`) でも claim と同じ credential mint が必要なため、`device-pairing.ts` の mint ロジックを `mintAndMergeCredential()` として共通化し、新規 `createStatusWithPairingHandler()` を追加して status route に配線した。

Refs ippoan/rust-alc-api#480

## 変更内容

- `app/composables/useAuth.ts`: `activateFromRegistration(res)` 漏斗関数を追加。`tenant_id` が無ければ no-op
- `app/pages/device-claim.vue` / `app/components/DeviceRegistration.vue`: `activateDevice` → `activateFromRegistration` に置換
- `app/types/index.ts`: `RegistrationStatusResponse` / `ClaimRegistrationResponse` に `auth_device_id`/`device_secret` を追加
- `server/utils/device-pairing.ts`: `mintAndMergeCredential()` 共通関数を抽出、`createStatusWithPairingHandler()` を新設
- `server/api/devices/register/status/[code].get.ts`: 新設ハンドラに差し替え

## Test plan

- [x] `npx nuxi typecheck` (kiosk credential 関連の型エラーは解消。fc1200-wasm / vue モジュール解決エラーは既存の環境依存問題で本 PR とは無関係)
- [x] `npx vitest run` — 全 1021 件 pass
- [x] `node scripts/check_coverage_100.mjs` — 全 29 登録ファイル 100% (`useAuth.ts` の新規分岐にテスト追加済み)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0127V338YCEACT9o7W9xL6Q9)_