### PR TITLE
chore(deps): @ippoan/auth-client を ^0.2.105 へ (login ループ #377 取込, Refs ippoan/auth-worker#379)

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -15,7 +15,7 @@
     "test:e2e": "playwright test"
   },
   "dependencies": {
-    "@ippoan/auth-client": "^0.2.78",
+    "@ippoan/auth-client": "^0.2.105",
     "@nuxtjs/tailwindcss": "^6.14.0",
     "@vite-pwa/nuxt": "^1.1.1",
     "@vladmandic/human": "^3.3.6",


### PR DESCRIPTION
## 概要

`#379` の初回 bump（8 consumer）で **`web/` 配下の alc-app を取りこぼしていた**分。auth-worker #377（毒 cookie で戻ったら reauth = login ループ回避）を含む `@ippoan/auth-client@0.2.105` を floor に指定する。

## 背景

alc-app だけ `^0.2.78` のままで #377 未反映だった（他 8 consumer は `^0.2.105` 反映済み）。`install_command: npm install` のため次回 deploy で 0.2.105 に再解決される。

## 変更
- `web/package.json`: `@ippoan/auth-client` を `^0.2.105` に更新

以後の auth-client release は auth-worker #382 の propagate 配線で alc-app にも自動 bump PR が作成されるため、この取りこぼしは再発しません。

Refs ippoan/auth-worker#379, ippoan/auth-worker#377

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LkS7MFMf5zLWaBF3kU5Hv8)_