### PR TITLE
fix(signaling): /device-log の log injection を防ぐ (sanitize + 型強制) (Refs ippoan/rust-alc-api#480)

### DIFF
--- a/cf-alc-signaling/src/index.ts
+++ b/cf-alc-signaling/src/index.ts
@@ -21,18 +21,23 @@ export default {
     // 認証なし・値は log のみ。RoomWatcher の接続挙動や fileLog を端末から送って
     // リモートで WS 未接続の原因を切り分けるための経路 (Refs ippoan/rust-alc-api#480)。
     if (request.method === 'POST' && url.pathname === '/device-log') {
-      let body: { device_id?: string; tag?: string; message?: string; lines?: string[] } = {};
+      let body: { device_id?: unknown; tag?: unknown; message?: unknown; lines?: unknown } = {};
       try {
         body = await request.json();
       } catch { /* ignore parse error */ }
-      const dev = (body.device_id || '(none)').slice(0, 64);
-      const tag = (body.tag || 'device').slice(0, 32);
-      const msgs = body.lines && Array.isArray(body.lines)
-        ? body.lines
-        : [body.message ?? ''];
-      // 1 行ずつ console.log (observability の 1 event = 1 行、長すぎる行は切る)。
-      for (const m of msgs.slice(0, 200)) {
-        console.log(`[device-log] dev=${dev} tag=${tag} ${String(m).slice(0, 2000)}`);
+      // 非認証エンドポイントなので log injection (CR/LF で偽 log 行を捏造) を防ぐ:
+      // 文字列に強制し、制御文字 (C0) を空白へ潰してから 1 行に収める。
+      const clean = (v: unknown, max: number): string =>
+        (typeof v === 'string' ? v : '')
+          // eslint-disable-next-line no-control-regex
+          .replace(/[\u0000-\u001F\u007F]/g, ' ')
+          .slice(0, max);
+      const dev = clean(body.device_id, 64) || '(none)';
+      const tag = clean(body.tag, 32) || 'device';
+      const rawMsgs: unknown[] = Array.isArray(body.lines) ? body.lines : [body.message];
+      // 1 行ずつ console.log (observability の 1 event = 1 行、制御文字除去済み)。
+      for (const m of rawMsgs.slice(0, 200)) {
+        console.log(`[device-log] dev=${dev} tag=${tag} ${clean(m, 2000)}`);
       }
       return new Response(null, {
         status: 204,


### PR DESCRIPTION
## 概要

自動セキュリティレビューの指摘対応。#79 で追加した `/device-log`(非認証)は、`device_id`/`tag`/`message` に CR/LF や C0 制御文字を仕込んで **偽の log 行を捏造できる(log injection)**。また非文字列入力で `String()` が想定外挙動になり得る。

`clean()` で各フィールドを:
- 文字列以外は空文字に強制(`typeof` チェック)
- C0 制御文字(U+0000–U+001F)と DEL(U+007F)を空白へ置換 → 1 行に収める

認証/レート制限は、本 endpoint が **observability に書くだけの一時診断用途**(データアクセス無し・workers.dev・値は log のみ)のため今回は見送り、injection 対策を優先。将来常設するなら shared header か rate-limit を検討。

Refs ippoan/rust-alc-api#480

## Test plan

- [x] `wrangler deploy --dry-run`(cf-alc-signaling)— ビルド成功
- [ ] `/device-log` に CR/LF 入り payload を送っても 1 行に収まる

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0127V338YCEACT9o7W9xL6Q9)_