### PR TITLE
fix(device): web claim の credential/settings_token を native に渡す (Refs ippoan/rust-alc-api#480)

### DIFF
--- a/web/app/components/DeviceSettings.vue
+++ b/web/app/components/DeviceSettings.vue
@@ -28,6 +28,7 @@ type AndroidDiag = {
   getFcmStatus?: () => string
   getAppVersion?: () => string
   checkForUpdate?: () => void
+  getLastUpdateResult?: () => string
   uploadDeviceLog?: () => void
 }
 
@@ -54,9 +55,15 @@ function uploadDeviceLog() {
 
 // アプリ更新 (releases/latest を DL・インストール、Android ブリッジ checkForUpdate)。
 const updating = ref(false)
+// 直近の OTA 更新結果 (ネイティブ UpdateStatusStore 由来、無音失敗を UI に可視化)。
+const updateResult = ref<{ ok: boolean, hint: string, version?: string } | null>(null)
 function checkForUpdate() {
   const android = (window as unknown as { Android?: AndroidDiag }).Android
-  if (!android?.checkForUpdate) return
+  if (!android?.checkForUpdate) {
+    // 旧 APK は checkForUpdate 未実装。無言で握りつぶさず理由を出す。
+    updateResult.value = { ok: false, hint: 'この APK は更新機能に未対応です (手動で再インストールしてください)' }
+    return
+  }
   updating.value = true
   try {
     android.checkForUpdate()
@@ -87,6 +94,14 @@ function refreshDeviceDiag() {
     if (ver) {
       const v = JSON.parse(ver) as { versionName?: string, versionCode?: number }
       appVersion.value = v.versionName ? `${v.versionName} (${v.versionCode ?? '?'})` : null
+    }
+    // 直近の OTA 更新結果 (成功/失敗/理由)。署名不一致等の「無音失敗」を UI に出す。
+    const upd = android.getLastUpdateResult?.()
+    if (upd) {
+      const u = JSON.parse(upd) as { ok?: boolean, hint?: string, version?: string }
+      updateResult.value = typeof u.ok === 'boolean'
+        ? { ok: u.ok, hint: u.hint ?? '', version: u.version }
+        : null
     }
   } catch { /* ブリッジ未実装の旧 APK 等は無視 */ }
 }
@@ -345,6 +360,14 @@ async function syncFc1200Date() {
             >
               {{ updating ? '更新中...' : '更新' }}
             </button>
+          </p>
+          <!-- 直近の OTA 更新結果 (署名不一致等の無音失敗を可視化) -->
+          <p
+            v-if="updateResult"
+            class="text-[11px] rounded px-2 py-1"
+            :class="updateResult.ok ? 'bg-green-50 text-green-700' : 'bg-red-50 text-red-700'"
+          >
+            {{ updateResult.ok ? '✓' : '⚠' }} {{ updateResult.hint }}
           </p>
         </div>
 

--- a/web/app/composables/useAuth.ts
+++ b/web/app/composables/useAuth.ts
@@ -221,6 +221,12 @@ export function useAuth() {
         if (android?.setDeviceId) {
           android.setDeviceId(devId)
         }
+        // setDeviceId は native の settings_token を remove するため、直後に必ず
+        // setSettingsToken で再設定する (旧APK互換で guard。呼び忘れが settings_token=false
+        // の直接原因だった、Refs rust-alc-api#480)。
+        if (android?.setSettingsToken) {
+          android.setSettingsToken(settingsToken ?? '')
+        }
       }
       if (settingsToken) {
         localStorage.setItem(DEVICE_SETTINGS_TOKEN_KEY, settingsToken)
@@ -249,6 +255,14 @@ export function useAuth() {
     activateDevice(res.tenant_id, res.device_id, res.settings_token)
     if (res.auth_device_id && res.device_secret) {
       useDeviceToken().storeKioskCredential(res.auth_device_id, res.device_secret)
+      // native (Android) にも credential を渡す。DeviceToken が device JWT を mint
+      // するのに必要 (無いと settings / register-fcm-token 等が 403、FCM 登録が通らない)。
+      // activateDevice() が setDeviceId → setSettingsToken を済ませた後に呼ぶこと
+      // (setDeviceCredential は最後、Refs rust-alc-api#480)。
+      const android = (window as any).Android
+      if (android?.setDeviceCredential) {
+        android.setDeviceCredential(res.auth_device_id, res.device_secret)
+      }
     }
   }
 
@@ -261,8 +275,15 @@ export function useAuth() {
       localStorage.removeItem(DEVICE_TENANT_KEY)
       localStorage.removeItem(DEVICE_ID_KEY)
       localStorage.removeItem(DEVICE_SETTINGS_TOKEN_KEY)
+      // web 側 kiosk credential も破棄 (localStorage)
+      useDeviceToken().clearKioskCredential()
       const android = (window as any).Android
-      if (android?.setDeviceId) {
+      // native も完全リセット (device_id / settings_token / auth_device_id /
+      // device_secret クリア + RoomWatcher 停止)。旧APK は resetDeviceRegistration が
+      // 無いので setDeviceId('') に degrade (Refs rust-alc-api#480)。
+      if (android?.resetDeviceRegistration) {
+        android.resetDeviceRegistration()
+      } else if (android?.setDeviceId) {
         android.setDeviceId('')
       }
     }

--- a/web/tests/composables/useAuth.test.ts
+++ b/web/tests/composables/useAuth.test.ts
@@ -196,6 +196,77 @@ describe('useAuth', () => {
 
       expect(deviceTenantId.value).toBeNull()
     })
+
+    it('should call Android.setSettingsToken after setDeviceId in order (Refs rust-alc-api#480)', async () => {
+      const order: string[] = []
+      ;(window as any).Android = {
+        setDeviceId: vi.fn(() => order.push('setDeviceId')),
+        setSettingsToken: vi.fn(() => order.push('setSettingsToken')),
+      }
+
+      const { useAuth } = await import('~/composables/useAuth')
+      useAuth().activateDevice('tenant-1', 'dev-1', 'stok')
+
+      expect((window as any).Android.setSettingsToken).toHaveBeenCalledWith('stok')
+      // 順序が重要: setDeviceId が native の settings_token を remove するので後に再設定
+      expect(order).toEqual(['setDeviceId', 'setSettingsToken'])
+      delete (window as any).Android
+    })
+
+    it('should call Android.setSettingsToken("") when no settings token given', async () => {
+      const mockSetSettingsToken = vi.fn()
+      ;(window as any).Android = { setDeviceId: vi.fn(), setSettingsToken: mockSetSettingsToken }
+
+      const { useAuth } = await import('~/composables/useAuth')
+      useAuth().activateDevice('tenant-1', 'dev-1')
+
+      expect(mockSetSettingsToken).toHaveBeenCalledWith('')
+      delete (window as any).Android
+    })
+
+    it('activateFromRegistration should pass credential to Android.setDeviceCredential last (Refs rust-alc-api#480)', async () => {
+      const order: string[] = []
+      ;(window as any).Android = {
+        setDeviceId: vi.fn(() => order.push('setDeviceId')),
+        setSettingsToken: vi.fn(() => order.push('setSettingsToken')),
+        setDeviceCredential: vi.fn(() => order.push('setDeviceCredential')),
+      }
+
+      const { useAuth } = await import('~/composables/useAuth')
+      useAuth().activateFromRegistration({
+        tenant_id: 'tenant-reg',
+        device_id: 'dev-reg',
+        settings_token: 'token-reg',
+        auth_device_id: 'auth-dev-reg',
+        device_secret: 'secret-reg',
+      })
+
+      expect((window as any).Android.setDeviceCredential).toHaveBeenCalledWith('auth-dev-reg', 'secret-reg')
+      // credential は setDeviceId → setSettingsToken の後 (最後) に渡す
+      expect(order).toEqual(['setDeviceId', 'setSettingsToken', 'setDeviceCredential'])
+      delete (window as any).Android
+    })
+
+    it('deactivateDevice calls Android.resetDeviceRegistration and clears kiosk credential (Refs rust-alc-api#480)', async () => {
+      const mockReset = vi.fn()
+      ;(window as any).Android = { setDeviceId: vi.fn(), resetDeviceRegistration: mockReset }
+
+      const { useAuth } = await import('~/composables/useAuth')
+      const { activateFromRegistration, deactivateDevice } = useAuth()
+
+      activateFromRegistration({
+        tenant_id: 'tenant-reg',
+        device_id: 'dev-reg',
+        auth_device_id: 'auth-dev-reg',
+        device_secret: 'secret-reg',
+      })
+      deactivateDevice()
+
+      expect(mockReset).toHaveBeenCalled()
+      const { useDeviceToken } = await import('~/composables/useDeviceToken')
+      expect(useDeviceToken().kioskDeviceId.value).toBeNull()
+      delete (window as any).Android
+    })
   })
 
   describe('session refresh (cookie)', () => {


### PR DESCRIPTION
## 概要

FCM 着信フォールバックが staging/prod で 403 になる問題（`register-fcm-token` → 403）の web 側修正（Fable 設計調査で確定した「web → native の1ホップ欠落」）。native 側は AlcoholChecker#16（1.4.30）で `setDeviceCredential` bridge 実装済み。

## 背景

server 側（rust-alc-api / auth-worker / alc-app Nitro）は既に全実装済みで、claim 応答に `auth_device_id` + `device_secret` が含まれ web に届いている。しかし web claim フローは native に `setDeviceId(deviceId)` しか渡さず、credential も `settings_token` も native に入らない → AlcoholChecker 側 `DeviceToken` が device JWT を mint できず、認証必須の backend 呼び出し（settings / register-fcm-token / report-*）が 403。

## 変更（`useAuth.ts`）

- **`activateDevice`**: `setDeviceId` の後に `setSettingsToken` を呼ぶ（呼び忘れ修正 = `settings_token=false` の直接原因）。`setDeviceId` が native の settings_token を remove するため**順序が重要**
- **`activateFromRegistration`**: `storeKioskCredential` に加え native `setDeviceCredential(auth_device_id, device_secret)` を呼ぶ。順序は **setDeviceId → setSettingsToken → setDeviceCredential**
- **`deactivateDevice`**: web kiosk credential を `clearKioskCredential` でクリア + native は `resetDeviceRegistration`（無ければ `setDeviceId('')` に degrade）で `auth_device_id`/`device_secret` も完全クリア
- 全て `android?.method` guard で旧 APK 互換（bridge 未実装なら no-op）
- `useAuth.test.ts` に順序 assert 込みで 4 ケース追加、**coverage 100% 維持**（ローカル実測: Stmts/Branch/Funcs/Lines 全て 100%）

## 併せて（2つ目のコミット）

`DeviceSettings.vue`: AlcoholChecker#14（native）で追加した `getLastUpdateResult` bridge の web 表示側。native 半分だけ merge され web 表示が commit され損ねていたため補完（署名不一致等の無音失敗を UI に色分け表示）。

## 検証

staging で URL フロー claim → native `fileLog` で `device_cred=true` → `PUT /api/devices/register-fcm-token` が 200 → `fcm_token_registered` が立つ。既存 web claim 済み端末は credential を後から配る経路が無いため**再登録が必要**（恒久 backfill は secret を無認証経路に乗せるので別 issue）。

Refs ippoan/rust-alc-api#480

---
_Generated by [Claude Code](https://claude.ai/code/session_0127V338YCEACT9o7W9xL6Q9)_