### PR TITLE
fix(device): アプリ内 QR スキャンの登録も funnel を通す (Refs ippoan/rust-alc-api#480)

### DIFF
--- a/web/app/pages/index.vue
+++ b/web/app/pages/index.vue
@@ -5,7 +5,7 @@ const config = useRuntimeConfig()
 const route = useRoute()
 
 // Auth + API init (全タブ共通)
-const { accessToken, isAuthenticated, deviceTenantId, refreshAccessToken, handleLineworksHash } = useAuth()
+const { accessToken, isAuthenticated, deviceTenantId, refreshAccessToken, handleLineworksHash, activateFromRegistration } = useAuth()
 
 // LINE WORKS コールバック処理 (hash fragment からトークン取得)
 onMounted(() => { handleLineworksHash() })
@@ -147,7 +147,11 @@ onMounted(() => {
           phone_number: phoneNumber,
         })
         if (res.device_id) {
-          ;(window as any).Android?.setDeviceId?.(res.device_id)
+          // funnel を通して activate する。raw setDeviceId だと settings_token /
+          // device credential (auth_device_id/device_secret) を native に渡さず、
+          // device JWT が mint できず register-fcm-token 等が 403 になる
+          // (アプリ内 QR スキャン経路の credential 取りこぼし、Refs rust-alc-api#480)。
+          activateFromRegistration(res)
           qrResult.value = `登録完了: ${res.device_id.slice(0, 8)}...`
         } else {
           qrResult.value = res.message || '登録に失敗しました'


### PR DESCRIPTION
## 真因（observability + code で確定）

`app=1.4.31 web=<新SHA>`（native/web とも新版）なのに `device_cred=false settings_token=false` が続く原因を特定。

`index.vue` の**アプリ内 QR スキャン**ハンドラ（`qr-scanned` listener）が funnel を通らず、raw で `Android.setDeviceId(res.device_id)` だけを呼んでいた:
```js
;(window as any).Android?.setDeviceId?.(res.device_id)   // credential/settings_token を捨てている
```

そのため**アプリ内スキャナで登録した端末**は:
- `settings_token` が native に渡らない → `settings_token=false`
- `auth_device_id`/`device_secret` が native に渡らない → `device_cred=false` → `DeviceToken` が device JWT を mint できず `register-fcm-token` 等が **403**

server 側（claim 200 / pair-internal 201 / auth-worker が credential 返却 / Nitro が merge）は全て正常で、client の**この経路だけ** funnel を素通りしていた。`activateFromRegistration` の doc コメントが警告していた「呼び出し箇所ごとの取りこぼし」の実例。

## 変更

`index.vue` の `qr-scanned` ハンドラを `activateFromRegistration(res)` funnel に置き換え。`device-claim.vue` と同じく setDeviceId → setSettingsToken → setDeviceCredential + kiosk credential 保存を通す。

## 検証

アプリ内 QR スキャンで再登録 → 診断ログで `settings_token=true device_cred=true` → `register-fcm-token` が 200 → `fcm_registered=true`。

Refs ippoan/rust-alc-api#480

---
_Generated by [Claude Code](https://claude.ai/code/session_0127V338YCEACT9o7W9xL6Q9)_