### PR TITLE
fix: cf-alc-recorder に nodejs_compat を追加 — mimetext バンドル失敗で staging deploy が落ちる問題 (Refs ippoan/alc-app-s3#43)

### DIFF
--- a/cf-alc-recorder/vitest.config.ts
+++ b/cf-alc-recorder/vitest.config.ts
@@ -20,6 +20,7 @@ export default defineWorkersConfig({
         isolatedStorage: false,
         miniflare: {
           compatibilityDate: "2025-07-15",
+          compatibilityFlags: ["nodejs_compat"],
           durableObjects: {
             RECORDER_HUB: { className: "RecorderHub", useSQLite: true },
           },

--- a/cf-alc-recorder/wrangler.toml
+++ b/cf-alc-recorder/wrangler.toml
@@ -12,6 +12,10 @@
 name = "alc-recorder"
 main = "src/index.ts"
 compatibility_date = "2025-07-15"
+# mimetext (crash_log メール通知) が Node 組み込み (path / node:os) を参照するため必須
+# (security-notification-app と同じ)。compatibility_flags は inheritable key なので
+# env.staging にも継承される (bindings と違い再宣言不要)
+compatibility_flags = ["nodejs_compat"]
 # account_id を明示 (web/wrangler.jsonc / cf-alc-signaling と同値)。未指定だと wrangler が
 # /memberships を列挙し、account-scoped な CLOUDFLARE_API_TOKEN では Authentication
 # error [code: 10000] で deploy が落ちる (signaling-deploy CI 実測)。


### PR DESCRIPTION
## 概要

#115 (crash_log メール通知) の merge 後、main の Recorder Deploy (staging) が失敗 ([run 29309020867](https://github.com/ippoan/alc-app/actions/runs/29309020867)):

```
✘ [ERROR] Could not resolve "path"
    node_modules/mime-types/index.js:16:22
▲ [WARNING] The package "node:os" wasn't found ... enable the "nodejs_compat" compatibility flag
```

`mimetext` が Node 組み込み (`path` / `node:os`) を参照するため、`nodejs_compat` なしでは wrangler のバンドルが失敗する。security-notification-app (mimetext の移植元) と同じく `compatibility_flags = ["nodejs_compat"]` を追加する。

- `compatibility_flags` は inheritable key なので top-level 宣言のみで `env.staging` にも効く (bindings と違い再宣言不要)
- vitest (miniflare) 側も `compatibilityFlags` を揃える
- PR CI で捕まらなかった理由: deploy job は main/tag 限定で、test job は mimetext を dynamic import (binding 不在で未到達) のためバンドルが走らない。本 PR は `wrangler deploy --env staging --dry-run` でバンドル成功を確認済み

## テスト

```
npx tsc --noEmit                              → clean
npx vitest run                                → 33 passed
npx wrangler deploy --env staging --dry-run   → バンドル成功 (binding 一覧まで出力)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VBuYUGURwG5c4uq1GuouYm

---
_Generated by [Claude Code](https://claude.ai/code/session_01VBuYUGURwG5c4uq1GuouYm)_