### PR TITLE
feat: cf-alc-recorder — crash_log 受信時にメール通知 (send_email、best-effort) (Refs ippoan/alc-app-s3#43)

### DIFF
--- a/.claude/skills/alc-app-map/SKILL.md
+++ b/.claude/skills/alc-app-map/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: alc-app-map
-generated-from: alc-app:aa5cd2ff81021d749b3a333a2afd16cf22d0a490
+generated-from: alc-app:b4aacaa1cf9ef811f73759a90e3732c00093fc8c
 paths: [web/, cf-alc-signaling/, cf-alc-recorder/]
 description: yhonda-ohishi-alc/alc-app (業務用アルコールチェッカーシステム / 複合 repo) の構造ナビゲーション。タニタ FC-1200 + NFC + 顔認証による本人確認付きアルコール測定 + 遠隔点呼。web/ (Nuxt 4 PWA on Workers)・cf-alc-signaling/ (WebRTC signaling DO)・cf-alc-recorder/ (CoreS3 測定データ受口 DO)・fc1200-wasm (秘匿) の区画、WebSerial/WebRTC/顔認証の composable 配置、秘匿ファイル・テストの gotcha を 1 枚にまとめる。トリガー:「alc-app」「アルコールチェッカー」「FC-1200」「fc1200」「点呼」「遠隔点呼」「顔認証」「NFC bridge」「WebRTC signaling」「cf-alc-signaling」「cf-alc-recorder」「alc-recorder」「CoreS3 測定」「alc.ippoan.org」等。
 ---
@@ -21,7 +21,7 @@ description: yhonda-ohishi-alc/alc-app (業務用アルコールチェッカー�
 |---|---|---|
 | **`web/`** | Nuxt 4 PWA (`app/` 構成) + `server/` + `wrangler.jsonc` | フロント本体 (Cloudflare Workers `cloudflare_module`)。下表参照 |
 | **`cf-alc-signaling/`** | `src/{index,signaling-room,room-registry}.ts` + `wrangler.toml` | WebRTC signaling worker。Durable Objects (Hibernatable WS) で SDP/ICE リレー。worker 名 `alc-signaling` |
-| **`cf-alc-recorder/`** | `src/{index,recorder-hub,auth,measurements}.ts` + `wrangler.toml` + `test/` | CoreS3 (alc-app-s3) 測定データ受口 worker (#106/#108)。上りは WS (`/ws`、テナント単位 DO `RecorderHub`) と Wi-Fi 客向け `POST /measurements` バッチ (#109、ステートレス) の 2 経路 — どちらも device JWT introspect (role allowlist: `device-hub` = CoreS3 / `device-print` = AtomS3 印刷ブリッジ ippoan/alc-app-s3#38。他 role は 403) → auth-worker `/alc-internal-proxy` → rust-alc-api `POST /api/hub/measurements` に転送。例外: `kind=crash_log` (CoreS3 異常リセット復帰レポート、ippoan/alc-app-s3#43) は backend へ転送せず R2 `CRASH_LOGS` (bucket `alc-crash-logs`、key `{tenant}/{device}/{seq 12桁0詰}.json`、再送冪等) へ直接保存して ack。下り command push は WS のみ。worker 名 `alc-recorder` |
+| **`cf-alc-recorder/`** | `src/{index,recorder-hub,auth,measurements}.ts` + `wrangler.toml` + `test/` | CoreS3 (alc-app-s3) 測定データ受口 worker (#106/#108)。上りは WS (`/ws`、テナント単位 DO `RecorderHub`) と Wi-Fi 客向け `POST /measurements` バッチ (#109、ステートレス) の 2 経路 — どちらも device JWT introspect (role allowlist: `device-hub` = CoreS3 / `device-print` = AtomS3 印刷ブリッジ ippoan/alc-app-s3#38。他 role は 403) → auth-worker `/alc-internal-proxy` → rust-alc-api `POST /api/hub/measurements` に転送。例外: `kind=crash_log` (CoreS3 異常リセット復帰レポート、ippoan/alc-app-s3#43) は backend へ転送せず R2 `CRASH_LOGS` (bucket `alc-crash-logs`、key `{tenant}/{device}/{seq 12桁0詰}.json`、再送冪等) へ直接保存して ack + メール通知 (`CRASH_EMAIL` send_email binding、best-effort、security-notification-app と同方式)。下り command push は WS のみ。worker 名 `alc-recorder` |
 | **`fc1200-wasm/`** | (git ignored) Rust → WASM | FC-1200 RS232C プロトコル実装を WASM に compile して**ソース秘匿**。`web` から `fc1200-wasm` import |
 | **`docs/`** | mkdocs (`mkdocs.yml`, admin/ operator/) | 運用ドキュメント。`docs/*.pdf` = Tanita Confidential で **.gitignore** |
 | **`plan/`** | `implementation-plan.md` `initialplan.md` | 実装計画 |
@@ -49,7 +49,7 @@ description: yhonda-ohishi-alc/alc-app (業務用アルコールチェッカー�
 - **web nitro**: `web/nuxt.config.ts` → `nitro.preset = "cloudflare_module"`、`main = .output/server/index.mjs` (`web/wrangler.jsonc`)。`vite-plugin-wasm` + `optimizeDeps.exclude: ['fc1200-wasm']`。
 - **web wrangler (jsonc)**: top-level = prod (`alc-app`, alc.ippoan.org)。`env.staging` = `alc-app-staging` (alc-staging.ippoan.org)。`NUXT_PUBLIC_{API_BASE,GOOGLE_CLIENT_ID,AUTH_WORKER_URL,STAGING_TENANT_ID,SIGNALING_URL}` を env で切替。
 - **signaling**: `cf-alc-signaling/src/index.ts` (worker entry) → DO `SignalingRoom` (device/admin 2 ピア間リレー) + `RoomRegistry`。`wrangler.toml` に migration v1/v2、`BACKEND_API_URL` var。secret 不要 (STUN P2P のみ、TURN 後日)。
-- **recorder**: `cf-alc-recorder/src/index.ts` (worker entry)。`/ws` → introspect 後にテナント単位 DO `RecorderHub` (Hibernatable WS、identity は WS attachment) へ routing。`POST /measurements` → DO を経由せず Worker 直で検証 + ingest 転送 (`src/measurements.ts` を WS 経路と共有)。下り `POST /tenants/:t/devices/:d/command` 等は `INTERNAL_SHARED_SECRET` の内部 API。binding: `AUTH_WORKER` (service) + `INTERNAL_SHARED_SECRET` (Secrets Store) + `CRASH_LOGS` (R2、crash_log 保存先)。prod/staging 2 面 (`env.staging`)。
+- **recorder**: `cf-alc-recorder/src/index.ts` (worker entry)。`/ws` → introspect 後にテナント単位 DO `RecorderHub` (Hibernatable WS、identity は WS attachment) へ routing。`POST /measurements` → DO を経由せず Worker 直で検証 + ingest 転送 (`src/measurements.ts` を WS 経路と共有)。下り `POST /tenants/:t/devices/:d/command` 等は `INTERNAL_SHARED_SECRET` の内部 API。binding: `AUTH_WORKER` (service) + `INTERNAL_SHARED_SECRET` (Secrets Store) + `CRASH_LOGS` (R2、crash_log 保存先) + `CRASH_EMAIL` (send_email、crash メール通知)。prod/staging 2 面 (`env.staging`)。
 - **接続**: `NUXT_PUBLIC_SIGNALING_URL` に signaling worker URL。Room ID = `tenko_session_id`。
 
 ## gotcha

--- a/cf-alc-recorder/package-lock.json
+++ b/cf-alc-recorder/package-lock.json
@@ -7,12 +7,36 @@
     "": {
       "name": "cf-alc-recorder",
       "version": "1.0.0",
+      "dependencies": {
+        "mimetext": "^3.0.28"
+      },
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.8.71",
         "@cloudflare/workers-types": "^4.20250101.0",
         "typescript": "^5.7.0",
         "vitest": "^3.2.4",
         "wrangler": "~4.35.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/runtime-corejs3": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.29.7.tgz",
+      "integrity": "sha512-ppj9ouYku+RX0ljtgZd+KMO5mkM2bCqg8H2PYAFWnLsHEIKIdRojqbJ2i3eVHrisuxy7nOFCmngTDdWtUCdXUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "core-js-pure": "^3.48.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@cloudflare/kv-asset-handler": {
@@ -1723,6 +1747,17 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/core-js-pure": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.49.0.tgz",
+      "integrity": "sha512-XM4RFka59xATyJv/cS3O3Kml72hQXUeGRuuTmMYFxwzc9/7C8OYTaIR/Ji+Yt8DXzsFLNhat15cE/JP15HrCgw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1921,6 +1956,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/js-base64": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.8.1.tgz",
+      "integrity": "sha512-5xVjhUZlHHeuO2W7w2rDFj/Kl1xLX+HjZxdOQwCsUOifl6UaoH1o1wsbsTMz+r0aeC7gCijvru02j6TfKZWzKg==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/js-tokens": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
@@ -1966,6 +2007,43 @@
       },
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimetext": {
+      "version": "3.0.28",
+      "resolved": "https://registry.npmjs.org/mimetext/-/mimetext-3.0.28.tgz",
+      "integrity": "sha512-eQXpbNrtxLCjUtiVbR/qR09dbPgZ2o+KR1uA7QKqGhbn8QV7HIL16mXXsobBL4/8TqoYh1us31kfz+dNfCev9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.0",
+        "@babel/runtime-corejs3": "^7.26.0",
+        "js-base64": "^3.7.7",
+        "mime-types": "^2.1.35"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://patreon.com/muratgozel"
       }
     },
     "node_modules/miniflare": {

--- a/cf-alc-recorder/package.json
+++ b/cf-alc-recorder/package.json
@@ -17,5 +17,8 @@
     "typescript": "^5.7.0",
     "vitest": "^3.2.4",
     "wrangler": "~4.35.0"
+  },
+  "dependencies": {
+    "mimetext": "^3.0.28"
   }
 }

--- a/cf-alc-recorder/src/index.ts
+++ b/cf-alc-recorder/src/index.ts
@@ -31,6 +31,7 @@ import {
 import {
   CRASH_LOG_KIND,
   forwardMeasurements,
+  notifyCrashByEmail,
   parseMeasurementItem,
   storeCrashLog,
   type MeasurementInput,
@@ -46,6 +47,10 @@ export interface Env {
   INTERNAL_SHARED_SECRET: unknown;
   /** crash_log (kind=crash_log) の保存先。backend へは転送しない (alc-app-s3#43) */
   CRASH_LOGS: R2Bucket;
+  /** crash_log のメール通知 (Email Routing send_email binding)。テスト環境は未設定 = skip */
+  CRASH_EMAIL?: SendEmail;
+  NOTIFY_EMAIL_FROM?: string;
+  NOTIFY_EMAIL_TO?: string;
 }
 
 function json(data: unknown, status = 200): Response {
@@ -184,6 +189,10 @@ async function handleMeasurementsPost(request: Request, env: Env, url: URL): Pro
   } catch (e) {
     console.log(`[crash_log] R2 put failed tenant=${auth.tenantId} device=${auth.deviceId}`, e);
     return json({ error: "storage_error" }, 502);
+  }
+  // メール通知は best-effort (失敗しても accept は返す)
+  for (const item of crashItems) {
+    await notifyCrashByEmail(env, auth.tenantId, auth.deviceId, item);
   }
 
   if (forwardItems.length > 0) {

--- a/cf-alc-recorder/src/measurements.ts
+++ b/cf-alc-recorder/src/measurements.ts
@@ -107,6 +107,63 @@ export async function storeCrashLog(
   console.log(`[crash_log] stored key=${key} reason=${reason}`);
 }
 
+/** crash_log メール通知に必要な env の部分型 (index.ts の Env が満たす)。 */
+export interface CrashEmailEnv {
+  CRASH_EMAIL?: SendEmail;
+  NOTIFY_EMAIL_FROM?: string;
+  NOTIFY_EMAIL_TO?: string;
+}
+
+/**
+ * crash_log をメール通知する (best-effort、security-notification-app と同じ
+ * Email Routing send_email binding + mimetext 方式)。
+ *
+ * R2 保存が正でメールは通知のみ — binding / vars 未設定 (テスト・未構成環境) は
+ * 黙って skip、送信失敗も log のみで ack を妨げない。クラッシュは稀なので
+ * 集約せずイベント毎に 1 通送る。
+ */
+export async function notifyCrashByEmail(
+  env: CrashEmailEnv,
+  tenantId: string,
+  deviceId: string,
+  item: ParsedMeasurement,
+): Promise<void> {
+  const binding = env.CRASH_EMAIL;
+  const from = env.NOTIFY_EMAIL_FROM;
+  const to = env.NOTIFY_EMAIL_TO;
+  if (!binding || !from || !to) return;
+  try {
+    const p = item.payload;
+    const str = (v: unknown): string => (typeof v === "string" ? v : "?");
+    const reason = str(p.reset_reason);
+    const body = [
+      `CoreS3 が異常リセットから復帰しました (crash_log)。`,
+      ``,
+      `reset_reason: ${reason} (code=${typeof p.reset_code === "number" ? p.reset_code : "?"})`,
+      `device_id:    ${deviceId}`,
+      `tenant_id:    ${tenantId}`,
+      `seq:          ${item.seq}`,
+      `firmware:     ${str(p.version)} (${str(p.slot)})`,
+      `R2 object:    alc-crash-logs/${crashLogKey(tenantId, deviceId, item.seq)}`,
+      ``,
+      `--- panic 前ログ (末尾) ---`,
+      typeof p.log === "string" && p.log ? p.log : "(ログなし — RAM 未保持の可能性)",
+    ].join("\n");
+
+    const { EmailMessage } = await import("cloudflare:email");
+    const { createMimeMessage } = await import("mimetext");
+    const msg = createMimeMessage();
+    msg.setSender({ name: "ALC Crash Notifier", addr: from });
+    msg.setRecipient(to);
+    msg.setSubject(`[alc] CoreS3 crash: ${reason} (${deviceId})`);
+    msg.addMessage({ contentType: "text/plain", data: body });
+    await binding.send(new EmailMessage(from, to, msg.asRaw()));
+    console.log(`[crash_log] email sent device=${deviceId} reason=${reason}`);
+  } catch (e) {
+    console.log(`[crash_log] email notify failed tenant=${tenantId} device=${deviceId}`, e);
+  }
+}
+
 /**
  * service binding fetch は host を無視するが、path が auth-worker 側 route
  * (`/alc-internal-proxy/...`) と一致する必要がある (web/server/utils/internal-proxy.ts と同形)。

--- a/cf-alc-recorder/src/recorder-hub.ts
+++ b/cf-alc-recorder/src/recorder-hub.ts
@@ -4,6 +4,7 @@ import { resolveSecret } from "./auth";
 import {
   CRASH_LOG_KIND,
   forwardMeasurements,
+  notifyCrashByEmail,
   parseMeasurementItem,
   storeCrashLog,
 } from "./measurements";
@@ -238,6 +239,8 @@ export class RecorderHub extends DurableObject<Env> {
         return;
       }
       this.send(ws, { type: "ack", seq });
+      // メール通知は best-effort (ack 済み。失敗は log のみ)
+      await notifyCrashByEmail(this.env, attachment.tenantId, attachment.deviceId, parsed.item);
       return;
     }
 

--- a/cf-alc-recorder/wrangler.toml
+++ b/cf-alc-recorder/wrangler.toml
@@ -54,6 +54,18 @@ secret_name = "INTERNAL_SHARED_SECRET"
 binding = "CRASH_LOGS"
 bucket_name = "alc-crash-logs"
 
+# crash_log のメール通知 (best-effort。R2 が正、メールは通知のみ)。
+# security-notification-app と同じ Email Routing send_email binding 方式 —
+# 宛先は検証済み destination address であること。差出人 (NOTIFY_EMAIL_FROM) は
+# Email Routing を有効化済みの mtamaramu.com ドメインを使う。
+[[send_email]]
+name = "CRASH_EMAIL"
+destination_address = "m.tama.ramu@gmail.com"
+
+[vars]
+NOTIFY_EMAIL_FROM = "alc-crash@mtamaramu.com"
+NOTIFY_EMAIL_TO = "m.tama.ramu@gmail.com"
+
 [env.staging]
 name = "alc-recorder-staging"
 
@@ -78,3 +90,11 @@ secret_name = "INTERNAL_SHARED_SECRET"
 [[env.staging.r2_buckets]]
 binding = "CRASH_LOGS"
 bucket_name = "alc-crash-logs"
+
+[[env.staging.send_email]]
+name = "CRASH_EMAIL"
+destination_address = "m.tama.ramu@gmail.com"
+
+[env.staging.vars]
+NOTIFY_EMAIL_FROM = "alc-crash@mtamaramu.com"
+NOTIFY_EMAIL_TO = "m.tama.ramu@gmail.com"


### PR DESCRIPTION
## 概要

crash_log (CoreS3 異常リセット復帰レポート) を受信して R2 へ保存した際に、**メールでも通知**する (#114 の続き)。security-notification-app と同じ **Email Routing `send_email` binding + mimetext** 方式。

- 件名: `[alc] CoreS3 crash: <reset_reason> (<device_id>)`
- 本文: reset reason / device / tenant / seq / firmware version / R2 object key / panic 前ログ (末尾)
- クラッシュは稀なので集約せずイベント毎に 1 通 (WS 経路・POST /measurements 経路の両方)
- **best-effort**: R2 保存が正でメールは通知のみ。binding/vars 未設定 (テスト環境) は skip、送信失敗も log のみで ack を妨げない
- 宛先 `m.tama.ramu@gmail.com` は検証済み destination address (security-notification-app で使用実績あり)。差出人は `alc-crash@mtamaramu.com` (Email Routing 有効化済みドメイン)

## テスト

```
npx tsc --noEmit  → clean
npx vitest run    → 33 passed
```

(miniflare は send_email binding 非対応のため、テストでは binding 不在 → skip 経路が走ることを既存テストで担保)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VBuYUGURwG5c4uq1GuouYm

---
_Generated by [Claude Code](https://claude.ai/code/session_01VBuYUGURwG5c4uq1GuouYm)_