### PR TITLE
fix: test.yml の pull_request paths に plan/** を追加

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,9 @@ on:
     # cf-alc-signaling/** も含める: signaling-only の PR (例: wrangler.toml の
     # account_id 追加) でも required check (ci / Vitest+Coverage, ci / PR Limit Check)
     # を発火させないと "2 expected checks" で永遠に blocked になるため (上記デッドロック)。
-    paths: ['web/**', '.claude/**', '.github/workflows/**', 'cf-alc-signaling/**']
+    # plan/** も含める: 設計ドキュメントのみの PR (#92) でも同じデッドロックを踏んだため
+    # (Refs #93)。
+    paths: ['web/**', '.claude/**', '.github/workflows/**', 'cf-alc-signaling/**', 'plan/**']
 
 permissions:
   contents: write


### PR DESCRIPTION
## 背景

`test.yml` の `pull_request.paths` フィルタに `plan/**` が含まれておらず、`plan/cores3-hub-consolidation.md` のみを変更するPR (#92) で CI ワークフロー自体がトリガーされず、required check (`ci / PR Limit Check`, `ci / Vitest + Coverage`) が一度も報告されないまま `mergeable_state: blocked` に固着した。

`.claude/**` / `.github/workflows/**` / `cf-alc-signaling/**` も過去に同じ理由で追加されてきた既知のデッドロックパターン(`test.yml` 自身のコメントに明記あり)。

## 修正

`paths` に `plan/**` を追加。

## 動作確認

- [x] YAML構文確認 (diffのみ、他ジョブへの影響なし)
- [ ] 本PR自身が `.github/workflows/**` に一致するため通常通りCIがトリガーされ、`plan/**` を単独で変更する将来のPRでもCIが発火することを確認 (このPRのmerge後、#92側で実地確認)

Refs #93


---
_Generated by [Claude Code](https://claude.ai/code/session_01W6g97ULXKMubffGiCFn3VF)_