### PR TITLE
feat(devices): kiosk 端末 re-pair (再認証) PR3a/3b — alc-app 側実装 (Refs rust-alc-api#495)

### DIFF
--- a/.claude/skills/alc-app-map/SKILL.md
+++ b/.claude/skills/alc-app-map/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: alc-app-map
-generated-from: alc-app:8ce334234fdb434832dfb73cd76513f2f3654ab8
+generated-from: alc-app:3bdd4d0f02f9ad31ae0ef5b295aeed2cc98254ee
 paths: [web/, cf-alc-signaling/]
 description: yhonda-ohishi-alc/alc-app (業務用アルコールチェッカーシステム / 複合 repo) の構造ナビゲーション。タニタ FC-1200 + NFC + 顔認証による本人確認付きアルコール測定 + 遠隔点呼。web/ (Nuxt 4 PWA on Workers)・cf-alc-signaling/ (WebRTC signaling DO)・fc1200-wasm (秘匿) の区画、WebSerial/WebRTC/顔認証の composable 配置、秘匿ファイル・テストの gotcha を 1 枚にまとめる。トリガー:「alc-app」「アルコールチェッカー」「FC-1200」「fc1200」「点呼」「遠隔点呼」「顔認証」「NFC bridge」「WebRTC signaling」「cf-alc-signaling」「alc.ippoan.org」等。
 ---
@@ -39,7 +39,7 @@ description: yhonda-ohishi-alc/alc-app (業務用アルコールチェッカー�
 | **components** | `Tenko*.vue` (多数: Kiosk/VideoCall/RemoteAdminView/ScheduleManager 等) `*Dashboard.vue` `FaceAuth.vue` `AlcMeasurement.vue` `Device*.vue` | 点呼 UI / ダッシュボード / 測定 / デバイス管理 |
 | **utils** | `web/app/utils/{api,env,face-approval,face-db,fc1200,human-config,license,offline-queue,video-store}.ts` | API client / 顔 DB (IndexedDB) / FC-1200 / human 設定 / オフラインキュー |
 | **worker** | `web/app/workers/face-detect.worker.ts` | 顔検出 Web Worker (@vladmandic/human) |
-| **server route** | `web/server/api/{proxy/[...path],tenko-call/{register,tenko},devices/*,github-checksum.get}.ts` | **proxy/** = auth-worker proxy (`createAuthWorkerProxyHandler`、#434 step 3 / 方式 B): cookie/Bearer JWT + X-Alc-Proxy-Secret (=INTERNAL_SHARED_SECRET) を AUTH_WORKER service binding 経由で auth-worker `/alc-proxy/*` に thin-forward。introspect / ACL / OIDC mint / X-Tenant-ID + X-User-* 注入は auth-worker 側に集約 (SA key 排除)。**admin / device JWT を伴う呼び出しは `app/utils/api.ts` の `request()` / `proxyRawFetch` が `/api/proxy` 経由に寄せる (#434 step 3d caller #3、admin 直叩き撤去)**。残る `tenko-call/{register,tenko}` (public) と `devices/*` (FCM token / version / watchdog / claim、Android 直叩き) は browser JWT 無しのため lockdown 化は caller #5 (Android)。NFC bridge checksum |
+| **server route** | `web/server/api/{proxy/[...path],tenko-call/{register,tenko},devices/*,github-checksum.get}.ts` | **proxy/** = auth-worker proxy (`createAuthWorkerProxyHandler`、#434 step 3 / 方式 B): cookie/Bearer JWT + X-Alc-Proxy-Secret (=INTERNAL_SHARED_SECRET) を AUTH_WORKER service binding 経由で auth-worker `/alc-proxy/*` に thin-forward。introspect / ACL / OIDC mint / X-Tenant-ID + X-User-* 注入は auth-worker 側に集約 (SA key 排除)。**admin / device JWT を伴う呼び出しは `app/utils/api.ts` の `request()` / `proxyRawFetch` が `/api/proxy` 経由に寄せる (#434 step 3d caller #3、admin 直叩き撤去)**。残る `tenko-call/{register,tenko}` (public) と `devices/*` (FCM token / version / watchdog / claim / **re-pair**、Android 直叩き) は browser JWT 無しのため lockdown 化は caller #5 (Android)。`devices/re-pair.post.ts` は kiosk 端末再認証 (rust-alc-api#495)。管理者側の window 発行 (`authorizeRepair`) はテナント認証付きなので `request()` → `/api/proxy` 経由。NFC bridge checksum |
 | **型 (生成)** | `web/app/types/generated/*` (91 file) + `web/app/types/index.ts` | rust-alc-api models.rs から **ts-rs 自動生成** (`Backend` namespace)。手動編集禁止。フロント固有型は index.ts に手動定義 |
 | **middleware** | `web/app/middleware/auth.global.ts` | 全ルート認証ガード |
 

--- a/web/app/components/DeviceRegistrationManager.vue
+++ b/web/app/components/DeviceRegistrationManager.vue
@@ -6,6 +6,7 @@ import {
   createDeviceUrlToken, createPermanentQr, createDeviceOwnerToken,
   approveDevice, rejectDevice, disableDevice, enableDevice, deleteDevice,
   updateDeviceCallSettings, testFcmNotification, testFcmAll, triggerUpdate,
+  authorizeRepair,
 } from '~/utils/api'
 import type { TestFcmAllResult } from '~/utils/api'
 
@@ -267,6 +268,31 @@ async function handleDelete(id: string) {
   } catch (e) {
     error.value = e instanceof Error ? e.message : '削除に失敗しました'
   }
+}
+
+// 再認証 window を開ける (Refs rust-alc-api#495)。端末が起動時 auto-retry や
+// 「再認証」ボタンで credential を再取得できるようになる (既定 15 分間)。
+const repairAuthorizing = ref<Set<string>>(new Set())
+async function handleAuthorizeRepair(id: string) {
+  repairAuthorizing.value = new Set([...repairAuthorizing.value, id])
+  try {
+    await authorizeRepair(id)
+    await refresh()
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : '再認証許可に失敗しました'
+  } finally {
+    const next = new Set(repairAuthorizing.value)
+    next.delete(id)
+    repairAuthorizing.value = next
+  }
+}
+
+/** 再認証 window の残り時間を「N分」表示用に算出する (期限切れ/未設定は null)。 */
+function repairWindowRemaining(authorizedUntil?: string | null): string | null {
+  if (!authorizedUntil) return null
+  const remainingMs = new Date(authorizedUntil).getTime() - Date.now()
+  if (remainingMs <= 0) return null
+  return `残り${Math.ceil(remainingMs / 60000)}分`
 }
 
 // 生成済みトークンのQR再表示用
@@ -1046,6 +1072,13 @@ Latest Release: {{ latestApkVersion || '取得中...' }}</pre>
                     class="text-green-600"
                   >(管理者)</span>
                 </p>
+                <p v-if="dev.re_pair_count > 0 || dev.re_pair_authorized_until" class="text-xs text-gray-400">
+                  再認証: {{ dev.re_pair_count }}回
+                  <span v-if="dev.last_re_pair_at">(最終 {{ dev.last_re_pair_at.slice(0, 16).replace('T', ' ') }})</span>
+                  <span v-if="repairWindowRemaining(dev.re_pair_authorized_until)" class="text-yellow-600">
+                    / window {{ repairWindowRemaining(dev.re_pair_authorized_until) }}
+                  </span>
+                </p>
               </div>
             </div>
             <div class="flex gap-1">
@@ -1103,6 +1136,18 @@ Latest Release: {{ latestApkVersion || '取得中...' }}</pre>
                 @click="triggerDeviceUpdate(dev.id)"
               >
                 {{ otaUpdatingDevice === dev.id ? '送信中...' : '更新' }}
+              </button>
+              <!-- 再認証を許可 (Refs rust-alc-api#495) -->
+              <button
+                v-if="dev.status === 'active'"
+                class="px-2 py-1 text-xs rounded"
+                :class="repairWindowRemaining(dev.re_pair_authorized_until)
+                  ? 'bg-yellow-100 text-yellow-700'
+                  : 'bg-purple-100 text-purple-700 hover:bg-purple-200'"
+                :disabled="repairAuthorizing.has(dev.id)"
+                @click="handleAuthorizeRepair(dev.id)"
+              >
+                {{ repairAuthorizing.has(dev.id) ? '許可中...' : repairWindowRemaining(dev.re_pair_authorized_until) || '再認証を許可' }}
               </button>
               <!-- スケジュール展開 -->
               <button

--- a/web/app/components/DeviceSettings.vue
+++ b/web/app/components/DeviceSettings.vue
@@ -9,8 +9,25 @@ const BLE_GW_DEVICES = [
 
 const { ports, isSupported, refreshPorts, forgetPort } = useSerialDeviceManager()
 const { isAndroidApp } = useFingerprint()
-const { deactivateDevice, deviceTenantId, deviceId: activatedDeviceId } = useAuth()
-const { clearKioskCredential } = useDeviceToken()
+const { deactivateDevice, deviceTenantId, deviceId: activatedDeviceId, reAuthenticateDevice } = useAuth()
+const { clearKioskCredential, hasKioskCredential } = useDeviceToken()
+
+// 再認証 (re-pair、Refs rust-alc-api#495)。管理者が端末一覧で「再認証を許可」した
+// window 内でのみ成功する。credential 欠落状態 (hasKioskCredential=false) なら
+// 登録済み端末でも起動時に自動で1回だけ試す (管理者が許可すれば端末に触れずリモート復旧)。
+const reAuthing = ref(false)
+const reAuthResult = ref<'success' | 'failure' | null>(null)
+async function reAuthenticate() {
+  if (reAuthing.value) return
+  reAuthing.value = true
+  reAuthResult.value = null
+  try {
+    const ok = await reAuthenticateDevice()
+    reAuthResult.value = ok ? 'success' : 'failure'
+  } finally {
+    reAuthing.value = false
+  }
+}
 
 // 端末登録リセット (WebView localStorage + Android native SharedPreferences 両方をクリア)
 const resetting = ref(false)
@@ -115,6 +132,12 @@ onMounted(() => {
   if (isAndroidApp) {
     refreshDeviceDiag()
     diagTimer = setInterval(refreshDeviceDiag, 3000) // 3秒ごとに更新
+  }
+  // 登録済みだが credential が欠落している端末 (rust-alc-api#480 の取りこぼし等) は、
+  // 管理者が window を開けていれば起動時の自動 1 回試行だけで無人復旧できる。
+  // 未許可 (window 外) なら黙って失敗する (再認証ボタンが常時案内として残る)。
+  if (activatedDeviceId && !hasKioskCredential.value) {
+    reAuthenticate()
   }
 })
 onUnmounted(() => {
@@ -392,6 +415,26 @@ async function syncFc1200Date() {
             更新
           </button>
         </div>
+
+        <!-- 再認証 (credential 欠落からのリモート復旧、Refs rust-alc-api#495) -->
+        <div v-if="activatedDeviceId" class="flex items-center gap-2 flex-wrap">
+          <span class="inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs"
+            :class="hasKioskCredential ? 'bg-green-50 text-green-700' : 'bg-yellow-50 text-yellow-700'">
+            <span class="w-1.5 h-1.5 rounded-full" :class="hasKioskCredential ? 'bg-green-500' : 'bg-yellow-500'" />
+            認証情報: {{ hasKioskCredential ? '取得済み' : '未取得' }}
+          </span>
+          <button
+            class="px-2 py-1 text-xs border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50"
+            :disabled="reAuthing"
+            @click="reAuthenticate"
+          >
+            {{ reAuthing ? '再認証中...' : '再認証' }}
+          </button>
+        </div>
+        <p v-if="reAuthResult" class="text-[11px] rounded px-2 py-1"
+          :class="reAuthResult === 'success' ? 'bg-green-50 text-green-700' : 'bg-red-50 text-red-700'">
+          {{ reAuthResult === 'success' ? '✓ 再認証に成功しました' : '⚠ 再認証に失敗しました (管理者に「再認証を許可」を依頼してください)' }}
+        </p>
 
         <button
           class="px-3 py-1.5 text-xs border rounded-lg transition-colors disabled:opacity-50"

--- a/web/app/composables/useAuth.ts
+++ b/web/app/composables/useAuth.ts
@@ -1,5 +1,7 @@
 import type { AuthUser } from '~/types'
 import { isClient } from '~/utils/env'
+import { rePairDevice } from '~/utils/api'
+import { getOrCreateWebInstallId } from '~/utils/webInstallId'
 
 /** Base64url → UTF-8 JSON デコード (マルチバイト文字対応) */
 function decodeJwtPayload(base64url: string): any {
@@ -337,6 +339,36 @@ export function useAuth() {
     return true
   }
 
+  /**
+   * 管理者が時限 window を開けた後、端末が device credential を再取得する
+   * (再認証、Refs rust-alc-api#495)。deviceId 未登録なら何もせず false。
+   * hardware_id は Android bridge (`getHardwareId`、PR4/任意) があればそれを、
+   * 無ければ web install id (localStorage 永続の乱数) を送る。成功したら
+   * activateFromRegistration と同じ保存先 (kiosk credential + Android native)
+   * に反映して true を返す。失敗理由は呼び出し側に区別させない (window 外 /
+   * cooldown / TOFU 不一致いずれも false、詳細は rust 側ログにのみ出る)。
+   */
+  async function reAuthenticateDevice(): Promise<boolean> {
+    if (!deviceId.value) return false
+    try {
+      const android = (window as any).Android
+      const hardwareId: string = android?.getHardwareId?.() || getOrCreateWebInstallId()
+      const res = await rePairDevice({
+        device_id: deviceId.value,
+        hardware_id: hardwareId,
+        ...(deviceSettingsToken.value ? { settings_token: deviceSettingsToken.value } : {}),
+      })
+      if (!res.auth_device_id || !res.device_secret) return false
+      useDeviceToken().storeKioskCredential(res.auth_device_id, res.device_secret)
+      if (android?.setDeviceCredential) {
+        android.setDeviceCredential(res.auth_device_id, res.device_secret)
+      }
+      return true
+    } catch {
+      return false
+    }
+  }
+
   return {
     user: readonly(user),
     accessToken: readonly(accessToken),
@@ -356,5 +388,6 @@ export function useAuth() {
     activateFromRegistration,
     deactivateDevice,
     applyStagingBypass,
+    reAuthenticateDevice,
   }
 }

--- a/web/app/types/index.ts
+++ b/web/app/types/index.ts
@@ -801,6 +801,11 @@ export interface Device {
   watchdog_running?: boolean | null
   created_at: string
   updated_at: string
+  /** re-pair (再認証) 状態。管理者が開けた時限 window の期限 (Refs rust-alc-api#495) */
+  re_pair_authorized_until?: string | null
+  last_re_pair_at?: string | null
+  re_pair_count: number
+  hardware_id?: string | null
 }
 
 export interface DeviceSettingsResponse {
@@ -877,6 +882,23 @@ export interface ApproveDeviceResponse {
   success: boolean
   device_id: string
   tenant_id: string
+}
+
+// --- 再認証 (re-pair、Refs rust-alc-api#495) ---
+
+export interface AuthorizeRepairResponse {
+  authorized_until: string
+}
+
+export interface RePairRequest {
+  device_id: string
+  hardware_id?: string
+  settings_token?: string
+}
+
+export interface RePairResponse {
+  auth_device_id: string
+  device_secret: string
 }
 
 // --- 携行品 ---

--- a/web/app/utils/api.ts
+++ b/web/app/utils/api.ts
@@ -16,6 +16,7 @@ import type {
   Device, DeviceRegistrationRequest, CreateRegistrationResponse, RegistrationStatusResponse,
   ClaimRegistrationRequest, ClaimRegistrationResponse, CreateTokenResponse, CreatePermanentQrResponse, ApproveDeviceResponse,
   DeviceSettingsResponse, CallSchedule,
+  AuthorizeRepairResponse, RePairRequest, RePairResponse,
   DailyHealthResponse, VehicleCategories,
   GuidanceRecord, CreateGuidanceRecord, GuidanceRecordsResponse, GuidanceRecordAttachment,
   CommunicationItem, CreateCommunicationItem, CommunicationItemsResponse,
@@ -800,6 +801,24 @@ export async function enableDevice(id: string): Promise<void> {
 
 export async function deleteDevice(id: string): Promise<void> {
   return request<void>(`/api/devices/${id}`, { method: 'DELETE' })
+}
+
+// --- 再認証 (re-pair、Refs rust-alc-api#495) ---
+
+// 管理者: 対象端末に時限 window を開ける (admin JWT 必須、テナント認証付き API)
+export async function authorizeRepair(id: string, resetBinding = false): Promise<AuthorizeRepairResponse> {
+  return request<AuthorizeRepairResponse>(`/api/devices/${id}/authorize-repair`, {
+    method: 'POST',
+    body: JSON.stringify({ reset_binding: resetBinding }),
+  })
+}
+
+// 端末: window 内で device credential を再取得 (認証不要、public ingest 経路)
+export async function rePairDevice(data: RePairRequest): Promise<RePairResponse> {
+  return publicIngestRequest<RePairResponse>('/api/devices/re-pair', {
+    method: 'POST',
+    body: JSON.stringify(data),
+  })
 }
 
 export async function getDeviceSettings(

--- a/web/app/utils/webInstallId.ts
+++ b/web/app/utils/webInstallId.ts
@@ -1,0 +1,16 @@
+// re-pair (再認証) の TOFU hardware bind 用フォールバック識別子 (Refs
+// rust-alc-api#495)。Android bridge の `getHardwareId()` (ANDROID_ID ベース、
+// PR4/任意) が無い web/PC 環境向けに、localStorage に永続する乱数 UUID を
+// 「この端末インストール」の識別子として使う。
+const WEB_INSTALL_ID_KEY = 'alc_web_install_id'
+
+/** localStorage に保存された web install id を返す。無ければ新規発行して保存する。 */
+export function getOrCreateWebInstallId(): string {
+  if (typeof window === 'undefined') return ''
+  let id = localStorage.getItem(WEB_INSTALL_ID_KEY)
+  if (!id) {
+    id = crypto.randomUUID()
+    localStorage.setItem(WEB_INSTALL_ID_KEY, id)
+  }
+  return id
+}

--- a/web/server/api/devices/re-pair.post.ts
+++ b/web/server/api/devices/re-pair.post.ts
@@ -1,0 +1,6 @@
+// kiosk 端末 re-pair (再認証、認証なし public 経路)。管理者が時限 window を開けた
+// (POST /api/devices/{id}/authorize-repair) 後、端末がこの endpoint で device
+// credential (auth_device_id/device_secret) を再取得する。rust 側が auth-worker
+// /device/pair-internal 呼び出しまで完結させるので、alc-app 側での mint 処理は不要
+// (Refs ippoan/rust-alc-api#495)。
+export default createInternalIngestHandler('/api/devices/re-pair')

--- a/web/tests/composables/useAuth.test.ts
+++ b/web/tests/composables/useAuth.test.ts
@@ -269,6 +269,137 @@ describe('useAuth', () => {
     })
   })
 
+  describe('reAuthenticateDevice (再認証、Refs rust-alc-api#495)', () => {
+    it('returns false when device is not registered (no deviceId)', async () => {
+      const { useAuth } = await import('~/composables/useAuth')
+      const { reAuthenticateDevice } = useAuth()
+
+      expect(await reAuthenticateDevice()).toBe(false)
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
+
+    it('stores credential and returns true on success', async () => {
+      const { useAuth } = await import('~/composables/useAuth')
+      const auth = useAuth()
+      auth.activateDevice('tenant-1', 'dev-1')
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ auth_device_id: 'auth-dev-1', device_secret: 'secret-1' }),
+      })
+
+      const ok = await auth.reAuthenticateDevice()
+
+      expect(ok).toBe(true)
+      expect(mockFetch.mock.calls[0][0]).toBe('/api/devices/re-pair')
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body)
+      expect(body.device_id).toBe('dev-1')
+      const { useDeviceToken } = await import('~/composables/useDeviceToken')
+      expect(useDeviceToken().kioskDeviceId.value).toBe('auth-dev-1')
+    })
+
+    it('returns false on non-2xx without surfacing the reason (window 外 / cooldown / TOFU 不一致等)', async () => {
+      const { useAuth } = await import('~/composables/useAuth')
+      const auth = useAuth()
+      auth.activateDevice('tenant-1', 'dev-1')
+      mockFetch.mockResolvedValueOnce({ ok: false, status: 404, statusText: 'Not Found', text: async () => '' })
+
+      expect(await auth.reAuthenticateDevice()).toBe(false)
+    })
+
+    it('returns false when response is missing credential fields', async () => {
+      const { useAuth } = await import('~/composables/useAuth')
+      const auth = useAuth()
+      auth.activateDevice('tenant-1', 'dev-1')
+      mockFetch.mockResolvedValueOnce({ ok: true, status: 200, json: async () => ({}) })
+
+      expect(await auth.reAuthenticateDevice()).toBe(false)
+    })
+
+    it('prefers Android.getHardwareId() and calls setDeviceCredential on success', async () => {
+      const setDeviceCredential = vi.fn()
+      ;(window as any).Android = { getHardwareId: vi.fn(() => 'hw-android'), setDeviceCredential }
+
+      const { useAuth } = await import('~/composables/useAuth')
+      const auth = useAuth()
+      auth.activateDevice('tenant-1', 'dev-1')
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ auth_device_id: 'auth-dev-2', device_secret: 'secret-2' }),
+      })
+
+      await auth.reAuthenticateDevice()
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body)
+      expect(body.hardware_id).toBe('hw-android')
+      expect(setDeviceCredential).toHaveBeenCalledWith('auth-dev-2', 'secret-2')
+      delete (window as any).Android
+    })
+
+    it('falls back to web install id when Android bridge is absent', async () => {
+      const { useAuth } = await import('~/composables/useAuth')
+      const auth = useAuth()
+      auth.activateDevice('tenant-1', 'dev-1')
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ auth_device_id: 'auth-dev-3', device_secret: 'secret-3' }),
+      })
+
+      await auth.reAuthenticateDevice()
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body)
+      expect(typeof body.hardware_id).toBe('string')
+      expect(body.hardware_id.length).toBeGreaterThan(0)
+    })
+
+    it('includes settings_token in the request body when present', async () => {
+      const { useAuth } = await import('~/composables/useAuth')
+      const auth = useAuth()
+      auth.activateDevice('tenant-1', 'dev-1', 'stok-1')
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ auth_device_id: 'auth-dev-4', device_secret: 'secret-4' }),
+      })
+
+      await auth.reAuthenticateDevice()
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body)
+      expect(body.settings_token).toBe('stok-1')
+    })
+
+    it('falls back to web install id when Android bridge lacks getHardwareId (old APK)', async () => {
+      ;(window as any).Android = { setDeviceCredential: vi.fn() }
+
+      const { useAuth } = await import('~/composables/useAuth')
+      const auth = useAuth()
+      auth.activateDevice('tenant-1', 'dev-1')
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ auth_device_id: 'auth-dev-5', device_secret: 'secret-5' }),
+      })
+
+      await auth.reAuthenticateDevice()
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body)
+      expect(typeof body.hardware_id).toBe('string')
+      expect(body.hardware_id.length).toBeGreaterThan(0)
+      delete (window as any).Android
+    })
+
+    it('returns false when fetch throws (network error)', async () => {
+      const { useAuth } = await import('~/composables/useAuth')
+      const auth = useAuth()
+      auth.activateDevice('tenant-1', 'dev-1')
+      mockFetch.mockRejectedValueOnce(new Error('network down'))
+
+      expect(await auth.reAuthenticateDevice()).toBe(false)
+    })
+  })
+
   describe('session refresh (cookie)', () => {
     function setDocCookie(value: string) {
       Object.defineProperty(document, 'cookie', { value, writable: true, configurable: true })

--- a/web/tests/utils/api.test.ts
+++ b/web/tests/utils/api.test.ts
@@ -37,6 +37,7 @@ import {
   approveDevice, approveDeviceByCode, rejectDevice, disableDevice, enableDevice, deleteDevice,
   getDeviceSettings, updateDeviceCallSettings, updateDeviceLastLogin,
   testFcmNotification, testFcmAll, triggerUpdate,
+  authorizeRepair, rePairDevice,
   // Carrying items
   getCarryingItems, createCarryingItem, updateCarryingItem, deleteCarryingItem, submitCarryingItemChecks,
   // Driver info
@@ -715,6 +716,7 @@ describe('api', () => {
       ['rejectDevice', () => rejectDevice(SEED_DEVICE_ID), `/api/devices/reject/${SEED_DEVICE_ID}`],
       ['disableDevice', () => disableDevice(SEED_DEVICE_ID), `/api/devices/disable/${SEED_DEVICE_ID}`],
       ['enableDevice', () => enableDevice(SEED_DEVICE_ID), `/api/devices/enable/${SEED_DEVICE_ID}`],
+      ['authorizeRepair', () => authorizeRepair(SEED_DEVICE_ID), `/api/devices/${SEED_DEVICE_ID}/authorize-repair`],
       ['testFcmNotification', () => testFcmNotification(SEED_DEVICE_ID), `/api/devices/${SEED_DEVICE_ID}/test-fcm`],
       ['testFcmAll', () => testFcmAll(), '/api/devices/test-fcm-all'],
       ['triggerUpdate', () => triggerUpdate(), '/api/devices/trigger-update'],
@@ -808,6 +810,26 @@ describe('api', () => {
       stubResponse(ok204())
       const result = await checkDeviceRegistrationStatus(SEED_REG_CODE)
       expect(result).toBeUndefined()
+    })
+
+    // re-pair (再認証、Refs rust-alc-api#495): 端末側は claimDeviceRegistration 等と同じ
+    // public ingest 経路 (same-origin, 認証情報なし)。
+    it.skipIf(isLive)('rePairDevice uses same-origin path (not apiBase)', async () => {
+      stubOk({ auth_device_id: 'dev-1', device_secret: 'secret-1' })
+      const result = await rePairDevice({ device_id: SEED_DEVICE_ID, hardware_id: 'hw-1' })
+      expect(mockFetch.mock.calls[0][0]).toBe('/api/devices/re-pair')
+      expect(mockFetch.mock.calls[0][1].method).toBe('POST')
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body)
+      expect(body.device_id).toBe(SEED_DEVICE_ID)
+      expect(body.hardware_id).toBe('hw-1')
+      expect(result.auth_device_id).toBe('dev-1')
+    })
+
+    it.skipIf(isLive)('rePairDevice surfaces non-2xx as API エラー (window 外 / cooldown 等)', async () => {
+      stubResponse(errResponse(404))
+      await expect(
+        rePairDevice({ device_id: SEED_DEVICE_ID }),
+      ).rejects.toThrow('API エラー (404)')
     })
 
     it('createDeviceUrlToken with opts', async () => {

--- a/web/tests/utils/webInstallId.test.ts
+++ b/web/tests/utils/webInstallId.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { getOrCreateWebInstallId } from '~/utils/webInstallId'
+
+describe('getOrCreateWebInstallId', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('generates and persists a new id on first call', () => {
+    const id = getOrCreateWebInstallId()
+    expect(id).toBeTruthy()
+    expect(localStorage.getItem('alc_web_install_id')).toBe(id)
+  })
+
+  it('returns the same id on subsequent calls', () => {
+    const first = getOrCreateWebInstallId()
+    const second = getOrCreateWebInstallId()
+    expect(second).toBe(first)
+  })
+})


### PR DESCRIPTION
## Summary

rust-alc-api#495 (kiosk 端末 re-pair) の PR3a/PR3b。バックエンド
(rust-alc-api#497/#498, auth-worker#345) は実装済みで、本 PR で alc-app 側の
フロントエンドを実装する。

**PR3a — 端末側:**
- `server/api/devices/re-pair.post.ts` — public ingest 経路
  (`createInternalIngestHandler`、認証不要。rust が auth-worker mint まで完結
  させるため alc-app 側での credential mint 処理は不要)
- `useAuth.reAuthenticateDevice()` — device credential を再取得し、
  `activateFromRegistration` と同じ保存先 (kiosk credential + Android native)
  に反映する。`hardware_id` は Android bridge の `getHardwareId()`
  (rust-alc-api#495 PR4/任意) があればそれを優先し、無ければ
  `utils/webInstallId.ts` (localStorage 永続の乱数) にフォールバックする
- `DeviceSettings.vue` — 「再認証」ボタン + 認証情報 取得済み/未取得 表示 +
  起動時 auto-retry (credential 欠落端末を管理者の window 発行だけで
  リモート復旧できるようにする)

**PR3b — 管理者側:**
- `api.ts` `authorizeRepair()` — テナント認証付き API (`request()` →
  `/api/proxy` 経由、既存 `approveDevice` 等と同パターン)
- `DeviceRegistrationManager.vue` — 端末一覧の各行に「再認証を許可」ボタン
  (window 残り時間をボタン上に表示) + `re_pair_count` / `last_re_pair_at`
  の履歴表示

## Test plan

- [x] `npm test` (全 1043 テスト、3 skipped) green
- [x] `node scripts/check_coverage_100.mjs` — `useAuth.ts` / `api.ts` 含む
      登録済み 29 ファイル全て 100% (branches 含む) green
- [x] 新規テスト: `reAuthenticateDevice` (deviceId 未登録 / 成功 / 非2xx /
      credential 欠落応答 / Android bridge 優先 / 旧 APK フォールバック /
      settings_token 付与 / fetch 例外) 8 パターン、`rePairDevice` /
      `authorizeRepair` の same-origin path 検証、`webInstallId` 永続化
- [ ] staging E2E (window 発行 → 端末 re-pair 成功 → `register-fcm-token`
      成功) は issue #495 Acceptance Criteria として backend PR 側の staging
      反映後に別途確認

Refs ippoan/rust-alc-api#495


---
_Generated by [Claude Code](https://claude.ai/code/session_01PxdPi54wqpvCzzFa65jEzt)_