### PR TITLE
feat(devices): 端末診断ログを signaling worker に送信 (/device-log + ボタン) (Refs ippoan/rust-alc-api#480)

### DIFF
--- a/cf-alc-signaling/src/index.ts
+++ b/cf-alc-signaling/src/index.ts
@@ -17,6 +17,41 @@ export default {
       return new Response('ok');
     }
 
+    // POST /device-log → 端末診断ログを observability に流す (cf_logging で読める)。
+    // 認証なし・値は log のみ。RoomWatcher の接続挙動や fileLog を端末から送って
+    // リモートで WS 未接続の原因を切り分けるための経路 (Refs ippoan/rust-alc-api#480)。
+    if (request.method === 'POST' && url.pathname === '/device-log') {
+      let body: { device_id?: string; tag?: string; message?: string; lines?: string[] } = {};
+      try {
+        body = await request.json();
+      } catch { /* ignore parse error */ }
+      const dev = (body.device_id || '(none)').slice(0, 64);
+      const tag = (body.tag || 'device').slice(0, 32);
+      const msgs = body.lines && Array.isArray(body.lines)
+        ? body.lines
+        : [body.message ?? ''];
+      // 1 行ずつ console.log (observability の 1 event = 1 行、長すぎる行は切る)。
+      for (const m of msgs.slice(0, 200)) {
+        console.log(`[device-log] dev=${dev} tag=${tag} ${String(m).slice(0, 2000)}`);
+      }
+      return new Response(null, {
+        status: 204,
+        headers: { 'Access-Control-Allow-Origin': '*' },
+      });
+    }
+
+    // OPTIONS preflight (device-log を fetch で叩く webview 向け CORS)
+    if (request.method === 'OPTIONS' && url.pathname === '/device-log') {
+      return new Response(null, {
+        status: 204,
+        headers: {
+          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Methods': 'POST, OPTIONS',
+          'Access-Control-Allow-Headers': 'Content-Type',
+        },
+      });
+    }
+
     // GET /active-rooms → list rooms with device connected
     if (request.method === 'GET' && url.pathname === '/active-rooms') {
       const id = env.ROOM_REGISTRY.idFromName('registry');

--- a/web/app/components/DeviceSettings.vue
+++ b/web/app/components/DeviceSettings.vue
@@ -28,6 +28,28 @@ type AndroidDiag = {
   getFcmStatus?: () => string
   getAppVersion?: () => string
   checkForUpdate?: () => void
+  uploadDeviceLog?: () => void
+}
+
+// 端末ログを signaling worker (/device-log) に送信 (observability で読める、WS 診断用)。
+const uploadingLog = ref(false)
+const logUploadMsg = ref('')
+function uploadDeviceLog() {
+  const android = (window as unknown as { Android?: AndroidDiag }).Android
+  if (!android?.uploadDeviceLog) {
+    logUploadMsg.value = 'この APK は未対応 (更新してください)'
+    return
+  }
+  uploadingLog.value = true
+  logUploadMsg.value = ''
+  try {
+    android.uploadDeviceLog()
+    logUploadMsg.value = 'ログを送信しました'
+  } catch {
+    logUploadMsg.value = '送信に失敗しました'
+  } finally {
+    setTimeout(() => { uploadingLog.value = false }, 3000)
+  }
 }
 
 // アプリ更新 (releases/latest を DL・インストール、Android ブリッジ checkForUpdate)。
@@ -356,6 +378,21 @@ async function syncFc1200Date() {
         <p class="text-[10px] text-gray-400">
           着信が来ない / FCM が届かない / 環境を切り替えた後に使ってください。リセット後は再登録が必要です。
         </p>
+
+        <!-- ログ送信 (Android のみ、WS 診断用) -->
+        <div v-if="isAndroidApp" class="pt-1">
+          <button
+            class="px-3 py-1.5 text-xs border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50"
+            :disabled="uploadingLog"
+            @click="uploadDeviceLog"
+          >
+            {{ uploadingLog ? '送信中...' : '診断ログを送信' }}
+          </button>
+          <span v-if="logUploadMsg" class="ml-2 text-[11px] text-gray-500">{{ logUploadMsg }}</span>
+          <p class="text-[10px] text-gray-400 mt-1">
+            RoomWatcher / 登録の動作ログを signaling worker に送ります (サポート診断用)。
+          </p>
+        </div>
       </div>
     </div>
 


### PR DESCRIPTION
## 概要

WS 未接続の原因を端末単体・リモートで切り分けるため、端末ログを signaling worker に送って observability(cf_logging)で読めるようにする。

- **cf-alc-signaling**: `POST /device-log` を追加。`{device_id, tag, message/lines}` を `console.log` に流す(observability = cf_logging で読める)。認証なし・値は log のみ・**workers.dev なので CF Access 対象外**(RoomWatcher からも直接叩ける)。CORS preflight 対応
- **alc-app DeviceSettings**: 「診断ログを送信」ボタン(Android のみ)。Android ブリッジ `uploadDeviceLog()`(AlcoholChecker PR で実装)を呼ぶ

対になる AlcoholChecker 側: RoomWatcher が connect/onOpen/onError/onClose/no-device-id を `/device-log` に自動 POST + `uploadDeviceLog()` ブリッジ。

## Test plan

- [x] `npx nuxi typecheck` — 新規型エラーなし
- [x] `npx vitest run` — pass
- [ ] 「診断ログを送信」→ cf_logging observability に `[device-log] dev=... tag=fileLog ...` が出る

Refs ippoan/rust-alc-api#480

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0127V338YCEACT9o7W9xL6Q9)_