### PR TITLE
fix(devices): 端末登録リセット後は staging auth バイパスを1回スキップ (Refs ippoan/rust-alc-api#480)

### DIFF
--- a/web/app/components/DeviceSettings.vue
+++ b/web/app/components/DeviceSettings.vue
@@ -79,6 +79,10 @@ function resetDeviceRegistration() {
     // kiosk credential を消し RoomWatcher を停止する (stale device_id 起因の WS未接続・FCM未 を解消)。
     const android = (window as unknown as { Android?: { resetDeviceRegistration?: () => void } }).Android
     android?.resetDeviceRegistration?.()
+    // staging の auth バイパス (NUXT_PUBLIC_STAGING_TENANT_ID) はリロード時に tenant を
+    // 自動再アクティベートするため、リセット直後は 1 回スキップして「未登録」を出し、
+    // 実登録 (device_id を入れる) の導線を通す。
+    sessionStorage.setItem('alc_skip_staging_bypass', '1')
     // 登録画面へ戻す
     window.location.href = '/'
   } finally {

--- a/web/app/composables/useAuth.ts
+++ b/web/app/composables/useAuth.ts
@@ -79,8 +79,15 @@ export function useAuth() {
     isLoading.value = false
   }
 
-  /** staging 環境で NUXT_PUBLIC_STAGING_TENANT_ID が設定されていれば自動 activateDevice */
+  /** staging 環境で NUXT_PUBLIC_STAGING_TENANT_ID が設定されていれば自動 activateDevice。
+   *  ただし端末登録リセット直後 (sessionStorage フラグ) は 1 回だけスキップし、実登録
+   *  (URL/QR claim で device_id を入れる) の導線を通す。バイパスは tenant のみで device_id
+   *  を持たないため、これが残ると WS/FCM が繋がらないまま「登録済み」に見えてしまう。 */
   function applyStagingBypass(stagingTenantId: string) {
+    if (isClient && sessionStorage.getItem('alc_skip_staging_bypass')) {
+      sessionStorage.removeItem('alc_skip_staging_bypass')
+      return
+    }
     if (stagingTenantId && !isAuthenticated.value && !isDeviceActivated.value) {
       activateDevice(stagingTenantId)
     }

--- a/web/tests/composables/useAuth.test.ts
+++ b/web/tests/composables/useAuth.test.ts
@@ -1151,5 +1151,22 @@ describe('useAuth', () => {
       // 既にアクティベート済みなので変更されない
       expect(auth.deviceTenantId.value).toBe('existing-tenant')
     })
+
+    it('should skip bypass once when alc_skip_staging_bypass flag is set (post-reset)', async () => {
+      sessionStorage.setItem('alc_skip_staging_bypass', '1')
+      const { useAuth } = await import('~/composables/useAuth')
+      const auth = useAuth()
+
+      // フラグが立っている間はバイパスをスキップ (未登録のまま)
+      auth.applyStagingBypass('staging-tenant-123')
+      expect(auth.isDeviceActivated.value).toBe(false)
+      // フラグは 1 回で消費される
+      expect(sessionStorage.getItem('alc_skip_staging_bypass')).toBeNull()
+
+      // 次回はバイパスが効く
+      auth.applyStagingBypass('staging-tenant-123')
+      expect(auth.isDeviceActivated.value).toBe(true)
+      expect(auth.deviceTenantId.value).toBe('staging-tenant-123')
+    })
   })
 })


### PR DESCRIPTION
## 概要

「端末登録をリセットしても登録済みに戻る(リセットされない)」問題を修正。

原因: staging は `NUXT_PUBLIC_STAGING_TENANT_ID` で auth バイパスが有効で、`useAuth.applyStagingBypass` がリロード時に tenant を自動再アクティベートする。リセットで localStorage/native を消しても、`window.location.href='/'` のリロード直後にバイパスが「登録済み」を復活させていた。

さらに重要: このバイパスは **tenant のみで device_id を持たない**。RoomWatcher(WS)も FCM も device_id が必須なので、バイパスだけの「登録済み」では **WS/FCM は永久に繋がらない**。実 device_id は URL/QR の実登録(`setDeviceId`)でしか入らない。

## 変更内容

- リセット時に `sessionStorage['alc_skip_staging_bypass']='1'` を立てる(`DeviceSettings.vue`)
- `applyStagingBypass` はこのフラグがあれば 1 回だけスキップし消費する(`useAuth.ts`)
- → リセット後は「未登録」が表示され、URL/QR の実登録で device_id を入れる導線が通る
- 実登録で device_id が入れば `isDeviceActivated` が true になり以降バイパスは自然にスキップ

## Test plan

- [x] `npx vitest run` — 全 1025 件 pass(skip フラグの分岐テスト追加)
- [x] `node scripts/check_coverage_100.mjs` — useAuth.ts 含む全 29 ファイル 100%
- [x] `npx nuxi typecheck` — 新規型エラーなし
- [ ] 実機(staging): リセット2タップ → 「未登録」表示 → URL/QR で実登録 → device_id が入り WS 接続

Refs ippoan/rust-alc-api#480

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0127V338YCEACT9o7W9xL6Q9)_