### PR TITLE
feat(recorder): device-print role を受理 — 印刷ブリッジの WS 遠隔管理を可能に

### DIFF
--- a/.claude/skills/alc-app-map/SKILL.md
+++ b/.claude/skills/alc-app-map/SKILL.md
@@ -21,7 +21,7 @@ description: yhonda-ohishi-alc/alc-app (業務用アルコールチェッカー�
 |---|---|---|
 | **`web/`** | Nuxt 4 PWA (`app/` 構成) + `server/` + `wrangler.jsonc` | フロント本体 (Cloudflare Workers `cloudflare_module`)。下表参照 |
 | **`cf-alc-signaling/`** | `src/{index,signaling-room,room-registry}.ts` + `wrangler.toml` | WebRTC signaling worker。Durable Objects (Hibernatable WS) で SDP/ICE リレー。worker 名 `alc-signaling` |
-| **`cf-alc-recorder/`** | `src/{index,recorder-hub,auth,measurements}.ts` + `wrangler.toml` + `test/` | CoreS3 (alc-app-s3) 測定データ受口 worker (#106/#108)。上りは WS (`/ws`、テナント単位 DO `RecorderHub`) と Wi-Fi 客向け `POST /measurements` バッチ (#109、ステートレス) の 2 経路 — どちらも device JWT introspect (`device-hub` role) → auth-worker `/alc-internal-proxy` → rust-alc-api `POST /api/hub/measurements` に転送。下り command push は WS のみ。worker 名 `alc-recorder` |
+| **`cf-alc-recorder/`** | `src/{index,recorder-hub,auth,measurements}.ts` + `wrangler.toml` + `test/` | CoreS3 (alc-app-s3) 測定データ受口 worker (#106/#108)。上りは WS (`/ws`、テナント単位 DO `RecorderHub`) と Wi-Fi 客向け `POST /measurements` バッチ (#109、ステートレス) の 2 経路 — どちらも device JWT introspect (role allowlist: `device-hub` = CoreS3 / `device-print` = AtomS3 印刷ブリッジ ippoan/alc-app-s3#38。他 role は 403) → auth-worker `/alc-internal-proxy` → rust-alc-api `POST /api/hub/measurements` に転送。下り command push は WS のみ。worker 名 `alc-recorder` |
 | **`fc1200-wasm/`** | (git ignored) Rust → WASM | FC-1200 RS232C プロトコル実装を WASM に compile して**ソース秘匿**。`web` から `fc1200-wasm` import |
 | **`docs/`** | mkdocs (`mkdocs.yml`, admin/ operator/) | 運用ドキュメント。`docs/*.pdf` = Tanita Confidential で **.gitignore** |
 | **`plan/`** | `implementation-plan.md` `initialplan.md` | 実装計画 |

--- a/cf-alc-recorder/src/auth.ts
+++ b/cf-alc-recorder/src/auth.ts
@@ -29,8 +29,21 @@ export interface RecorderAuthDecision {
   deviceId: string;
 }
 
-/** CoreS3 組み込みハブ専用 role (auth-worker src/lib/device.ts の allowlist に追加、#363)。 */
+/** CoreS3 組み込みハブ role (auth-worker src/lib/device.ts の allowlist、#363)。 */
 export const DEVICE_ROLE_HUB = "device-hub";
+
+/** AtomS3 印刷ブリッジ role (ippoan/alc-app-s3#38。下り print/ota command の待受に WS 接続する)。 */
+export const DEVICE_ROLE_PRINT = "device-print";
+
+/**
+ * recorder への接続を許可する device role の allowlist。
+ * kiosk / uploader 等の他 role は従来どおり 403 (blast radius 分離) —
+ * 広げるのは「recorder の下り command で遠隔管理したいデバイス」だけ。
+ */
+export const RECORDER_DEVICE_ROLES: ReadonlySet<string> = new Set([
+  DEVICE_ROLE_HUB,
+  DEVICE_ROLE_PRINT,
+]);
 
 /** Secrets Store binding (`.get()`) / 文字列 のいずれでも値を取り出す。 */
 export async function resolveSecret(binding: unknown): Promise<string | null> {
@@ -86,7 +99,8 @@ export async function introspectToken(
  * introspect 結果から WS ハンドシェイクの可否を決める (純粋関数)。
  *
  * - `active` でない (署名不正 / exp 切れ / env 不一致 / ACL 不許可テナント) → 401
- * - role が `device-hub` 以外 (kiosk / uploader 等) → 403 (blast radius 分離)
+ * - role が allowlist (device-hub / device-print) 以外 (kiosk / uploader 等) →
+ *   403 (blast radius 分離)
  * - tenant_id / sub (device_id) 欠落 → 401 (identity 注入に必須なので fail-closed)
  */
 export function decideRecorderAuth(
@@ -95,7 +109,7 @@ export function decideRecorderAuth(
   if (!result || result.active !== true || !result.tenant_id || !result.sub) {
     return { status: 401, tenantId: "", deviceId: "" };
   }
-  if (result.role !== DEVICE_ROLE_HUB) {
+  if (typeof result.role !== "string" || !RECORDER_DEVICE_ROLES.has(result.role)) {
     return { status: 403, tenantId: "", deviceId: "" };
   }
   return { status: 101, tenantId: result.tenant_id, deviceId: result.sub };

--- a/cf-alc-recorder/test/recorder.test.ts
+++ b/cf-alc-recorder/test/recorder.test.ts
@@ -119,6 +119,17 @@ describe("ハンドシェイク認証 (introspect)", () => {
     ).toBe(401);
     expect(decideRecorderAuth(null).status).toBe(401);
   });
+
+  it("decideRecorderAuth: allowlist role の判定 (hub/print は 101、他は 403)", () => {
+    const claims = { active: true, tenant_id: "t", sub: "d" };
+    // AtomS3 印刷ブリッジ (ippoan/alc-app-s3#38) — 下り print/ota command 待受
+    expect(decideRecorderAuth({ ...claims, role: "device-print" }).status).toBe(101);
+    expect(decideRecorderAuth({ ...claims, role: "device-hub" }).status).toBe(101);
+    // blast radius 分離: 他 role・role 欠落は従来どおり 403
+    expect(decideRecorderAuth({ ...claims, role: "device-kiosk" }).status).toBe(403);
+    expect(decideRecorderAuth({ ...claims, role: "device-uploader" }).status).toBe(403);
+    expect(decideRecorderAuth({ ...claims }).status).toBe(403);
+  });
 });
 
 describe("measurement → ingest 転送 → ack", () => {


### PR DESCRIPTION
## 概要

AtomS3 印刷ブリッジ ([ippoan/alc-app-s3#38](https://github.com/ippoan/alc-app-s3/issues/38)) が下り print/ota command を待ち受けるために cf-alc-recorder へ WS 接続できるよう、`decideRecorderAuth` の role 判定を `device-hub` 単独一致から **allowlist (`device-hub` / `device-print`)** に広げる。

- kiosk / uploader 等の他 role は従来どおり 403 — blast radius 分離の方針は維持し、広げるのは「recorder の下り command で遠隔管理したいデバイス」のみ
- 下り command API (shared secret 認証) は role 非依存のため変更なし

## 関連 PR (3 repo 連携)

- firmware: [ippoan/alc-app-s3#42](https://github.com/ippoan/alc-app-s3/pull/42) (AUTH/WS コマンド + LAN 対応 WS 常時接続) — マージ済み想定
- auth-worker: device-print role 追加 + /device/setup 機種分離 (次 PR)

## テスト

純粋関数 `decideRecorderAuth` に allowlist 判定ケースを追加 (hub/print → 101、kiosk/uploader/role 欠落 → 403)。

※ ローカル (Windows) は miniflare DO SQLite の既知環境問題で DO 接続系 13 件が **main でも branch でも同様に**落ちるため、差分は新テスト +1 passed のみ。全件は CI (Linux) で検証。

🤖 Generated with [Claude Code](https://claude.com/claude-code)