### PR TITLE
feat(devices): デバイス設定タブにアプリ(APK)バージョンを表示 (Refs ippoan/rust-alc-api#480)

### DIFF
--- a/web/app/components/DeviceSettings.vue
+++ b/web/app/components/DeviceSettings.vue
@@ -26,10 +26,12 @@ type AndroidDiag = {
   isCallConnected?: () => boolean
   isCallEnabled?: () => boolean
   getFcmStatus?: () => string
+  getAppVersion?: () => string
 }
 const wsConnected = ref<boolean | null>(null)
 const fcmRegistered = ref<boolean | null>(null)
 const fcmTokenPresent = ref<boolean | null>(null)
+const appVersion = ref<string | null>(null)
 let diagTimer: ReturnType<typeof setInterval> | null = null
 
 function refreshDeviceDiag() {
@@ -42,6 +44,12 @@ function refreshDeviceDiag() {
       const s = JSON.parse(raw) as { token_present?: boolean, registered?: boolean }
       fcmTokenPresent.value = s.token_present ?? null
       fcmRegistered.value = s.registered ?? null
+    }
+    // アプリ (APK) のバージョン。旧 APK は getAppVersion 未実装なので null のまま。
+    const ver = android.getAppVersion?.()
+    if (ver) {
+      const v = JSON.parse(ver) as { versionName?: string, versionCode?: number }
+      appVersion.value = v.versionName ? `${v.versionName} (${v.versionCode ?? '?'})` : null
     }
   } catch { /* ブリッジ未実装の旧 APK 等は無視 */ }
 }
@@ -291,6 +299,9 @@ async function syncFc1200Date() {
             </span>
           </p>
           <p v-if="activatedDeviceId" class="font-mono text-gray-400 break-all">device: {{ activatedDeviceId }}</p>
+          <p v-if="isAndroidApp">アプリ:
+            <span class="font-medium text-gray-700">{{ appVersion ?? '取得中...' }}</span>
+          </p>
         </div>
 
         <!-- WS (着信) / FCM 状態 (Android アプリのみ、診断用) -->


### PR DESCRIPTION
## 概要

端末が想定の APK バージョンか(例: 1.4.24 の FCM 修正が入っているか)を端末単体で確認できるよう、デバイス設定タブにアプリバージョンを表示する。

既存の Android ブリッジ `getAppVersion()`(`{versionName, versionCode}` を返す、実装済み)を診断ポーリングで取得し、端末登録セクションに「**アプリ: 1.4.24 (55)**」形式で表示。旧 APK(`getAppVersion` 未実装)は「取得中...」のまま。Android 側の変更は不要。

## Test plan

- [x] `npx nuxi typecheck` — 新規型エラーなし
- [x] `npx vitest run` — 全 1025 件 pass
- [ ] 実機のデバイス設定タブに APK バージョンが表示される

Refs ippoan/rust-alc-api#480

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0127V338YCEACT9o7W9xL6Q9)_