### PR TITLE
feat(devices): デバイス設定タブに端末登録リセット + signaling worker のログ強化 (Refs ippoan/rust-alc-api#480)

### DIFF
--- a/cf-alc-signaling/src/room-registry.ts
+++ b/cf-alc-signaling/src/room-registry.ts
@@ -260,6 +260,11 @@ export class RoomRegistry extends DurableObject<Env> {
       // Find watcher WebSocket tagged with this device_id
       const allSockets = this.ctx.getWebSockets(`device:${deviceId}`);
       if (allSockets.length === 0) {
+        // 接続中の device_id を一覧して mismatch を診断可能にする (app が別 id で接続 or 全く未接続かを判別)
+        const connected = this.ctx.getWebSockets()
+          .map(s => (this.ctx.getTags(s).find(t => t.startsWith('device:')) || 'device:(none)').slice(7))
+          .filter((v, i, a) => a.indexOf(v) === i);
+        console.log(`[test-call] device=${deviceId} NOT connected. connected device_ids=[${connected.join(', ')}] total_ws=${this.ctx.getWebSockets().length}`);
         return new Response(JSON.stringify({ error: 'device_not_connected' }), {
           status: 404,
           headers: { 'Content-Type': 'application/json' },

--- a/cf-alc-signaling/wrangler.toml
+++ b/cf-alc-signaling/wrangler.toml
@@ -2,6 +2,11 @@ name = "alc-signaling"
 main = "src/index.ts"
 compatibility_date = "2025-01-01"
 
+# Workers Logs を有効化 (console.log を永続化し dashboard / cf_logging MCP からクエリ可能にする)
+[observability]
+enabled = true
+head_sampling_rate = 1
+
 [vars]
 BACKEND_API_URL = "https://rust-alc-api-566bls5vfq-an.a.run.app"
 

--- a/web/app/components/DeviceSettings.vue
+++ b/web/app/components/DeviceSettings.vue
@@ -9,6 +9,30 @@ const BLE_GW_DEVICES = [
 
 const { ports, isSupported, refreshPorts, forgetPort } = useSerialDeviceManager()
 const { isAndroidApp } = useFingerprint()
+const { deactivateDevice, deviceTenantId, deviceId: activatedDeviceId } = useAuth()
+const { clearKioskCredential } = useDeviceToken()
+
+// 端末登録リセット (WebView localStorage + Android native SharedPreferences 両方をクリア)
+const resetting = ref(false)
+
+function resetDeviceRegistration() {
+  if (resetting.value) return
+  if (!window.confirm('この端末の登録を解除します。着信・FCM・送信の設定がすべて消え、再登録が必要になります。よろしいですか？')) return
+  resetting.value = true
+  try {
+    // WebView 側 (localStorage): tenant / device_id / settings_token / kiosk credential
+    deactivateDevice()
+    clearKioskCredential()
+    // Android native 側 (SharedPreferences): device_id / settings_token / fcm 登録マーク /
+    // kiosk credential を消し RoomWatcher を停止する (stale device_id 起因の WS未接続・FCM未 を解消)。
+    const android = (window as unknown as { Android?: { resetDeviceRegistration?: () => void } }).Android
+    android?.resetDeviceRegistration?.()
+    // 登録画面へ戻す
+    window.location.href = '/'
+  } finally {
+    resetting.value = false
+  }
+}
 
 // FC-1200 composable
 const fc1200 = useFc1200Serial()
@@ -197,6 +221,34 @@ async function syncFc1200Date() {
 
 <template>
   <div class="w-full max-w-lg mx-auto px-4 py-4 space-y-6">
+    <!-- 端末登録リセット -->
+    <div class="bg-white rounded-xl shadow-sm overflow-hidden">
+      <div class="px-4 py-3 bg-gray-50 border-b">
+        <h3 class="text-sm font-medium text-gray-800">端末登録</h3>
+        <p class="text-xs text-gray-500">この端末に保存された登録情報 (テナント・device ID・着信/FCM 設定)</p>
+      </div>
+      <div class="p-4 space-y-3">
+        <div class="text-xs text-gray-600 space-y-1">
+          <p>状態:
+            <span :class="deviceTenantId ? 'text-green-600 font-medium' : 'text-gray-400'">
+              {{ deviceTenantId ? '登録済み' : '未登録' }}
+            </span>
+          </p>
+          <p v-if="activatedDeviceId" class="font-mono text-gray-400 break-all">device: {{ activatedDeviceId }}</p>
+        </div>
+        <button
+          class="px-3 py-1.5 text-xs text-red-600 border border-red-300 rounded-lg hover:bg-red-50 transition-colors disabled:opacity-50"
+          :disabled="resetting"
+          @click="resetDeviceRegistration"
+        >
+          {{ resetting ? 'リセット中...' : '端末登録をリセット' }}
+        </button>
+        <p class="text-[10px] text-gray-400">
+          着信が来ない / FCM が届かない / 環境を切り替えた後に使ってください。リセット後は再登録が必要です。
+        </p>
+      </div>
+    </div>
+
     <!-- Android WebView: WebSocket ブリッジ経由のテスト -->
     <template v-if="isAndroidApp">
       <!-- FC-1200 セクション (Android) -->


### PR DESCRIPTION
## 概要

staging で「端末は登録済みに見えるのに WS未接続・FCM未・着信テスト失敗」を調査した結果、根本原因は **ストレージが2系統に分裂**していることと判明:

| ストレージ | スコープ | 保持するもの |
|---|---|---|
| localStorage (WebView) | オリジンごとに別 (prod/staging 別) | `alc_device_tenant_id` → 「登録済み」表示判定 |
| SharedPreferences (native) | 全環境で共有 (1個) | `device_id` 等 → RoomWatcher(WS)・FCM が使う |

prod で登録した端末を staging に切り替えても native の `device_id` が残り、RoomWatcher が旧 id で接続 → staging のデバイス行(別id)は WS未接続 のまま、FCM も旧 id で staging に投げて FCM未 になる。`/watchers` を叩くと `count:0`(= 実際にはどの端末も signaling に接続していない)で裏付けられた。

## 変更内容

### web (`DeviceSettings.vue`)
- 「デバイス設定」タブに **端末登録リセット** セクションを追加。登録状態を表示し、「端末登録をリセット」ボタンで:
  - WebView 側 localStorage: `deactivateDevice()` + `clearKioskCredential()`
  - Android native 側 SharedPreferences: 新規ブリッジ `Android.resetDeviceRegistration()`(AlcoholChecker 側 PR で実装)を呼び、`device_id` / `settings_token` / FCM 登録マーク / kiosk credential を消して RoomWatcher を停止
  - `/` へ戻して再登録画面へ

### cf-alc-signaling
- Workers Logs (`[observability]`) を有効化し、`console.log` を dashboard / cf_logging MCP からクエリ可能にする
- `/test-call/:deviceId` が `device_not_connected` (404) の時、**接続中の device_id 一覧**をログ出力し「app が別 id で接続 / 全く未接続」を判別可能にする

Refs ippoan/rust-alc-api#480

## Test plan

- [x] `npx vitest run` — 全 1024 件 pass
- [x] `npx nuxi typecheck` — 新規型エラーなし (既存の fc1200-wasm/vue 解決エラーは本 PR 無関係)
- [x] `wrangler deploy --dry-run` (cf-alc-signaling) — ビルド成功
- [ ] cf-alc-signaling は CI 対象外のため merge 後に手動 `wrangler deploy` が必要

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0127V338YCEACT9o7W9xL6Q9)_