### PR TITLE
feat(devices): デバイス設定タブに「更新」ボタンを追加 (Refs ippoan/rust-alc-api#480)

### DIFF
--- a/web/app/components/DeviceSettings.vue
+++ b/web/app/components/DeviceSettings.vue
@@ -27,6 +27,21 @@ type AndroidDiag = {
   isCallEnabled?: () => boolean
   getFcmStatus?: () => string
   getAppVersion?: () => string
+  checkForUpdate?: () => void
+}
+
+// アプリ更新 (releases/latest を DL・インストール、Android ブリッジ checkForUpdate)。
+const updating = ref(false)
+function checkForUpdate() {
+  const android = (window as unknown as { Android?: AndroidDiag }).Android
+  if (!android?.checkForUpdate) return
+  updating.value = true
+  try {
+    android.checkForUpdate()
+  } finally {
+    // ダウンロード〜インストールはネイティブ側で進むので、少し待ってボタンを戻す。
+    setTimeout(() => { updating.value = false }, 5000)
+  }
 }
 const wsConnected = ref<boolean | null>(null)
 const fcmRegistered = ref<boolean | null>(null)
@@ -299,8 +314,15 @@ async function syncFc1200Date() {
             </span>
           </p>
           <p v-if="activatedDeviceId" class="font-mono text-gray-400 break-all">device: {{ activatedDeviceId }}</p>
-          <p v-if="isAndroidApp">アプリ:
-            <span class="font-medium text-gray-700">{{ appVersion ?? '取得中...' }}</span>
+          <p v-if="isAndroidApp" class="flex items-center gap-2">
+            <span>アプリ: <span class="font-medium text-gray-700">{{ appVersion ?? '取得中...' }}</span></span>
+            <button
+              class="px-2 py-0.5 text-[11px] rounded bg-blue-50 text-blue-600 hover:bg-blue-100 disabled:opacity-50"
+              :disabled="updating"
+              @click="checkForUpdate"
+            >
+              {{ updating ? '更新中...' : '更新' }}
+            </button>
           </p>
         </div>
 


### PR DESCRIPTION
## 概要

アプリバージョン表示の隣に「更新」ボタンを追加。Android ブリッジ `checkForUpdate()`(AlcoholChecker #11 で追加)を呼び、`releases/latest` の APK を DL・インストールする。端末単体で最新版へ更新できる。旧 APK(`checkForUpdate` 未実装)ではボタンは no-op。

## Test plan

- [x] `npx nuxi typecheck` — 新規型エラーなし
- [x] `npx vitest run` — 全 1025 件 pass
- [ ] 実機(APK 1.4.25+): 「更新」ボタン → 最新版 DL・インストール

Refs ippoan/rust-alc-api#480

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0127V338YCEACT9o7W9xL6Q9)_