### PR TITLE
fix(signaling): wrangler.toml に account_id を追加し deploy の認証エラーを解消 (Refs ippoan/rust-alc-api#480)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,10 @@ on:
     # を catch-all で含める。個別 file 列挙だと新規 workflow を追加する PR
     # (例: ci-shape-report.yml) で required check が来ず "2 expected checks" の
     # デッドロックになる (上記コメント参照)。
-    paths: ['web/**', '.claude/**', '.github/workflows/**']
+    # cf-alc-signaling/** も含める: signaling-only の PR (例: wrangler.toml の
+    # account_id 追加) でも required check (ci / Vitest+Coverage, ci / PR Limit Check)
+    # を発火させないと "2 expected checks" で永遠に blocked になるため (上記デッドロック)。
+    paths: ['web/**', '.claude/**', '.github/workflows/**', 'cf-alc-signaling/**']
 
 permissions:
   contents: write

--- a/cf-alc-signaling/wrangler.toml
+++ b/cf-alc-signaling/wrangler.toml
@@ -1,6 +1,10 @@
 name = "alc-signaling"
 main = "src/index.ts"
 compatibility_date = "2025-01-01"
+# account_id を明示 (web/wrangler.jsonc と同値)。未指定だと wrangler が /memberships を
+# 列挙し、account-scoped な CLOUDFLARE_API_TOKEN では Authentication error [code: 10000] で
+# deploy が落ちる (CI 実測)。
+account_id = "24b45709d060d957340180e995f0d373"
 
 # Workers Logs を有効化 (console.log を永続化し dashboard / cf_logging MCP からクエリ可能にする)
 [observability]


### PR DESCRIPTION
## 概要

#70 で追加した signaling-deploy workflow が main への merge 後の初回 deploy で失敗した([該当 run](https://github.com/ippoan/alc-app/actions/runs/28577064252)):

```
✘ A request to the Cloudflare API (/memberships) failed.
  Authentication error [code: 10000]
```

`cf-alc-signaling/wrangler.toml` に `account_id` が無かったため、wrangler が起動時に `/memberships` を列挙しに行き、account-scoped な `CLOUDFLARE_API_TOKEN` では権限不足で落ちていた(token 自体は account を解決できているが membership 列挙で 10000)。

`web/wrangler.jsonc` は元々 `account_id: 24b45709d060d957340180e995f0d373` を持っており frontend-ci deploy が通っていた。cf-alc-signaling にも同値を明示して `/memberships` 列挙をスキップさせる。account ID は非秘密値(複数の CLAUDE.md に平文で記載済み)。

Refs ippoan/rust-alc-api#480

## Test plan

- [ ] merge 後の main push で signaling-deploy workflow が `wrangler deploy` を成功させる
- [ ] deploy 後 `/watchers` エンドポイントが引き続き応答し、#69 の observability + test-call 404 ログが有効になる

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0127V338YCEACT9o7W9xL6Q9)_