### PR TITLE
ci(signaling): cf-alc-signaling の deploy CI を追加 (Refs ippoan/rust-alc-api#480)

### DIFF
--- a/.github/workflows/signaling-deploy.yml
+++ b/.github/workflows/signaling-deploy.yml
@@ -1,0 +1,51 @@
+name: Signaling Deploy
+
+# cf-alc-signaling (WebRTC signaling worker) の deploy CI。
+#
+# この worker は Durable Object (SignalingRoom / RoomRegistry) を持つため、
+# frontend-ci.yml は使えない — frontend-ci は release script の `wrangler deploy` を
+# `wrangler versions upload` (no-traffic) へ global 置換するが、DO worker はそれと
+# 相性が悪い (durable-object-worker skill 参照)。よって real `wrangler deploy` を
+# 行う bespoke workflow にする。単一環境運用 (staging/prod 分割なし)。
+#
+# migration (v1 SignalingRoom / v2 RoomRegistry) は既に適用済みなので、新規
+# migration を追加しない限り通常の `wrangler deploy` で反映される。
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'cf-alc-signaling/**'
+      - '.github/workflows/signaling-deploy.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'cf-alc-signaling/**'
+      - '.github/workflows/signaling-deploy.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: cf-alc-signaling
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22' # wrangler v4 は Node 22+ 必須
+          cache: 'npm'
+          cache-dependency-path: cf-alc-signaling/package-lock.json
+      - run: npm ci
+      - name: Typecheck
+        run: npx tsc --noEmit
+      # deploy は PR では skip (typecheck による gate のみ)。push / dispatch で反映。
+      - name: Deploy
+        if: github.event_name != 'pull_request'
+        run: npx wrangler deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
## 概要

cf-alc-signaling (WebRTC signaling worker) は今まで手動 `wrangler deploy` 運用だったため、#69 で入れた observability 有効化 + test-call 404 ログのようなコード変更が自動反映されなかった。deploy を CI 化する。

`cf-alc-signaling` は Durable Object (`SignalingRoom` / `RoomRegistry`) を持つため **frontend-ci.yml は使えない** — frontend-ci は release script の `wrangler deploy` を `wrangler versions upload` (no-traffic) へ global 置換し、DO worker と相性が悪い(`durable-object-worker` skill 参照)。よって real `wrangler deploy` を行う bespoke workflow を追加する。

- 単一環境運用(staging/prod 分割なし、`alc-signaling` のみ)
- migration (v1 SignalingRoom / v2 RoomRegistry) は適用済みなので、新規 migration を追加しない限り通常の `wrangler deploy` で反映される
- **push to main** で反映(paths: `cf-alc-signaling/**` or workflow 自身)、**PR は typecheck gate のみ**(deploy は `github.event_name != 'pull_request'` で skip)
- Node 22(wrangler v4 必須)、`secrets.CLOUDFLARE_API_TOKEN` で認証(Release Wave と同 org secret)

Refs ippoan/rust-alc-api#480

## Test plan

- [x] `wrangler deploy --dry-run` (cf-alc-signaling) — ビルド成功
- [ ] PR で typecheck job が gate として走る
- [ ] merge 後 push で `wrangler deploy` が走り、#69 のログ強化が本番反映される

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0127V338YCEACT9o7W9xL6Q9)_