### PR TITLE
feat(device-settings): 診断ログ送信時に web 版を native へ渡す (Refs ippoan/rust-alc-api#480)

### DIFF
--- a/web/app/components/DeviceSettings.vue
+++ b/web/app/components/DeviceSettings.vue
@@ -29,6 +29,7 @@ type AndroidDiag = {
   getAppVersion?: () => string
   checkForUpdate?: () => void
   getLastUpdateResult?: () => string
+  setWebVersion?: (version: string) => void
   uploadDeviceLog?: () => void
 }
 
@@ -44,6 +45,10 @@ function uploadDeviceLog() {
   uploadingLog.value = true
   logUploadMsg.value = ''
   try {
+    // web (alc-app) の版を native に渡してから送る。診断ログの web= に出て
+    // web/native の版ズレ判別に使う (旧 APK は setWebVersion 未実装 → guard)。
+    const webVersion = String(useRuntimeConfig().public.appVersion ?? 'dev')
+    android.setWebVersion?.(webVersion)
     android.uploadDeviceLog()
     logUploadMsg.value = 'ログを送信しました'
   } catch {


### PR DESCRIPTION
## 概要

FCM 切り分けのため、診断ログに web (alc-app) の版も出せるようにする web 側の対応。native 側（AlcoholChecker#17, 1.4.31）は `setWebVersion` bridge + 診断ログ `web=` 出力を実装済み。

## 変更

`DeviceSettings.vue` の診断ログ送信ボタンで、`uploadDeviceLog()` の前に `android.setWebVersion(NUXT_PUBLIC_APP_VERSION)` を呼ぶ（staging=commit SHA / release=tag）。`setWebVersion` 未実装の旧 APK は `android?.method` guard で no-op。

これで診断ログ 1 行に `app=<native版> web=<web版>` が並び、web/native の版ズレ（＝ web claim フローが旧コードで `setDeviceCredential` 未達か）を observability だけで判別できる。

Refs ippoan/rust-alc-api#480

---
_Generated by [Claude Code](https://claude.ai/code/session_0127V338YCEACT9o7W9xL6Q9)_