### PR TITLE
chore(devices): 更新ボタンに title 追加 + staging 強制再デプロイ (Refs ippoan/rust-alc-api#480)

### DIFF
--- a/web/app/components/DeviceSettings.vue
+++ b/web/app/components/DeviceSettings.vue
@@ -319,6 +319,7 @@ async function syncFc1200Date() {
             <button
               class="px-2 py-0.5 text-[11px] rounded bg-blue-50 text-blue-600 hover:bg-blue-100 disabled:opacity-50"
               :disabled="updating"
+              title="最新版 (releases/latest) を取得してインストールします"
               @click="checkForUpdate"
             >
               {{ updating ? '更新中...' : '更新' }}


### PR DESCRIPTION
## 概要

直近の連続マージ(#74〜#77)で **auto-merge が deploy-staging 完了前に merge → head ブランチ削除 → staging cutover が cancel** され続け、staging worker が古い build(`ccf3dd5e` = #73 相当)に固着していた(`auto-merge-deploy-race` skill の症状と一致。worker の appVersion が 5 回マージしても不変、cache-bust しても同じ)。

この PR は **draft で出す**ことで auto-merge を効かせず、deploy-staging を最後まで完走させて staging を最新 main(#75 バイパススキップ / #76 バージョン表示 / #77 更新ボタン込み)にそろえる。diff は更新ボタンへの `title` 追加のみ。

deploy 完走 + staging 実測で最新反映を確認してから ready 化 → merge する。

Refs ippoan/rust-alc-api#480

## Test plan

- [x] `npx vitest run` — pass(#77 で確認済み、diff は title 属性のみ)
- [ ] draft のまま deploy-staging 完走 → `curl https://alc-staging.ippoan.org/` の appVersion が最新コミットに変わる
- [ ] staging でデバイス設定に「アプリ: 1.4.x」+ 更新ボタン、リセット後「未登録」(バイパススキップ #75)が反映

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0127V338YCEACT9o7W9xL6Q9)_