### PR TITLE
feat(recorder): device/setup ページの live update 用 SSE を追加

### DIFF
--- a/cf-alc-recorder/src/index.ts
+++ b/cf-alc-recorder/src/index.ts
@@ -15,6 +15,8 @@
  *       (WS measurement frame と同形)。下りが無いためステートレス (DO 不要、Worker 直)。
  *   - POST /tenants/:tenantId/devices/:deviceId/command … 接続中デバイスへの下り push
  *   - GET  /tenants/:tenantId/devices                   … 接続中デバイス一覧 (debug)
+ *   - GET  /tenants/:tenantId/events                    … 接続中デバイス一覧の SSE push
+ *     (auth-worker /device/setup/events が透過。接続/切断のたびに `devices` event を配信)
  *   - GET  /tenants/:tenantId/commands/:id/result       … command_result の取得
  *     (下り 3 endpoint は `Authorization: <INTERNAL_SHARED_SECRET>` の内部 API。
  *      auth-worker /auth/introspect と同じ server-to-server shared secret 認証)
@@ -219,6 +221,15 @@ export default {
       if (denied) return denied;
       return hubStub(env, decodeURIComponent(devicesMatch[1])).fetch(
         "https://recorder-hub.internal/devices",
+      );
+    }
+
+    const eventsMatch = url.pathname.match(/^\/tenants\/([^/]+)\/events$/);
+    if (eventsMatch && request.method === "GET") {
+      const denied = await requireInternalAuth(request, env);
+      if (denied) return denied;
+      return hubStub(env, decodeURIComponent(eventsMatch[1])).fetch(
+        "https://recorder-hub.internal/events",
       );
     }
 

--- a/cf-alc-recorder/src/recorder-hub.ts
+++ b/cf-alc-recorder/src/recorder-hub.ts
@@ -25,6 +25,13 @@ import { forwardMeasurements, parseMeasurementItem } from "./measurements";
  *
  * Hibernation 復帰: 接続 identity は in-memory に持たず、毎メッセージ
  * `ws.deserializeAttachment()` から読む (= 復帰後も転送先 tenant/device が壊れない)。
+ *
+ * 下り (server → browser、device/setup ページの live update、Refs auth-worker
+ * live update 要望): `GET /events` は SSE で接続中デバイス一覧の変化を push する。
+ * `sseControllers` は in-memory (DO storage 非永続) — SSE は接続維持中しか
+ * hibernation しない (ハンドラの fetch が生きている間は isolate も生きる) ため
+ * 一覧を毎回 `getWebSockets()` から再計算すれば問題ない。SSE 接続自体が切れたら
+ * (タブを閉じる等) controller を配列から外すだけで DO 側の状態は増えない。
  */
 
 /** WS attachment。hibernation を跨いで identity を保持する。 */
@@ -63,6 +70,9 @@ function json(data: unknown, status = 200): Response {
 }
 
 export class RecorderHub extends DurableObject<Env> {
+  /** 接続中の SSE クライアント (`/events`)。DO storage には持たない (in-memory のみ)。 */
+  private readonly sseControllers = new Set<ReadableStreamDefaultController<Uint8Array>>();
+
   constructor(ctx: DurableObjectState, env: Env) {
     super(ctx, env);
     // keepalive ping は hibernation を起こさず runtime が応答する (文字列完全一致)。
@@ -90,6 +100,9 @@ export class RecorderHub extends DurableObject<Env> {
     }
     if (url.pathname === "/devices" && request.method === "GET") {
       return this.handleDevices();
+    }
+    if (url.pathname === "/events" && request.method === "GET") {
+      return this.handleEvents();
     }
     const resultMatch = url.pathname.match(/^\/command-result\/([^/]+)$/);
     if (resultMatch && request.method === "GET") {
@@ -125,6 +138,7 @@ export class RecorderHub extends DurableObject<Env> {
     const attachment: WsAttachment = { tenantId, deviceId };
     pair[1].serializeAttachment(attachment);
     this.send(pair[1], { type: "connected" });
+    this.broadcastDevices();
 
     return new Response(null, { status: 101, webSocket: pair[0] });
   }
@@ -172,6 +186,7 @@ export class RecorderHub extends DurableObject<Env> {
 
   async webSocketClose(ws: WebSocket, code: number, reason: string, _wasClean: boolean): Promise<void> {
     ws.close(code, reason);
+    this.broadcastDevices();
   }
 
   async webSocketError(ws: WebSocket, _error: unknown): Promise<void> {
@@ -282,13 +297,60 @@ export class RecorderHub extends DurableObject<Env> {
     return json({ id, delivered: sockets.length }, 202);
   }
 
-  private handleDevices(): Response {
+  private currentDeviceIds(): string[] {
     const ids = new Set<string>();
     for (const ws of this.ctx.getWebSockets()) {
       const attachment = ws.deserializeAttachment() as WsAttachment | null;
       if (attachment?.deviceId) ids.add(attachment.deviceId);
     }
-    return json({ devices: [...ids].sort() });
+    return [...ids].sort();
+  }
+
+  private handleDevices(): Response {
+    return json({ devices: this.currentDeviceIds() });
+  }
+
+  /** GET /events — 接続中デバイス一覧の変化を push する SSE ストリーム。 */
+  private handleEvents(): Response {
+    const encoder = new TextEncoder();
+    const hub = this;
+    let controllerRef: ReadableStreamDefaultController<Uint8Array> | null = null;
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controllerRef = controller;
+        hub.sseControllers.add(controller);
+        // 接続直後に現在のスナップショットを送る (browser 側の初期表示用)。
+        controller.enqueue(
+          encoder.encode(`event: devices\ndata: ${JSON.stringify({ devices: hub.currentDeviceIds() })}\n\n`),
+        );
+      },
+      cancel() {
+        if (controllerRef) hub.sseControllers.delete(controllerRef);
+      },
+    });
+    return new Response(stream, {
+      headers: {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-store",
+        Connection: "keep-alive",
+      },
+    });
+  }
+
+  /** 接続中デバイス一覧を全 SSE クライアントへ push する (接続/切断のたびに呼ぶ)。 */
+  private broadcastDevices(): void {
+    if (this.sseControllers.size === 0) return;
+    const encoder = new TextEncoder();
+    const frame = encoder.encode(
+      `event: devices\ndata: ${JSON.stringify({ devices: this.currentDeviceIds() })}\n\n`,
+    );
+    for (const controller of this.sseControllers) {
+      try {
+        controller.enqueue(frame);
+      } catch {
+        this.sseControllers.delete(controller);
+      }
+    }
   }
 
   private async handleCommandResultGet(id: string): Promise<Response> {

--- a/cf-alc-recorder/test/mocks/auth-worker.mjs
+++ b/cf-alc-recorder/test/mocks/auth-worker.mjs
@@ -36,6 +36,14 @@ const TOKENS = {
     email: "",
     exp: 9999999999,
   },
+  "hub-token-tenant-sse": {
+    active: true,
+    tenant_id: "tenant-sse",
+    role: "device-hub",
+    sub: "device-sse",
+    email: "",
+    exp: 9999999999,
+  },
   "kiosk-token": {
     active: true,
     tenant_id: "tenant-1",

--- a/cf-alc-recorder/test/recorder.test.ts
+++ b/cf-alc-recorder/test/recorder.test.ts
@@ -463,6 +463,27 @@ describe("下り command push / command_result", () => {
     const body = (await res.json()) as { devices: string[] };
     expect(body.devices).toContain("device-cmd");
   });
+
+  it("SSE (/events) は接続直後に接続中デバイス一覧のスナップショットを送る", async () => {
+    const { ws } = await connectAccepted("hub-token-tenant-sse");
+    openSockets.push(ws);
+    const res = await SELF.fetch(`${BASE}/tenants/tenant-sse/events`, {
+      headers: { Authorization: SHARED_SECRET },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("text/event-stream");
+    const reader = res.body!.getReader();
+    const { value } = await reader.read();
+    const chunk = new TextDecoder().decode(value);
+    expect(chunk).toContain("event: devices");
+    expect(JSON.parse(chunk.split("data: ")[1]!)).toEqual({ devices: ["device-sse"] });
+    await reader.cancel();
+  });
+
+  it("SSE (/events) も shared secret 必須 (欠落は 401)", async () => {
+    const res = await SELF.fetch(`${BASE}/tenants/tenant-cmd/events`);
+    expect(res.status).toBe(401);
+  });
 });
 
 describe("hibernation 復帰 / テナント分離", () => {


### PR DESCRIPTION
## Summary
- `RecorderHub` に `GET /events` (SSE) を追加。デバイス WS 接続/切断のたびに接続中 device_id 一覧を push する
- `GET /tenants/:t/events` を worker ルートに追加 (`/tenants/:t/devices` と同じ shared secret 認証)
- auth-worker 側の `/device/setup` ページが「WS 接続してもページが自動更新されない」問題を解消するための下地 (auth-worker 側は別 PR)

## Test plan
- [x] `npx tsc --noEmit` — エラーなし
- [x] `npx vitest run` — shared secret 必須テスト等 non-WS 系は pass。WS 経由のテストはローカル (Windows) の miniflare SQLite ロック問題で pre-existing に失敗 (この PR 前の baseline でも同数失敗することを確認済み)。CI (Linux) での確認が必要
- [ ] CI green を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)