### PR TITLE
feat: cf-alc-recorder — crash_log を backend へ転送せず R2 に直接保存 (Refs ippoan/alc-app-s3#43)

### DIFF
--- a/.claude/skills/alc-app-map/SKILL.md
+++ b/.claude/skills/alc-app-map/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: alc-app-map
-generated-from: alc-app:3bdd4d0f02f9ad31ae0ef5b295aeed2cc98254ee
+generated-from: alc-app:aa5cd2ff81021d749b3a333a2afd16cf22d0a490
 paths: [web/, cf-alc-signaling/, cf-alc-recorder/]
 description: yhonda-ohishi-alc/alc-app (業務用アルコールチェッカーシステム / 複合 repo) の構造ナビゲーション。タニタ FC-1200 + NFC + 顔認証による本人確認付きアルコール測定 + 遠隔点呼。web/ (Nuxt 4 PWA on Workers)・cf-alc-signaling/ (WebRTC signaling DO)・cf-alc-recorder/ (CoreS3 測定データ受口 DO)・fc1200-wasm (秘匿) の区画、WebSerial/WebRTC/顔認証の composable 配置、秘匿ファイル・テストの gotcha を 1 枚にまとめる。トリガー:「alc-app」「アルコールチェッカー」「FC-1200」「fc1200」「点呼」「遠隔点呼」「顔認証」「NFC bridge」「WebRTC signaling」「cf-alc-signaling」「cf-alc-recorder」「alc-recorder」「CoreS3 測定」「alc.ippoan.org」等。
 ---
@@ -21,7 +21,7 @@ description: yhonda-ohishi-alc/alc-app (業務用アルコールチェッカー�
 |---|---|---|
 | **`web/`** | Nuxt 4 PWA (`app/` 構成) + `server/` + `wrangler.jsonc` | フロント本体 (Cloudflare Workers `cloudflare_module`)。下表参照 |
 | **`cf-alc-signaling/`** | `src/{index,signaling-room,room-registry}.ts` + `wrangler.toml` | WebRTC signaling worker。Durable Objects (Hibernatable WS) で SDP/ICE リレー。worker 名 `alc-signaling` |
-| **`cf-alc-recorder/`** | `src/{index,recorder-hub,auth,measurements}.ts` + `wrangler.toml` + `test/` | CoreS3 (alc-app-s3) 測定データ受口 worker (#106/#108)。上りは WS (`/ws`、テナント単位 DO `RecorderHub`) と Wi-Fi 客向け `POST /measurements` バッチ (#109、ステートレス) の 2 経路 — どちらも device JWT introspect (role allowlist: `device-hub` = CoreS3 / `device-print` = AtomS3 印刷ブリッジ ippoan/alc-app-s3#38。他 role は 403) → auth-worker `/alc-internal-proxy` → rust-alc-api `POST /api/hub/measurements` に転送。下り command push は WS のみ。worker 名 `alc-recorder` |
+| **`cf-alc-recorder/`** | `src/{index,recorder-hub,auth,measurements}.ts` + `wrangler.toml` + `test/` | CoreS3 (alc-app-s3) 測定データ受口 worker (#106/#108)。上りは WS (`/ws`、テナント単位 DO `RecorderHub`) と Wi-Fi 客向け `POST /measurements` バッチ (#109、ステートレス) の 2 経路 — どちらも device JWT introspect (role allowlist: `device-hub` = CoreS3 / `device-print` = AtomS3 印刷ブリッジ ippoan/alc-app-s3#38。他 role は 403) → auth-worker `/alc-internal-proxy` → rust-alc-api `POST /api/hub/measurements` に転送。例外: `kind=crash_log` (CoreS3 異常リセット復帰レポート、ippoan/alc-app-s3#43) は backend へ転送せず R2 `CRASH_LOGS` (bucket `alc-crash-logs`、key `{tenant}/{device}/{seq 12桁0詰}.json`、再送冪等) へ直接保存して ack。下り command push は WS のみ。worker 名 `alc-recorder` |
 | **`fc1200-wasm/`** | (git ignored) Rust → WASM | FC-1200 RS232C プロトコル実装を WASM に compile して**ソース秘匿**。`web` から `fc1200-wasm` import |
 | **`docs/`** | mkdocs (`mkdocs.yml`, admin/ operator/) | 運用ドキュメント。`docs/*.pdf` = Tanita Confidential で **.gitignore** |
 | **`plan/`** | `implementation-plan.md` `initialplan.md` | 実装計画 |
@@ -49,7 +49,7 @@ description: yhonda-ohishi-alc/alc-app (業務用アルコールチェッカー�
 - **web nitro**: `web/nuxt.config.ts` → `nitro.preset = "cloudflare_module"`、`main = .output/server/index.mjs` (`web/wrangler.jsonc`)。`vite-plugin-wasm` + `optimizeDeps.exclude: ['fc1200-wasm']`。
 - **web wrangler (jsonc)**: top-level = prod (`alc-app`, alc.ippoan.org)。`env.staging` = `alc-app-staging` (alc-staging.ippoan.org)。`NUXT_PUBLIC_{API_BASE,GOOGLE_CLIENT_ID,AUTH_WORKER_URL,STAGING_TENANT_ID,SIGNALING_URL}` を env で切替。
 - **signaling**: `cf-alc-signaling/src/index.ts` (worker entry) → DO `SignalingRoom` (device/admin 2 ピア間リレー) + `RoomRegistry`。`wrangler.toml` に migration v1/v2、`BACKEND_API_URL` var。secret 不要 (STUN P2P のみ、TURN 後日)。
-- **recorder**: `cf-alc-recorder/src/index.ts` (worker entry)。`/ws` → introspect 後にテナント単位 DO `RecorderHub` (Hibernatable WS、identity は WS attachment) へ routing。`POST /measurements` → DO を経由せず Worker 直で検証 + ingest 転送 (`src/measurements.ts` を WS 経路と共有)。下り `POST /tenants/:t/devices/:d/command` 等は `INTERNAL_SHARED_SECRET` の内部 API。binding: `AUTH_WORKER` (service) + `INTERNAL_SHARED_SECRET` (Secrets Store)。prod/staging 2 面 (`env.staging`)。
+- **recorder**: `cf-alc-recorder/src/index.ts` (worker entry)。`/ws` → introspect 後にテナント単位 DO `RecorderHub` (Hibernatable WS、identity は WS attachment) へ routing。`POST /measurements` → DO を経由せず Worker 直で検証 + ingest 転送 (`src/measurements.ts` を WS 経路と共有)。下り `POST /tenants/:t/devices/:d/command` 等は `INTERNAL_SHARED_SECRET` の内部 API。binding: `AUTH_WORKER` (service) + `INTERNAL_SHARED_SECRET` (Secrets Store) + `CRASH_LOGS` (R2、crash_log 保存先)。prod/staging 2 面 (`env.staging`)。
 - **接続**: `NUXT_PUBLIC_SIGNALING_URL` に signaling worker URL。Room ID = `tenko_session_id`。
 
 ## gotcha

--- a/cf-alc-recorder/src/index.ts
+++ b/cf-alc-recorder/src/index.ts
@@ -29,8 +29,10 @@ import {
   resolveSecret,
 } from "./auth";
 import {
+  CRASH_LOG_KIND,
   forwardMeasurements,
   parseMeasurementItem,
+  storeCrashLog,
   type MeasurementInput,
   type ParsedMeasurement,
 } from "./measurements";
@@ -42,6 +44,8 @@ export interface Env {
   AUTH_WORKER: Fetcher;
   /** CF Secrets Store binding (`.get()`)。テストでは文字列で注入する。 */
   INTERNAL_SHARED_SECRET: unknown;
+  /** crash_log (kind=crash_log) の保存先。backend へは転送しない (alc-app-s3#43) */
+  CRASH_LOGS: R2Bucket;
 }
 
 function json(data: unknown, status = 200): Response {
@@ -169,16 +173,31 @@ async function handleMeasurementsPost(request: Request, env: Env, url: URL): Pro
     return json({ accepted: [] });
   }
 
-  const result = await forwardMeasurements(
-    env.AUTH_WORKER,
-    auth.sharedSecret,
-    auth.tenantId,
-    auth.deviceId,
-    items,
-  );
-  if (!result.ok) {
-    // 詳細 (上流 body) は echo しない。端末は同じ batch を再送できる。
-    return json({ error: result.error }, 502);
+  // crash_log は backend へ転送せず R2 に保存して完結 (alc-app-s3#43)。
+  // R2 put 失敗は batch ごと 502 (端末が同じ batch を再送、put は seq key で冪等)。
+  const crashItems = items.filter((item) => item.kind === CRASH_LOG_KIND);
+  const forwardItems = items.filter((item) => item.kind !== CRASH_LOG_KIND);
+  try {
+    for (const item of crashItems) {
+      await storeCrashLog(env.CRASH_LOGS, auth.tenantId, auth.deviceId, item, Date.now());
+    }
+  } catch (e) {
+    console.log(`[crash_log] R2 put failed tenant=${auth.tenantId} device=${auth.deviceId}`, e);
+    return json({ error: "storage_error" }, 502);
+  }
+
+  if (forwardItems.length > 0) {
+    const result = await forwardMeasurements(
+      env.AUTH_WORKER,
+      auth.sharedSecret,
+      auth.tenantId,
+      auth.deviceId,
+      forwardItems,
+    );
+    if (!result.ok) {
+      // 詳細 (上流 body) は echo しない。端末は同じ batch を再送できる。
+      return json({ error: result.error }, 502);
+    }
   }
   return json({ accepted: items.map((item) => item.seq) });
 }

--- a/cf-alc-recorder/src/measurements.ts
+++ b/cf-alc-recorder/src/measurements.ts
@@ -64,6 +64,50 @@ export function parseMeasurementItem(msg: MeasurementInput): ParseMeasurementRes
 }
 
 /**
+ * crash_log (CoreS3 の異常リセット復帰レポート: reset reason + panic 前ログ、
+ * Refs ippoan/alc-app-s3#43) はバックエンド (rust-alc-api hub_measurements) へ
+ * 転送せず、受口の DO/Worker が R2 (`CRASH_LOGS`) へ直接保存して完結させる。
+ */
+export const CRASH_LOG_KIND = "crash_log";
+
+/**
+ * crash_log の R2 object key。seq ベースなので同 seq の再送は同じ key を
+ * 上書きする (= 冪等、ack 前の再送で重複オブジェクトを作らない)。
+ * seq は 12 桁 0 詰めにして prefix 一覧が数値順に並ぶようにする。
+ */
+export function crashLogKey(tenantId: string, deviceId: string, seq: number): string {
+  return `${tenantId}/${deviceId}/${String(seq).padStart(12, "0")}.json`;
+}
+
+/**
+ * crash_log 1 件を R2 へ保存する。reset reason は Workers Observability から
+ * 集計できるよう log にも 1 行残す (値は payload 由来 = untrusted だが log のみ)。
+ */
+export async function storeCrashLog(
+  bucket: R2Bucket,
+  tenantId: string,
+  deviceId: string,
+  item: ParsedMeasurement,
+  receivedAtMs: number,
+): Promise<void> {
+  const key = crashLogKey(tenantId, deviceId, item.seq);
+  await bucket.put(
+    key,
+    JSON.stringify({
+      tenant_id: tenantId,
+      device_id: deviceId,
+      seq: item.seq,
+      recorded_at_ms: item.recorded_at_ms,
+      received_at_ms: receivedAtMs,
+      payload: item.payload,
+    }),
+    { httpMetadata: { contentType: "application/json" } },
+  );
+  const reason = typeof item.payload.reset_reason === "string" ? item.payload.reset_reason : "?";
+  console.log(`[crash_log] stored key=${key} reason=${reason}`);
+}
+
+/**
  * service binding fetch は host を無視するが、path が auth-worker 側 route
  * (`/alc-internal-proxy/...`) と一致する必要がある (web/server/utils/internal-proxy.ts と同形)。
  */

--- a/cf-alc-recorder/src/recorder-hub.ts
+++ b/cf-alc-recorder/src/recorder-hub.ts
@@ -1,7 +1,12 @@
 import { DurableObject } from "cloudflare:workers";
 import type { Env } from "./index";
 import { resolveSecret } from "./auth";
-import { forwardMeasurements, parseMeasurementItem } from "./measurements";
+import {
+  CRASH_LOG_KIND,
+  forwardMeasurements,
+  parseMeasurementItem,
+  storeCrashLog,
+} from "./measurements";
 
 /**
  * RecorderHub — テナント単位の Durable Object (Hibernatable WebSockets)。
@@ -212,6 +217,29 @@ export class RecorderHub extends DurableObject<Env> {
       return;
     }
     const seq = parsed.item.seq;
+
+    // crash_log (CoreS3 の異常リセット復帰レポート、alc-app-s3#43) は backend へ
+    // 転送せず R2 へ直接保存して ack する。key は seq ベースで再送冪等
+    if (parsed.item.kind === CRASH_LOG_KIND) {
+      try {
+        await storeCrashLog(
+          this.env.CRASH_LOGS,
+          attachment.tenantId,
+          attachment.deviceId,
+          parsed.item,
+          Date.now(),
+        );
+      } catch (e) {
+        console.log(
+          `[crash_log] R2 put failed tenant=${attachment.tenantId} device=${attachment.deviceId} seq=${seq}`,
+          e,
+        );
+        this.send(ws, { type: "error", seq, message: "storage_error" });
+        return;
+      }
+      this.send(ws, { type: "ack", seq });
+      return;
+    }
 
     const sharedSecret = await resolveSecret(this.env.INTERNAL_SHARED_SECRET);
     if (!sharedSecret) {

--- a/cf-alc-recorder/test/recorder.test.ts
+++ b/cf-alc-recorder/test/recorder.test.ts
@@ -207,6 +207,41 @@ describe("measurement → ingest 転送 → ack", () => {
     expect(calls[0].items[0].kind).toBe("fc1200_raw");
   });
 
+  it("crash_log は backend へ転送せず R2 に保存して ack する (alc-app-s3#43)", async () => {
+    const { ws, messages } = await connectAccepted("hub-token-1");
+    openSockets.push(ws);
+
+    const frame = JSON.stringify({
+      type: "measurement",
+      seq: 42,
+      recorded_at_ms: 0,
+      kind: "crash_log",
+      payload: { type: "crash_log", reset_reason: "panic", reset_code: 4, log: "PANIC: boom\n" },
+    });
+    ws.send(frame);
+    expect(await messages.next()).toEqual({ type: "ack", seq: 42 });
+
+    // backend (ingest) は呼ばれない
+    expect((await spyIngest()).length).toBe(0);
+
+    // R2 に seq ベースの key で保存される (tenant/device は JWT claims 由来)
+    const obj = await env.CRASH_LOGS.get("tenant-1/device-1/000000000042.json");
+    expect(obj).not.toBeNull();
+    const stored = JSON.parse(await obj!.text()) as Record<string, unknown>;
+    expect(stored.tenant_id).toBe("tenant-1");
+    expect(stored.device_id).toBe("device-1");
+    expect(stored.seq).toBe(42);
+    expect(stored.recorded_at_ms).toBe(0);
+    expect(typeof stored.received_at_ms).toBe("number");
+    expect((stored.payload as Record<string, unknown>).reset_reason).toBe("panic");
+
+    // 同 seq の再送は同じ key を上書き (重複オブジェクトを作らない)
+    ws.send(frame);
+    expect(await messages.next()).toEqual({ type: "ack", seq: 42 });
+    const listed = await env.CRASH_LOGS.list({ prefix: "tenant-1/device-1/" });
+    expect(listed.objects.length).toBe(1);
+  });
+
   it("上流エラー時は error(seq) を返す (詳細は echo しない)。端末は再送できる", async () => {
     const { ws, messages } = await connectAccepted("hub-token-1");
     openSockets.push(ws);
@@ -310,6 +345,28 @@ describe("POST /measurements (Wi-Fi 客の上りバッチ)", () => {
     expect((await postMeasurements(batch, "hub-token-1")).status).toBe(200);
     expect((await postMeasurements(batch, "hub-token-1")).status).toBe(200);
     expect((await spyIngest()).length).toBe(2);
+  });
+
+  it("crash_log は R2 へ保存し、他の kind だけ ingest へ転送する (alc-app-s3#43)", async () => {
+    const res = await postMeasurements(
+      [
+        { seq: 100, kind: "crash_log", payload: { reset_reason: "task_wdt", log: "EVT HEAP ...\n" } },
+        { seq: 101, kind: "temperature", payload: { value: 36.6 } },
+      ],
+      "hub-token-1",
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ accepted: [100, 101] });
+
+    // ingest へは crash_log 以外だけが渡る
+    const calls = await spyIngest();
+    expect(calls.length).toBe(1);
+    expect(calls[0].items.map((i) => i.seq)).toEqual([101]);
+
+    const obj = await env.CRASH_LOGS.get("tenant-1/device-1/000000000100.json");
+    expect(obj).not.toBeNull();
+    const stored = JSON.parse(await obj!.text()) as Record<string, unknown>;
+    expect((stored.payload as Record<string, unknown>).reset_reason).toBe("task_wdt");
   });
 
   it("不正 body は 400: invalid JSON / 非配列 / 上限超過", async () => {

--- a/cf-alc-recorder/vitest.config.ts
+++ b/cf-alc-recorder/vitest.config.ts
@@ -25,6 +25,7 @@ export default defineWorkersConfig({
           },
           serviceBindings: { AUTH_WORKER: "auth-worker" },
           bindings: { INTERNAL_SHARED_SECRET: "test-shared-secret" },
+          r2Buckets: { CRASH_LOGS: "alc-crash-logs" },
           workers: [
             {
               name: "auth-worker",

--- a/cf-alc-recorder/wrangler.toml
+++ b/cf-alc-recorder/wrangler.toml
@@ -45,6 +45,15 @@ binding = "INTERNAL_SHARED_SECRET"
 store_id = "bd7bc91a3e5f4111add4acf6cb4b8733"
 secret_name = "INTERNAL_SHARED_SECRET"
 
+# crash_log (CoreS3 の異常リセット復帰レポート、ippoan/alc-app-s3#43) の保存先。
+# backend (rust-alc-api hub_measurements) へは転送せず R2 で完結させる。
+# key: {tenant_id}/{device_id}/{seq 12桁0詰}.json (再送冪等)。
+# バケットは prod/staging 共用 (tenant_id が別なので衝突しない)。
+# 初回 deploy 前に `npx wrangler r2 bucket create alc-crash-logs` が必要。
+[[r2_buckets]]
+binding = "CRASH_LOGS"
+bucket_name = "alc-crash-logs"
+
 [env.staging]
 name = "alc-recorder-staging"
 
@@ -65,3 +74,7 @@ service = "auth-worker-staging"
 binding = "INTERNAL_SHARED_SECRET"
 store_id = "bd7bc91a3e5f4111add4acf6cb4b8733"
 secret_name = "INTERNAL_SHARED_SECRET"
+
+[[env.staging.r2_buckets]]
+binding = "CRASH_LOGS"
+bucket_name = "alc-crash-logs"


### PR DESCRIPTION
## 概要

CoreS3 (alc-app-s3) の異常リセット復帰レポート (`kind="crash_log"`: reset reason + panic 前ログ) の保存先を、当初案の rust-alc-api `hub_measurements` から **R2 直書き**に変更する (ippoan/rust-alc-api#570 は close 済み)。WS 受口は Durable Object なので env binding 経由で R2 へ直接 put できる — バックエンドまで伝播させる必要がない。

## 変更内容

- `measurements.ts`: `CRASH_LOG_KIND` / `crashLogKey` / `storeCrashLog` を追加。key は `{tenant_id}/{device_id}/{seq 12桁0詰}.json` — seq ベースなので **ack 前の再送は同じ key を上書き = 冪等**。object には tenant/device/seq/recorded_at_ms/received_at_ms/payload を格納し、reset_reason を Workers Observability 用に log 出力
- `recorder-hub.ts` (WS 経路): `kind === "crash_log"` は R2 put → ack (backend へ転送しない)。put 失敗は `storage_error` を返し端末が再送
- `index.ts` (`POST /measurements` 経路): batch を crash_log とそれ以外に分割し、crash_log は R2、残りだけ ingest へ転送
- `wrangler.toml`: R2 binding `CRASH_LOGS` → bucket `alc-crash-logs` (prod/staging 共用 — tenant_id が別なので衝突しない)
- テスト 2 件追加 (WS: R2 保存 + ingest 不呼出 + 再送冪等 / POST: 分割転送)

## ⚠️ merge 前に必要な手作業

R2 バケットが未作成のため、**merge (= recorder-deploy) 前に作成が必要**:

```sh
npx wrangler r2 bucket create alc-crash-logs
```

## デプロイ順序

本 PR の deploy 後に、開発機へ crash log 対応 firmware (alc-app-s3#45、merge 済み) を OTA するのが安全な順序 (先に firmware が動いても crash_log が error になって再送し続けるだけで実害なし)。

## テスト

```
npx tsc --noEmit  → clean
npx vitest run    → 33 passed (追加 2 件含む)
```

## 閲覧方法

`wrangler r2 object get` / Cloudflare dashboard で `alc-crash-logs` バケットの `{tenant}/{device}/` prefix を一覧。reset_reason は Workers Observability の `[crash_log] stored` ログでも確認可能。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VBuYUGURwG5c4uq1GuouYm

---
_Generated by [Claude Code](https://claude.ai/code/session_01VBuYUGURwG5c4uq1GuouYm)_