### PR TITLE
feat: cf-alc-recorder に POST /measurements を追加 (Wi-Fi 客の上り経路)

### DIFF
--- a/.claude/skills/alc-app-map/SKILL.md
+++ b/.claude/skills/alc-app-map/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: alc-app-map
 generated-from: alc-app:3bdd4d0f02f9ad31ae0ef5b295aeed2cc98254ee
-paths: [web/, cf-alc-signaling/]
-description: yhonda-ohishi-alc/alc-app (業務用アルコールチェッカーシステム / 複合 repo) の構造ナビゲーション。タニタ FC-1200 + NFC + 顔認証による本人確認付きアルコール測定 + 遠隔点呼。web/ (Nuxt 4 PWA on Workers)・cf-alc-signaling/ (WebRTC signaling DO)・fc1200-wasm (秘匿) の区画、WebSerial/WebRTC/顔認証の composable 配置、秘匿ファイル・テストの gotcha を 1 枚にまとめる。トリガー:「alc-app」「アルコールチェッカー」「FC-1200」「fc1200」「点呼」「遠隔点呼」「顔認証」「NFC bridge」「WebRTC signaling」「cf-alc-signaling」「alc.ippoan.org」等。
+paths: [web/, cf-alc-signaling/, cf-alc-recorder/]
+description: yhonda-ohishi-alc/alc-app (業務用アルコールチェッカーシステム / 複合 repo) の構造ナビゲーション。タニタ FC-1200 + NFC + 顔認証による本人確認付きアルコール測定 + 遠隔点呼。web/ (Nuxt 4 PWA on Workers)・cf-alc-signaling/ (WebRTC signaling DO)・cf-alc-recorder/ (CoreS3 測定データ受口 DO)・fc1200-wasm (秘匿) の区画、WebSerial/WebRTC/顔認証の composable 配置、秘匿ファイル・テストの gotcha を 1 枚にまとめる。トリガー:「alc-app」「アルコールチェッカー」「FC-1200」「fc1200」「点呼」「遠隔点呼」「顔認証」「NFC bridge」「WebRTC signaling」「cf-alc-signaling」「cf-alc-recorder」「alc-recorder」「CoreS3 測定」「alc.ippoan.org」等。
 ---
 
 # alc-app-map — yhonda-ohishi-alc/alc-app 構造ナビゲーション
@@ -21,6 +21,7 @@ description: yhonda-ohishi-alc/alc-app (業務用アルコールチェッカー�
 |---|---|---|
 | **`web/`** | Nuxt 4 PWA (`app/` 構成) + `server/` + `wrangler.jsonc` | フロント本体 (Cloudflare Workers `cloudflare_module`)。下表参照 |
 | **`cf-alc-signaling/`** | `src/{index,signaling-room,room-registry}.ts` + `wrangler.toml` | WebRTC signaling worker。Durable Objects (Hibernatable WS) で SDP/ICE リレー。worker 名 `alc-signaling` |
+| **`cf-alc-recorder/`** | `src/{index,recorder-hub,auth,measurements}.ts` + `wrangler.toml` + `test/` | CoreS3 (alc-app-s3) 測定データ受口 worker (#106/#108)。上りは WS (`/ws`、テナント単位 DO `RecorderHub`) と Wi-Fi 客向け `POST /measurements` バッチ (#109、ステートレス) の 2 経路 — どちらも device JWT introspect (`device-hub` role) → auth-worker `/alc-internal-proxy` → rust-alc-api `POST /api/hub/measurements` に転送。下り command push は WS のみ。worker 名 `alc-recorder` |
 | **`fc1200-wasm/`** | (git ignored) Rust → WASM | FC-1200 RS232C プロトコル実装を WASM に compile して**ソース秘匿**。`web` から `fc1200-wasm` import |
 | **`docs/`** | mkdocs (`mkdocs.yml`, admin/ operator/) | 運用ドキュメント。`docs/*.pdf` = Tanita Confidential で **.gitignore** |
 | **`plan/`** | `implementation-plan.md` `initialplan.md` | 実装計画 |
@@ -48,6 +49,7 @@ description: yhonda-ohishi-alc/alc-app (業務用アルコールチェッカー�
 - **web nitro**: `web/nuxt.config.ts` → `nitro.preset = "cloudflare_module"`、`main = .output/server/index.mjs` (`web/wrangler.jsonc`)。`vite-plugin-wasm` + `optimizeDeps.exclude: ['fc1200-wasm']`。
 - **web wrangler (jsonc)**: top-level = prod (`alc-app`, alc.ippoan.org)。`env.staging` = `alc-app-staging` (alc-staging.ippoan.org)。`NUXT_PUBLIC_{API_BASE,GOOGLE_CLIENT_ID,AUTH_WORKER_URL,STAGING_TENANT_ID,SIGNALING_URL}` を env で切替。
 - **signaling**: `cf-alc-signaling/src/index.ts` (worker entry) → DO `SignalingRoom` (device/admin 2 ピア間リレー) + `RoomRegistry`。`wrangler.toml` に migration v1/v2、`BACKEND_API_URL` var。secret 不要 (STUN P2P のみ、TURN 後日)。
+- **recorder**: `cf-alc-recorder/src/index.ts` (worker entry)。`/ws` → introspect 後にテナント単位 DO `RecorderHub` (Hibernatable WS、identity は WS attachment) へ routing。`POST /measurements` → DO を経由せず Worker 直で検証 + ingest 転送 (`src/measurements.ts` を WS 経路と共有)。下り `POST /tenants/:t/devices/:d/command` 等は `INTERNAL_SHARED_SECRET` の内部 API。binding: `AUTH_WORKER` (service) + `INTERNAL_SHARED_SECRET` (Secrets Store)。prod/staging 2 面 (`env.staging`)。
 - **接続**: `NUXT_PUBLIC_SIGNALING_URL` に signaling worker URL。Room ID = `tenko_session_id`。
 
 ## gotcha
@@ -62,7 +64,7 @@ description: yhonda-ohishi-alc/alc-app (業務用アルコールチェッカー�
 ## CCoW/CI から見た立ち位置
 
 - rust-alc-api を叩く consumer 群の親玉 (carins / nuxt-trouble / nuxt_dtako_logs の兄弟だが最も大きい)。認証は `@ippoan/auth-client` + auth-worker (auth.ippoan.org)。
-- CI: `.github/workflows/{test,tag-release,docs}.yml`。test = `web/**` パス変更時 `npm ci` → `vitest run --coverage` → `check_coverage_100.mjs` → Job Summary/artifact。`docs.yml` = mkdocs。`coverage_100.toml` で 100% リグレッション検出。
+- CI: `.github/workflows/{test,tag-release,docs,recorder-deploy,signaling-deploy,skills-check}.yml`。test = `web/**` パス変更時 `npm ci` → `vitest run --coverage` → `check_coverage_100.mjs` → Job Summary/artifact。`recorder-deploy.yml` = cf-alc-recorder の vitest + deploy。`docs.yml` = mkdocs。`coverage_100.toml` で 100% リグレッション検出。
 - **main 直 push 禁止** (branch protection)。`gh pr merge --squash --auto` で CI 通過後 auto-merge (`enforce_admins: false`)。
 - `.claude/skills/` に repo 固有 skill (`next-session` `resume-session`) あり。`.githooks/` も。
 
@@ -85,6 +87,7 @@ description: yhonda-ohishi-alc/alc-app (業務用アルコールチェッカー�
 | `web/` | Nuxt 4 PWA フロントエンド (Cloudflare Workers) | このリポジトリ |
 | `fc1200-wasm/` | FC-1200 RS232C プロトコル WASM (ソース秘匿) | このリポジトリ |
 | `cf-alc-signaling/` | WebRTC シグナリング (Cloudflare Durable Objects + Hibernatable WS) | このリポジトリ |
+| `cf-alc-recorder/` | CoreS3 測定データ受口 (WS + POST バッチ → rust-alc-api 転送) | このリポジトリ |
 | `~/rust/rust-nfc-bridge/` | NFC リーダー → 仮想シリアルポート (Windows) | 別リポジトリ (symlink: alc-app) |
 | `~/rust/rust-alc-api/` | バックエンド API (GCP Cloud Run + PostgreSQL RLS) | 別リポジトリ (symlink: alc-app) |
 | `plan/` | 実装計画ドキュメント | このリポジトリ |
@@ -111,6 +114,7 @@ description: yhonda-ohishi-alc/alc-app (業務用アルコールチェッカー�
 - **cf-alc-signaling (Cloudflare Workers)**: `cd cf-alc-signaling && wrangler deploy`
   - URL: https://alc-signaling.m-tama-ramu.workers.dev
   - シークレット不要 (現在 STUN P2P のみ。TURN は後日対応予定)
+- **cf-alc-recorder (Cloudflare Workers)**: CI 経由 (`recorder-deploy.yml`: `npx vitest run` → staging / release deploy)。手動 fallback: `cd cf-alc-recorder && wrangler deploy`
 - **rust-alc-api (GCP Cloud Run)**: 別リポジトリで管理
 - **rust-nfc-bridge**: `v*` タグ push で GitHub Actions が自動リリース (Windows ビルド + MSI 作成 + GitHub Release にアップロード)
   - 手順: `Cargo.toml` の version を上げる → commit & push → `gh release create v0.x.x` → Actions が MSI を追加

--- a/cf-alc-recorder/src/index.ts
+++ b/cf-alc-recorder/src/index.ts
@@ -10,6 +10,9 @@
  *   - GET  /ws                                         … WS 受口 (Upgrade 必須)。
  *       `Authorization: Bearer <device JWT>` を auth-worker /auth/introspect で検証し、
  *       role=device-hub のみ accept → テナント単位の RecorderHub DO へ routing。
+ *   - POST /measurements                                … Wi-Fi 客の上りバッチ (#109)。
+ *       認証は /ws と同じ device JWT introspect。body は measurement の配列
+ *       (WS measurement frame と同形)。下りが無いためステートレス (DO 不要、Worker 直)。
  *   - POST /tenants/:tenantId/devices/:deviceId/command … 接続中デバイスへの下り push
  *   - GET  /tenants/:tenantId/devices                   … 接続中デバイス一覧 (debug)
  *   - GET  /tenants/:tenantId/commands/:id/result       … command_result の取得
@@ -23,6 +26,12 @@ import {
   introspectToken,
   resolveSecret,
 } from "./auth";
+import {
+  forwardMeasurements,
+  parseMeasurementItem,
+  type MeasurementInput,
+  type ParsedMeasurement,
+} from "./measurements";
 
 export { RecorderHub } from "./recorder-hub";
 
@@ -59,13 +68,22 @@ async function requireInternalAuth(request: Request, env: Env): Promise<Response
   return null;
 }
 
-/** WS ハンドシェイク: introspect → role/tenant 判定 → DO routing。 */
-async function handleWebSocket(request: Request, env: Env, url: URL): Promise<Response> {
-  if (request.headers.get("Upgrade")?.toLowerCase() !== "websocket") {
-    return new Response("Expected WebSocket. Use GET /ws with Upgrade header", {
-      status: 426,
-    });
-  }
+/** device JWT introspect の成功時 identity (+ 転送で再利用する shared secret)。 */
+interface DeviceAuth {
+  tenantId: string;
+  deviceId: string;
+  sharedSecret: string;
+}
+
+/**
+ * device JWT (Bearer) の認証 — /ws と /measurements の共通部。
+ * introspect → role/tenant 判定。NG 時はそのまま返せる Response を返す。
+ */
+async function authenticateDevice(
+  request: Request,
+  env: Env,
+  origin: string,
+): Promise<DeviceAuth | Response> {
   const token = bearerToken(request.headers.get("Authorization"));
   if (!token) {
     return json({ error: "missing_bearer_token" }, 401);
@@ -75,7 +93,7 @@ async function handleWebSocket(request: Request, env: Env, url: URL): Promise<Re
     return json({ error: "server_error" }, 503);
   }
   // origin は APP_TENANT_ACL の per-app 判定に使われる (auth-worker 側で allowlist)。
-  const result = await introspectToken(env.AUTH_WORKER, sharedSecret, token, url.origin);
+  const result = await introspectToken(env.AUTH_WORKER, sharedSecret, token, origin);
   if (result === null) {
     // introspect 自体が失敗 (binding 未設定 / shared secret 不一致 / 5xx)。
     return json({ error: "server_error" }, 503);
@@ -84,13 +102,83 @@ async function handleWebSocket(request: Request, env: Env, url: URL): Promise<Re
   if (decision.status !== 101) {
     return json({ error: decision.status === 403 ? "forbidden_role" : "invalid_token" }, decision.status);
   }
+  return { tenantId: decision.tenantId, deviceId: decision.deviceId, sharedSecret };
+}
+
+/** WS ハンドシェイク: introspect → role/tenant 判定 → DO routing。 */
+async function handleWebSocket(request: Request, env: Env, url: URL): Promise<Response> {
+  if (request.headers.get("Upgrade")?.toLowerCase() !== "websocket") {
+    return new Response("Expected WebSocket. Use GET /ws with Upgrade header", {
+      status: 426,
+    });
+  }
+  const auth = await authenticateDevice(request, env, url.origin);
+  if (auth instanceof Response) return auth;
 
   // identity は introspect 済み claims から内部ヘッダーで DO に渡す (client 由来の
   // 同名ヘッダーが混ざらないよう必ず上書きする)。
   const fwd = new Request("https://recorder-hub.internal/connect", request);
-  fwd.headers.set("X-Recorder-Tenant-Id", decision.tenantId);
-  fwd.headers.set("X-Recorder-Device-Id", decision.deviceId);
-  return hubStub(env, decision.tenantId).fetch(fwd);
+  fwd.headers.set("X-Recorder-Tenant-Id", auth.tenantId);
+  fwd.headers.set("X-Recorder-Device-Id", auth.deviceId);
+  return hubStub(env, auth.tenantId).fetch(fwd);
+}
+
+/** POST /measurements 1 リクエストの item 数上限 (WS の 64KB message 上限に相当する暴走ガード)。 */
+const MAX_BATCH_ITEMS = 100;
+
+/**
+ * POST /measurements — Wi-Fi 客の上りバッチ (Refs ippoan/alc-app#109)。
+ *
+ * 1 件でも不正な item があれば batch ごと 400 で reject する (端末は同じ batch を
+ * 再送する。同 seq 再送は rust 側 `UNIQUE (tenant, device, seq)` が冪等に吸収)。
+ * 成功時は受理した seq の一覧を返す (デバイスの ack 消し込み用)。
+ */
+async function handleMeasurementsPost(request: Request, env: Env, url: URL): Promise<Response> {
+  const auth = await authenticateDevice(request, env, url.origin);
+  if (auth instanceof Response) return auth;
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return json({ error: "invalid_json" }, 400);
+  }
+  if (!Array.isArray(body)) {
+    return json({ error: "invalid_body" }, 400);
+  }
+  if (body.length > MAX_BATCH_ITEMS) {
+    return json({ error: "too_many_items" }, 400);
+  }
+
+  const items: ParsedMeasurement[] = [];
+  for (let i = 0; i < body.length; i++) {
+    const entry: unknown = body[i];
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      return json({ error: "invalid_item", index: i }, 400);
+    }
+    const parsed = parseMeasurementItem(entry as MeasurementInput);
+    if (!parsed.ok) {
+      return json({ error: parsed.error, index: i }, 400);
+    }
+    items.push(parsed.item);
+  }
+  if (items.length === 0) {
+    // 空バッチは上流を叩かず即 accept (デバイス側の送信キュー空振り)。
+    return json({ accepted: [] });
+  }
+
+  const result = await forwardMeasurements(
+    env.AUTH_WORKER,
+    auth.sharedSecret,
+    auth.tenantId,
+    auth.deviceId,
+    items,
+  );
+  if (!result.ok) {
+    // 詳細 (上流 body) は echo しない。端末は同じ batch を再送できる。
+    return json({ error: result.error }, 502);
+  }
+  return json({ accepted: items.map((item) => item.seq) });
 }
 
 export default {
@@ -103,6 +191,10 @@ export default {
 
     if (url.pathname === "/ws") {
       return handleWebSocket(request, env, url);
+    }
+
+    if (url.pathname === "/measurements" && request.method === "POST") {
+      return handleMeasurementsPost(request, env, url);
     }
 
     // ── 下り: 内部 HTTP API (shared secret 認証) ────────────────────────────

--- a/cf-alc-recorder/src/measurements.ts
+++ b/cf-alc-recorder/src/measurements.ts
@@ -1,0 +1,120 @@
+/**
+ * measurement の検証 + ingest 転送 — WS 経路 (recorder-hub.ts) と
+ * `POST /measurements` (Wi-Fi 客の上り、index.ts) の共有部 (Refs ippoan/alc-app#109)。
+ *
+ * tenant_id / device_id は introspect 済み JWT claims からの注入のみ — ペイロード内の
+ * 同名 field は信用しない (WS 経路と同じ原則)。
+ */
+
+/** 上り measurement 1 件 (JSON parse 後、field は全て untrusted)。 */
+export interface MeasurementInput {
+  seq?: unknown;
+  recorded_at_ms?: unknown;
+  kind?: unknown;
+  payload?: unknown;
+}
+
+/** 検証済み measurement (ingest 転送形。device_id は転送時に注入する)。 */
+export interface ParsedMeasurement {
+  seq: number;
+  kind: string;
+  recorded_at_ms: number | null;
+  payload: Record<string, unknown>;
+}
+
+export type ParseMeasurementResult =
+  | { ok: true; item: ParsedMeasurement }
+  | { ok: false; error: "invalid_seq" | "invalid_payload" | "missing_kind"; seq?: number };
+
+/**
+ * measurement 1 件を検証する (WS frame / POST body の item 共通)。
+ *
+ * - seq: 有限数値必須 (ack / 冪等キーの要)
+ * - payload: 非配列 object 必須
+ * - kind: トップレベル優先、無ければ ble-medical-gateway 互換 JSON の `payload.type` に
+ *   fallback。enum 検証は rust 側 (source of truth) に任せ、ここでは空でないことだけ確認
+ * - recorded_at_ms: 数値以外は null (サーバ受信時刻扱いは rust 側)
+ */
+export function parseMeasurementItem(msg: MeasurementInput): ParseMeasurementResult {
+  const seq = msg.seq;
+  if (typeof seq !== "number" || !Number.isFinite(seq)) {
+    return { ok: false, error: "invalid_seq" };
+  }
+  const payload =
+    msg.payload && typeof msg.payload === "object" && !Array.isArray(msg.payload)
+      ? (msg.payload as Record<string, unknown>)
+      : null;
+  if (!payload) {
+    return { ok: false, error: "invalid_payload", seq };
+  }
+  const kind =
+    typeof msg.kind === "string" && msg.kind
+      ? msg.kind
+      : typeof payload.type === "string" && payload.type
+        ? payload.type
+        : "";
+  if (!kind) {
+    return { ok: false, error: "missing_kind", seq };
+  }
+  const recordedAtMs =
+    typeof msg.recorded_at_ms === "number" && Number.isFinite(msg.recorded_at_ms)
+      ? msg.recorded_at_ms
+      : null;
+  return { ok: true, item: { seq, kind, recorded_at_ms: recordedAtMs, payload } };
+}
+
+/**
+ * service binding fetch は host を無視するが、path が auth-worker 側 route
+ * (`/alc-internal-proxy/...`) と一致する必要がある (web/server/utils/internal-proxy.ts と同形)。
+ */
+export const INGEST_URL =
+  "https://alc-internal-proxy.internal/alc-internal-proxy/api/hub/measurements";
+
+export type ForwardResult = { ok: true } | { ok: false; error: string };
+
+/**
+ * 検証済み measurement を auth-worker `/alc-internal-proxy` 経由で rust-alc-api
+ * `POST /api/hub/measurements` へ転送する。tenant_id は X-Tenant-ID ヘッダー、
+ * device_id は item に注入する。
+ * 失敗時の詳細 (body) は caller の response に echo しない。log にのみ残す。
+ */
+export async function forwardMeasurements(
+  authWorker: Fetcher,
+  sharedSecret: string,
+  tenantId: string,
+  deviceId: string,
+  items: ParsedMeasurement[],
+): Promise<ForwardResult> {
+  const body = items.map((item) => ({
+    device_id: deviceId,
+    kind: item.kind,
+    seq: item.seq,
+    recorded_at_ms: item.recorded_at_ms,
+    payload: item.payload,
+  }));
+  let res: Response;
+  try {
+    res = await authWorker.fetch(INGEST_URL, {
+      method: "POST",
+      headers: {
+        "X-Alc-Proxy-Secret": sharedSecret,
+        "X-Tenant-ID": tenantId,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+  } catch (e) {
+    console.log(
+      `[measurement] upstream unreachable tenant=${tenantId} device=${deviceId} n=${items.length}`,
+      e,
+    );
+    return { ok: false, error: "upstream_unreachable" };
+  }
+  if (!res.ok) {
+    console.log(
+      `[measurement] upstream ${res.status} tenant=${tenantId} device=${deviceId} n=${items.length}`,
+    );
+    return { ok: false, error: `upstream_${res.status}` };
+  }
+  return { ok: true };
+}

--- a/cf-alc-recorder/src/recorder-hub.ts
+++ b/cf-alc-recorder/src/recorder-hub.ts
@@ -1,6 +1,7 @@
 import { DurableObject } from "cloudflare:workers";
 import type { Env } from "./index";
 import { resolveSecret } from "./auth";
+import { forwardMeasurements, parseMeasurementItem } from "./measurements";
 
 /**
  * RecorderHub — テナント単位の Durable Object (Hibernatable WebSockets)。
@@ -53,13 +54,6 @@ const CMD_RESULT_TTL_MS = 10 * 60 * 1000;
 
 /** 上り 1 メッセージの上限 (これ以上は parse せず reject)。 */
 const MAX_MESSAGE_BYTES = 64 * 1024;
-
-/**
- * service binding fetch は host を無視するが、path が auth-worker 側 route
- * (`/alc-internal-proxy/...`) と一致する必要がある (web/server/utils/internal-proxy.ts と同形)。
- */
-const INGEST_URL =
-  "https://alc-internal-proxy.internal/alc-internal-proxy/api/hub/measurements";
 
 function json(data: unknown, status = 200): Response {
   return new Response(JSON.stringify(data), {
@@ -191,36 +185,18 @@ export class RecorderHub extends DurableObject<Env> {
     attachment: WsAttachment,
     msg: InboundMessage,
   ): Promise<void> {
-    const seq = msg.seq;
-    if (typeof seq !== "number" || !Number.isFinite(seq)) {
-      this.send(ws, { type: "error", message: "invalid_seq" });
+    // 検証 + 転送は POST /measurements (Wi-Fi 客の上り) と共有 (measurements.ts)。
+    const parsed = parseMeasurementItem(msg);
+    if (!parsed.ok) {
+      this.send(
+        ws,
+        parsed.seq !== undefined
+          ? { type: "error", seq: parsed.seq, message: parsed.error }
+          : { type: "error", message: parsed.error },
+      );
       return;
     }
-    const payload =
-      msg.payload && typeof msg.payload === "object" && !Array.isArray(msg.payload)
-        ? (msg.payload as Record<string, unknown>)
-        : null;
-    if (!payload) {
-      this.send(ws, { type: "error", seq, message: "invalid_payload" });
-      return;
-    }
-    // kind はトップレベル優先、無ければ ble-medical-gateway 互換 JSON の `type` に
-    // fallback (temperature / blood_pressure / alcohol / fc1200_raw)。enum 検証は
-    // rust 側 (source of truth) に任せ、ここでは空でないことだけ確認する。
-    const kind =
-      typeof msg.kind === "string" && msg.kind
-        ? msg.kind
-        : typeof payload.type === "string" && payload.type
-          ? payload.type
-          : "";
-    if (!kind) {
-      this.send(ws, { type: "error", seq, message: "missing_kind" });
-      return;
-    }
-    const recordedAtMs =
-      typeof msg.recorded_at_ms === "number" && Number.isFinite(msg.recorded_at_ms)
-        ? msg.recorded_at_ms
-        : null;
+    const seq = parsed.item.seq;
 
     const sharedSecret = await resolveSecret(this.env.INTERNAL_SHARED_SECRET);
     if (!sharedSecret) {
@@ -228,40 +204,17 @@ export class RecorderHub extends DurableObject<Env> {
       return;
     }
 
-    // tenant_id は X-Tenant-ID ヘッダー、device_id は item に注入 — どちらも
-    // introspect 済み JWT claims 由来 (ペイロード内の同名 field は使わない)。
-    const item = {
-      device_id: attachment.deviceId,
-      kind,
-      seq,
-      recorded_at_ms: recordedAtMs,
-      payload,
-    };
-    let res: Response;
-    try {
-      res = await this.env.AUTH_WORKER.fetch(INGEST_URL, {
-        method: "POST",
-        headers: {
-          "X-Alc-Proxy-Secret": sharedSecret,
-          "X-Tenant-ID": attachment.tenantId,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify([item]),
-      });
-    } catch (e) {
-      console.log(
-        `[measurement] upstream unreachable tenant=${attachment.tenantId} device=${attachment.deviceId} seq=${seq}`,
-        e,
-      );
-      this.send(ws, { type: "error", seq, message: "upstream_unreachable" });
-      return;
-    }
-    if (!res.ok) {
+    // tenant_id / device_id は WS attachment (= introspect 済み JWT claims) から注入。
+    const result = await forwardMeasurements(
+      this.env.AUTH_WORKER,
+      sharedSecret,
+      attachment.tenantId,
+      attachment.deviceId,
+      [parsed.item],
+    );
+    if (!result.ok) {
       // 詳細 (body) は response に echo しない。status のみ端末へ返し log に残す。
-      console.log(
-        `[measurement] upstream ${res.status} tenant=${attachment.tenantId} device=${attachment.deviceId} seq=${seq}`,
-      );
-      this.send(ws, { type: "error", seq, message: `upstream_${res.status}` });
+      this.send(ws, { type: "error", seq, message: result.error });
       return;
     }
     this.send(ws, { type: "ack", seq });

--- a/cf-alc-recorder/test/recorder.test.ts
+++ b/cf-alc-recorder/test/recorder.test.ts
@@ -240,6 +240,137 @@ describe("measurement → ingest 転送 → ack", () => {
   });
 });
 
+describe("POST /measurements (Wi-Fi 客の上りバッチ)", () => {
+  /** POST /measurements を投げるヘルパー。 */
+  async function postMeasurements(body: unknown, token?: string): Promise<Response> {
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    if (token) headers.Authorization = `Bearer ${token}`;
+    return SELF.fetch(`${BASE}/measurements`, {
+      method: "POST",
+      headers,
+      body: typeof body === "string" ? body : JSON.stringify(body),
+    });
+  }
+
+  it("認証は /ws と同じ: Bearer なし 401 / active:false 401 / kiosk role 403", async () => {
+    expect((await postMeasurements([])).status).toBe(401);
+    expect((await postMeasurements([], "expired-token")).status).toBe(401);
+    const res = await postMeasurements([], "kiosk-token");
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: "forbidden_role" });
+  });
+
+  it("バッチを 1 回の ingest で転送し、受理 seq 一覧を返す。tenant/device は JWT claims から注入", async () => {
+    const res = await postMeasurements(
+      [
+        {
+          seq: 1,
+          recorded_at_ms: 1752300000000,
+          payload: {
+            type: "temperature",
+            value: 36.5,
+            // ペイロード側の識別子は無視される (詐称不可)
+            device_id: "spoofed-device",
+            tenant_id: "spoofed-tenant",
+          },
+        },
+        { seq: 2, kind: "alcohol", payload: { value: 0.0 } },
+      ],
+      "hub-token-1",
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ accepted: [1, 2] });
+
+    const calls = await spyIngest();
+    expect(calls.length).toBe(1);
+    expect(calls[0].tenantId).toBe("tenant-1");
+    expect(calls[0].items.length).toBe(2);
+    // device_id は JWT の sub、kind はトップレベル優先 / payload.type fallback
+    expect(calls[0].items[0].device_id).toBe("device-1");
+    expect(calls[0].items[0].kind).toBe("temperature");
+    expect(calls[0].items[0].recorded_at_ms).toBe(1752300000000);
+    expect(calls[0].items[1].kind).toBe("alcohol");
+    expect(calls[0].items[1].recorded_at_ms).toBeNull();
+    expect((calls[0].items[0].payload as Record<string, unknown>).value).toBe(36.5);
+  });
+
+  it("同じ seq の再送も accept される (重複排除は rust 側 UNIQUE で冪等)", async () => {
+    const batch = [{ seq: 7, kind: "alcohol", payload: { value: 0.0 } }];
+    expect((await postMeasurements(batch, "hub-token-1")).status).toBe(200);
+    expect((await postMeasurements(batch, "hub-token-1")).status).toBe(200);
+    expect((await spyIngest()).length).toBe(2);
+  });
+
+  it("不正 body は 400: invalid JSON / 非配列 / 上限超過", async () => {
+    const invalid = await postMeasurements("not-json{", "hub-token-1");
+    expect(invalid.status).toBe(400);
+    expect(await invalid.json()).toEqual({ error: "invalid_json" });
+
+    const nonArray = await postMeasurements({ seq: 1 }, "hub-token-1");
+    expect(nonArray.status).toBe(400);
+    expect(await nonArray.json()).toEqual({ error: "invalid_body" });
+
+    const tooMany = await postMeasurements(
+      Array.from({ length: 101 }, (_, i) => ({ seq: i, kind: "alcohol", payload: {} })),
+      "hub-token-1",
+    );
+    expect(tooMany.status).toBe(400);
+    expect(await tooMany.json()).toEqual({ error: "too_many_items" });
+
+    expect(await spyIngest()).toEqual([]);
+  });
+
+  it("1 件でも不正な item があれば batch ごと 400 (index 付き)、ingest は呼ばれない", async () => {
+    const cases: Array<{ body: unknown[]; error: string; index: number }> = [
+      { body: ["str"], error: "invalid_item", index: 0 },
+      { body: [{ seq: "x", payload: {} }], error: "invalid_seq", index: 0 },
+      {
+        body: [
+          { seq: 1, kind: "alcohol", payload: {} },
+          { seq: 2, payload: "str" },
+        ],
+        error: "invalid_payload",
+        index: 1,
+      },
+      { body: [{ seq: 3, payload: { value: 1 } }], error: "missing_kind", index: 0 },
+    ];
+    for (const c of cases) {
+      const res = await postMeasurements(c.body, "hub-token-1");
+      expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({ error: c.error, index: c.index });
+    }
+    expect(await spyIngest()).toEqual([]);
+  });
+
+  it("空バッチは上流を叩かず accepted:[] を返す", async () => {
+    const res = await postMeasurements([], "hub-token-1");
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ accepted: [] });
+    expect(await spyIngest()).toEqual([]);
+  });
+
+  it("上流エラー時は 502 (詳細は echo しない)。端末は同じ batch を再送できる", async () => {
+    const res = await postMeasurements(
+      [{ seq: 2, kind: "boom", payload: { x: 1 } }],
+      "hub-token-1",
+    );
+    expect(res.status).toBe(502);
+    expect(await res.json()).toEqual({ error: "upstream_500" });
+
+    const retry = await postMeasurements(
+      [{ seq: 2, kind: "alcohol", payload: { x: 1 } }],
+      "hub-token-1",
+    );
+    expect(retry.status).toBe(200);
+    expect(await retry.json()).toEqual({ accepted: [2] });
+  });
+
+  it("GET /measurements は 404 (POST のみ)", async () => {
+    const res = await SELF.fetch(`${BASE}/measurements`);
+    expect(res.status).toBe(404);
+  });
+});
+
 describe("下り command push / command_result", () => {
   it("接続中デバイスへ command を push し、command_result を取得できる", async () => {
     const { ws, messages } = await connectAccepted("hub-token-tenant-cmd");


### PR DESCRIPTION
## 概要

測定データ上り経路の transport 分岐設計 (ippoan/alc-app-s3#25) のうち、Wi-Fi 客向けのステートレスな POST バッチ受口を cf-alc-recorder に追加する。

Closes #109

## 変更内容

- **`POST /measurements`** を追加
  - 認証は `/ws` と同じ: `Authorization: Bearer <device JWT>` → auth-worker `/auth/introspect` (`device-hub` role のみ)。共通部を `authenticateDevice()` に抽出
  - body は measurement の配列 (`{seq, recorded_at_ms?, kind?, payload}` — WS measurement フレームと同形)
  - introspect 済み claims (tenant_id / sub) を注入して auth-worker `/alc-internal-proxy` → rust-alc-api `POST /api/hub/measurements` へ 1 回の呼び出しで転送 — ペイロード内の識別子は信用しない (WS と同じ原則)
  - **DO 不要** (下りが無いのでステートレス、Worker 直で処理)
- **`src/measurements.ts`** を新設: item 検証 (`parseMeasurementItem`) + ingest 転送 (`forwardMeasurements`) を RecorderHub (WS 経路) と共有。error 名 (`invalid_seq` / `invalid_payload` / `missing_kind` / `upstream_*`) は WS と同一
- レスポンス: 受理した seq の一覧 `{accepted: [..]}` (デバイスの ack 消し込み用)
  - 1 件でも不正な item は batch ごと `400 {error, index}` — 端末は同 batch を再送、rust 側 `UNIQUE (tenant, device, seq)` が冪等に吸収
  - 上流エラーは 502 (詳細 body は echo しない)
  - 暴走ガード: 100 item / batch 上限
- test/recorder.test.ts に POST 経路のテスト 8 件を追加 (認証 3 態 / バッチ転送 + claims 注入 / 冪等再送 / 不正 body / 不正 item / 空バッチ / 上流 500 / メソッド制限)
- alc-app-map skill に cf-alc-recorder 区画を追加 (map-check 追従、#108 新設時の未更新分も含む)

## テスト

- 新規 8 件を含む非 DO テストは全てローカルでパス
- WS/DO 系 13 件はローカル (Windows) では既存の `SQLITE_CANTOPEN` 環境問題により main でも同様に落ちるため、CI (Linux) で検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)