### PR TITLE
feat(cf-alc-recorder): CoreS3 バッテリー状態を cron で定期取得しR2に履歴保存 (Refs #121)

### DIFF
--- a/cf-alc-recorder/README.md
+++ b/cf-alc-recorder/README.md
@@ -53,6 +53,25 @@ CoreS3 →(WSS + device JWT)→ cf-alc-recorder →(AUTH_WORKER service binding)
 { "type": "command", "id": "<uuid>", "payload": { } }    // MEASURE 指示 / timecard イベント / 設定変更
 ```
 
+## バッテリー snapshot cron (Refs #121)
+
+CoreS3 の電源/バッテリー状態 (`/device/setup` の手動照会と同じ WS command
+`{action:"battery"}` → `command_result`) を 30 分おきに自動取得し R2
+(`BATTERY_HISTORY`) へ保存する。対象 device (tenant_id/device_id) は
+auth-worker `GET /internal/hub-devices` から取得する — 本 worker は tenant/device
+の registry を持たない。未接続デバイス・応答 timeout は silent skip (best-effort、
+次周期に譲る)。rust-alc-api hub_measurements は使わない (診断値であって測定データ
+ではないため、crash_log と同じ R2 直接保存)。
+
+保存先の key は `{tenant_id}/{device_id}/{取得時刻ms}.json`。**7日で自動削除**する
+Object Lifecycle Rule はコードでは制御できないバケット側の運用設定 — 初回 deploy
+前に手動で以下を実行すること:
+
+```sh
+npx wrangler r2 bucket create alc-battery-history
+npx wrangler r2 bucket lifecycle add alc-battery-history --expire-days 7
+```
+
 ## 開発
 
 ```sh
@@ -65,7 +84,9 @@ npm test          # @cloudflare/vitest-pool-workers (introspect モックは tes
 
 CI (`.github/workflows/recorder-deploy.yml`) 経由:
 main push → staging (`alc-recorder-staging`、auth-worker-staging に binding)、
-`v*` tag push → production (`alc-recorder`)。
+`v*` tag push → production (`alc-recorder`)。cron ([triggers]) は prod のみ
+(staging に実機フリートは無い)。
 
 依存: rust-alc-api の受け口 (ippoan/rust-alc-api#564)、auth-worker の `device-hub`
-role + `/alc-internal-proxy` allowlist (ippoan/auth-worker#363)。
+role + `/alc-internal-proxy` allowlist (ippoan/auth-worker#363)、
+`GET /internal/hub-devices` (ippoan/auth-worker#401)。

--- a/cf-alc-recorder/src/battery-snapshot.ts
+++ b/cf-alc-recorder/src/battery-snapshot.ts
@@ -1,0 +1,188 @@
+/**
+ * CoreS3 電源/バッテリー状態の cron 定期取得 (Refs ippoan/alc-app#121)。
+ *
+ * `/device/setup` の手動照会 (WS command `{action:"battery"}` → `command_result`、
+ * alc-app-s3/crates/hub-drivers/src/ws_uplink.rs:528) と同じ経路を DO 経由で自動化する。
+ * DO が WS 接続を持っているので、対象 device の列挙以外は全て本 worker (cf-alc-recorder)
+ * 内で完結させる — rust-alc-api hub_measurements は使わない (診断値であって測定データでは
+ * ないため)。履歴は R2 (`BATTERY_HISTORY`) に JSON で保存し、7日で Object Lifecycle Rule
+ * (bucket 側の運用設定、コードでは制御不可) により自動削除される想定。
+ *
+ * 対象 device (tenant_id + device_id) は auth-worker `GET /internal/hub-devices`
+ * (server-to-server shared secret 認証) から取得する — cf-alc-recorder 自身は
+ * tenant/device の registry を持たない。
+ *
+ * 未接続 device・command_result timeout は best-effort で silent skip する
+ * (crash_log のような loud fail は不要 — 診断値の欠測は次周期で埋まる)。
+ */
+
+/** auth-worker `/internal/hub-devices` が返す最小限の device 参照。 */
+export interface HubDeviceRef {
+  tenant_id: string;
+  device_id: string;
+}
+
+/** WS command `{action:"battery"}` の command_result payload (alc-app-s3 ws_uplink.rs 準拠)。 */
+export interface BatteryReading {
+  read: boolean;
+  percent?: number;
+  mv?: number;
+  vbus?: boolean;
+  charge?: number;
+}
+
+/** command_result 待ちのポーリング回数・間隔 (最大 3 秒程度で諦める)。 */
+const POLL_ATTEMPTS = 6;
+const POLL_INTERVAL_MS = 500;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * auth-worker `/internal/hub-devices` から hub device 一覧を取得する。
+ * 到達不能・非 200・不正な body は空配列 (cron は best-effort、次周期に譲る)。
+ */
+export async function fetchHubDevices(
+  authWorker: Fetcher,
+  sharedSecret: string,
+): Promise<HubDeviceRef[]> {
+  let res: Response;
+  try {
+    res = await authWorker.fetch("https://auth-worker.internal/internal/hub-devices", {
+      headers: { Authorization: sharedSecret },
+    });
+  } catch (e) {
+    console.log("[battery_cron] auth-worker unreachable", e);
+    return [];
+  }
+  if (!res.ok) {
+    console.log(`[battery_cron] hub-devices fetch failed status=${res.status}`);
+    return [];
+  }
+  let data: unknown;
+  try {
+    data = await res.json();
+  } catch {
+    return [];
+  }
+  const devices = (data as { devices?: unknown })?.devices;
+  if (!Array.isArray(devices)) return [];
+  return devices.filter(
+    (d): d is HubDeviceRef =>
+      !!d &&
+      typeof d === "object" &&
+      typeof (d as HubDeviceRef).tenant_id === "string" &&
+      typeof (d as HubDeviceRef).device_id === "string",
+  );
+}
+
+/** command_result の payload を BatteryReading として検証する。形が合わなければ null。 */
+export function parseBatteryPayload(payload: unknown): BatteryReading | null {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return null;
+  const p = payload as Record<string, unknown>;
+  if (typeof p.read !== "boolean") return null;
+  return {
+    read: p.read,
+    ...(typeof p.percent === "number" ? { percent: p.percent } : {}),
+    ...(typeof p.mv === "number" ? { mv: p.mv } : {}),
+    ...(typeof p.vbus === "boolean" ? { vbus: p.vbus } : {}),
+    ...(typeof p.charge === "number" ? { charge: p.charge } : {}),
+  };
+}
+
+/** R2 object key。crash_log (`crashLogKey`) と同じ tenant/device 階層 + 取得時刻 (ms)。 */
+export function batterySnapshotKey(tenantId: string, deviceId: string, nowMs: number): string {
+  return `${tenantId}/${deviceId}/${nowMs}.json`;
+}
+
+/** バッテリー snapshot を R2 へ保存する。 */
+export async function storeBatterySnapshot(
+  bucket: R2Bucket,
+  tenantId: string,
+  deviceId: string,
+  reading: BatteryReading,
+  nowMs: number,
+): Promise<void> {
+  const key = batterySnapshotKey(tenantId, deviceId, nowMs);
+  await bucket.put(
+    key,
+    JSON.stringify({
+      tenant_id: tenantId,
+      device_id: deviceId,
+      recorded_at_ms: nowMs,
+      ...reading,
+    }),
+    { httpMetadata: { contentType: "application/json" } },
+  );
+}
+
+/** cron が呼ぶ env の部分型。 */
+export interface BatteryCronEnv {
+  RECORDER_HUB: DurableObjectNamespace;
+  AUTH_WORKER: Fetcher;
+  BATTERY_HISTORY: R2Bucket;
+}
+
+/**
+ * 1 device 分の照会。未接続 (404) / 送信失敗 / command_result timeout は
+ * silent skip (log のみ、例外は投げない — cron 全体を止めない)。
+ */
+async function snapshotOneDevice(
+  env: BatteryCronEnv,
+  tenantId: string,
+  deviceId: string,
+  nowMs: number,
+): Promise<void> {
+  const stub = env.RECORDER_HUB.get(env.RECORDER_HUB.idFromName(tenantId));
+
+  let commandRes: Response;
+  try {
+    commandRes = await stub.fetch("https://recorder-hub.internal/command", {
+      method: "POST",
+      headers: { "X-Recorder-Device-Id": deviceId, "Content-Type": "application/json" },
+      body: JSON.stringify({ payload: { action: "battery" } }),
+    });
+  } catch (e) {
+    console.log(`[battery_cron] command send failed tenant=${tenantId} device=${deviceId}`, e);
+    return;
+  }
+  if (commandRes.status === 404) {
+    return; // device not connected — silent skip (best-effort)
+  }
+  if (!commandRes.ok) {
+    console.log(
+      `[battery_cron] command send status=${commandRes.status} tenant=${tenantId} device=${deviceId}`,
+    );
+    return;
+  }
+  const { id } = (await commandRes.json()) as { id?: string };
+  if (!id) return;
+
+  for (let attempt = 0; attempt < POLL_ATTEMPTS; attempt++) {
+    await sleep(POLL_INTERVAL_MS);
+    const resultRes = await stub.fetch(`https://recorder-hub.internal/command-result/${id}`);
+    if (resultRes.status !== 200) continue;
+    const stored = (await resultRes.json()) as { payload?: unknown };
+    const reading = parseBatteryPayload(stored.payload);
+    if (!reading) return;
+    await storeBatterySnapshot(env.BATTERY_HISTORY, tenantId, deviceId, reading, nowMs);
+    return;
+  }
+  console.log(`[battery_cron] command_result timeout tenant=${tenantId} device=${deviceId} id=${id}`);
+}
+
+/**
+ * cron エントリポイント (`scheduled()` から呼ぶ)。shared secret 未設定なら
+ * 何もしない (server_error を返す先が無いので log のみ)。
+ */
+export async function runBatterySnapshotCron(
+  env: BatteryCronEnv,
+  sharedSecret: string,
+  nowMs: number,
+): Promise<void> {
+  const devices = await fetchHubDevices(env.AUTH_WORKER, sharedSecret);
+  for (const { tenant_id, device_id } of devices) {
+    await snapshotOneDevice(env, tenant_id, device_id, nowMs);
+  }
+}

--- a/cf-alc-recorder/src/index.ts
+++ b/cf-alc-recorder/src/index.ts
@@ -20,6 +20,9 @@
  *   - GET  /tenants/:tenantId/commands/:id/result       … command_result の取得
  *     (下り 3 endpoint は `Authorization: <INTERNAL_SHARED_SECRET>` の内部 API。
  *      auth-worker /auth/introspect と同じ server-to-server shared secret 認証)
+ *
+ * cron (`*` / prod のみ、Refs #121): CoreS3 電源/バッテリー状態を 30 分おきに
+ * 定期取得し R2 (`BATTERY_HISTORY`) へ保存する (battery-snapshot.ts)。
  */
 import {
   bearerToken,
@@ -37,6 +40,7 @@ import {
   type MeasurementInput,
   type ParsedMeasurement,
 } from "./measurements";
+import { runBatterySnapshotCron } from "./battery-snapshot";
 
 export { RecorderHub } from "./recorder-hub";
 
@@ -51,6 +55,8 @@ export interface Env {
   CRASH_EMAIL?: SendEmail;
   NOTIFY_EMAIL_FROM?: string;
   NOTIFY_EMAIL_TO?: string;
+  /** バッテリー snapshot cron の保存先 (7日 lifecycle rule はバケット側で設定、Refs #121) */
+  BATTERY_HISTORY: R2Bucket;
 }
 
 function json(data: unknown, status = 200): Response {
@@ -271,5 +277,23 @@ export default {
     }
 
     return new Response("Not Found", { status: 404 });
+  },
+
+  /**
+   * cron (`wrangler.toml` `[triggers]`、30分おき・prod のみ、Refs #121)。
+   * INTERNAL_SHARED_SECRET 未設定なら auth-worker を呼べないので何もしない
+   * (server_error を返す先が無い cron なので log のみ)。
+   */
+  async scheduled(_controller: ScheduledController, env: Env, ctx: ExecutionContext): Promise<void> {
+    ctx.waitUntil(
+      (async () => {
+        const sharedSecret = await resolveSecret(env.INTERNAL_SHARED_SECRET);
+        if (!sharedSecret) {
+          console.log("[battery_cron] INTERNAL_SHARED_SECRET not configured, skip");
+          return;
+        }
+        await runBatterySnapshotCron(env, sharedSecret, Date.now());
+      })(),
+    );
   },
 } satisfies ExportedHandler<Env>;

--- a/cf-alc-recorder/test/battery-snapshot.test.ts
+++ b/cf-alc-recorder/test/battery-snapshot.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { SELF, env } from "cloudflare:test";
+import type { Env } from "../src/index";
+import {
+  fetchHubDevices,
+  parseBatteryPayload,
+  batterySnapshotKey,
+  storeBatterySnapshot,
+  runBatterySnapshotCron,
+} from "../src/battery-snapshot";
+
+declare module "cloudflare:test" {
+  interface ProvidedEnv extends Env {}
+}
+
+const BASE = "https://alc-recorder.test";
+const SHARED_SECRET = "test-shared-secret";
+
+/** WS 接続を張る (recorder.test.ts の connect/connectAccepted と同形)。 */
+async function connect(token: string): Promise<{ res: Response; ws: WebSocket | null }> {
+  const res = await SELF.fetch(`${BASE}/ws`, {
+    headers: { Upgrade: "websocket", Authorization: `Bearer ${token}` },
+  });
+  return { res, ws: res.webSocket ?? null };
+}
+
+function messageQueue(ws: WebSocket) {
+  const queue: unknown[] = [];
+  const waiters: Array<(v: unknown) => void> = [];
+  ws.addEventListener("message", (event) => {
+    const parsed: unknown = JSON.parse((event as MessageEvent).data as string);
+    const waiter = waiters.shift();
+    if (waiter) waiter(parsed);
+    else queue.push(parsed);
+  });
+  ws.accept();
+  return {
+    next(timeoutMs = 3000): Promise<unknown> {
+      const head = queue.shift();
+      if (head !== undefined) return Promise.resolve(head);
+      return new Promise((resolve, reject) => {
+        const timer = setTimeout(
+          () => reject(new Error("timeout waiting for ws message")),
+          timeoutMs,
+        );
+        waiters.push((v) => {
+          clearTimeout(timer);
+          resolve(v);
+        });
+      });
+    },
+  };
+}
+
+async function connectAccepted(token: string) {
+  const { res, ws } = await connect(token);
+  expect(res.status).toBe(101);
+  expect(ws).not.toBeNull();
+  const messages = messageQueue(ws!);
+  expect(await messages.next()).toEqual({ type: "connected" });
+  return { ws: ws!, messages };
+}
+
+async function setHubDevices(devices: Array<{ tenant_id: string; device_id: string }>) {
+  await env.AUTH_WORKER.fetch("https://auth-worker.internal/__spy/hub-devices", {
+    method: "POST",
+    body: JSON.stringify(devices),
+  });
+}
+
+const openSockets: WebSocket[] = [];
+
+beforeEach(async () => {
+  await env.AUTH_WORKER.fetch("https://auth-worker.internal/__spy/reset", { method: "POST" });
+});
+
+afterEach(() => {
+  for (const ws of openSockets.splice(0)) {
+    try {
+      ws.close();
+    } catch {
+      // already closed
+    }
+  }
+});
+
+describe("parseBatteryPayload", () => {
+  it("accepts a well-formed battery reading", () => {
+    expect(parseBatteryPayload({ read: true, percent: 100, mv: 4202, vbus: false, charge: 2 })).toEqual({
+      read: true,
+      percent: 100,
+      mv: 4202,
+      vbus: false,
+      charge: 2,
+    });
+  });
+
+  it("keeps optional fields absent when the device didn't read power (read:false)", () => {
+    expect(parseBatteryPayload({ read: false })).toEqual({ read: false });
+  });
+
+  it("drops fields with the wrong type instead of keeping bogus values", () => {
+    expect(parseBatteryPayload({ read: true, percent: "100", mv: 4202 })).toEqual({
+      read: true,
+      mv: 4202,
+    });
+  });
+
+  it("returns null for non-objects, arrays, and missing/invalid `read`", () => {
+    expect(parseBatteryPayload(null)).toBeNull();
+    expect(parseBatteryPayload("nope")).toBeNull();
+    expect(parseBatteryPayload([])).toBeNull();
+    expect(parseBatteryPayload({})).toBeNull();
+    expect(parseBatteryPayload({ read: "true" })).toBeNull();
+  });
+});
+
+describe("batterySnapshotKey / storeBatterySnapshot", () => {
+  it("builds a {tenant}/{device}/{ms}.json key", () => {
+    expect(batterySnapshotKey("tenant-1", "device-1", 1234)).toBe("tenant-1/device-1/1234.json");
+  });
+
+  it("stores the reading as JSON under that key", async () => {
+    await storeBatterySnapshot(
+      env.BATTERY_HISTORY,
+      "tenant-1",
+      "device-1",
+      { read: true, percent: 88, mv: 4100, vbus: true, charge: 1 },
+      555,
+    );
+    const obj = await env.BATTERY_HISTORY.get("tenant-1/device-1/555.json");
+    expect(obj).not.toBeNull();
+    const body = await obj!.json();
+    expect(body).toEqual({
+      tenant_id: "tenant-1",
+      device_id: "device-1",
+      recorded_at_ms: 555,
+      read: true,
+      percent: 88,
+      mv: 4100,
+      vbus: true,
+      charge: 1,
+    });
+  });
+});
+
+describe("fetchHubDevices", () => {
+  it("returns the devices auth-worker reports", async () => {
+    await setHubDevices([{ tenant_id: "tenant-1", device_id: "device-1" }]);
+    const devices = await fetchHubDevices(env.AUTH_WORKER, SHARED_SECRET);
+    expect(devices).toEqual([{ tenant_id: "tenant-1", device_id: "device-1" }]);
+  });
+
+  it("returns [] on 401 (wrong secret) instead of throwing", async () => {
+    const devices = await fetchHubDevices(env.AUTH_WORKER, "wrong-secret");
+    expect(devices).toEqual([]);
+  });
+
+  it("filters out malformed entries", async () => {
+    await env.AUTH_WORKER.fetch("https://auth-worker.internal/__spy/hub-devices", {
+      method: "POST",
+      body: JSON.stringify([
+        { tenant_id: "t", device_id: "d" },
+        { tenant_id: "t" }, // device_id 欠落
+        "not-an-object",
+      ]),
+    });
+    const devices = await fetchHubDevices(env.AUTH_WORKER, SHARED_SECRET);
+    expect(devices).toEqual([{ tenant_id: "t", device_id: "d" }]);
+  });
+});
+
+describe("runBatterySnapshotCron", () => {
+  it("queries the connected device, and stores the battery reading to R2", async () => {
+    const { ws, messages } = await connectAccepted("hub-token-tenant-cmd");
+    openSockets.push(ws);
+    await setHubDevices([{ tenant_id: "tenant-cmd", device_id: "device-cmd" }]);
+
+    const cronPromise = runBatterySnapshotCron(env, SHARED_SECRET, 999);
+
+    // 端末側に battery command が届くので、実機の代わりに command_result を返す。
+    const frame = (await messages.next()) as { type: string; id: string; payload: unknown };
+    expect(frame.type).toBe("command");
+    expect(frame.payload).toEqual({ action: "battery" });
+    ws.send(
+      JSON.stringify({
+        type: "command_result",
+        id: frame.id,
+        payload: { read: true, percent: 100, mv: 4202, vbus: false, charge: 2 },
+      }),
+    );
+
+    await cronPromise;
+
+    const obj = await env.BATTERY_HISTORY.get("tenant-cmd/device-cmd/999.json");
+    expect(obj).not.toBeNull();
+    const body = (await obj!.json()) as Record<string, unknown>;
+    expect(body).toEqual({
+      tenant_id: "tenant-cmd",
+      device_id: "device-cmd",
+      recorded_at_ms: 999,
+      read: true,
+      percent: 100,
+      mv: 4202,
+      vbus: false,
+      charge: 2,
+    });
+  });
+
+  it("silently skips a device that isn't connected (no R2 object written)", async () => {
+    await setHubDevices([{ tenant_id: "tenant-cmd", device_id: "no-such-device" }]);
+    await runBatterySnapshotCron(env, SHARED_SECRET, 42);
+    const listed = await env.BATTERY_HISTORY.list({ prefix: "tenant-cmd/no-such-device/" });
+    expect(listed.objects).toHaveLength(0);
+  });
+
+  it("does nothing when auth-worker reports no hub devices", async () => {
+    await expect(runBatterySnapshotCron(env, SHARED_SECRET, 1)).resolves.toBeUndefined();
+  });
+});

--- a/cf-alc-recorder/test/mocks/auth-worker.mjs
+++ b/cf-alc-recorder/test/mocks/auth-worker.mjs
@@ -6,6 +6,9 @@
  * - `POST /alc-internal-proxy/api/hub/measurements` … ingest 転送のモック。
  *   `X-Alc-Proxy-Secret` を検証し、受けた body / X-Tenant-ID を記録する。
  *   item の kind に "boom" が含まれると 500 を返す (上流失敗の再現用)。
+ * - `GET /internal/hub-devices` … battery cron 用 hub device 一覧のモック。
+ *   `Authorization: <shared secret>` を要求。`POST /__spy/hub-devices` で
+ *   テストから内容を差し替えられる (既定は空配列)。
  * - `GET /__spy/ingest` / `POST /__spy/reset` … テストからの観測用。
  */
 
@@ -57,6 +60,7 @@ const TOKENS = {
 };
 
 let ingestCalls = [];
+let hubDevices = [];
 
 function json(data, status = 200) {
   return new Response(JSON.stringify(data), {
@@ -104,11 +108,23 @@ export default {
       return json({ inserted: Array.isArray(items) ? items.length : 0 });
     }
 
+    if (url.pathname === "/internal/hub-devices" && request.method === "GET") {
+      if (request.headers.get("Authorization") !== SHARED_SECRET) {
+        return json({ error: "unauthorized" }, 401);
+      }
+      return json({ devices: hubDevices });
+    }
+
     if (url.pathname === "/__spy/ingest" && request.method === "GET") {
       return json(ingestCalls);
     }
     if (url.pathname === "/__spy/reset" && request.method === "POST") {
       ingestCalls = [];
+      hubDevices = [];
+      return json({ ok: true });
+    }
+    if (url.pathname === "/__spy/hub-devices" && request.method === "POST") {
+      hubDevices = await request.json();
       return json({ ok: true });
     }
 

--- a/cf-alc-recorder/vitest.config.ts
+++ b/cf-alc-recorder/vitest.config.ts
@@ -26,7 +26,7 @@ export default defineWorkersConfig({
           },
           serviceBindings: { AUTH_WORKER: "auth-worker" },
           bindings: { INTERNAL_SHARED_SECRET: "test-shared-secret" },
-          r2Buckets: { CRASH_LOGS: "alc-crash-logs" },
+          r2Buckets: { CRASH_LOGS: "alc-crash-logs", BATTERY_HISTORY: "alc-battery-history" },
           workers: [
             {
               name: "auth-worker",

--- a/cf-alc-recorder/wrangler.toml
+++ b/cf-alc-recorder/wrangler.toml
@@ -25,6 +25,10 @@ account_id = "24b45709d060d957340180e995f0d373"
 enabled = true
 head_sampling_rate = 1
 
+# CoreS3 電源/バッテリー状態の定期取得 (Refs #121)。prod のみ (staging に実機フリートは無い)。
+[triggers]
+crons = ["*/30 * * * *"]
+
 # テナント単位の Durable Object (Hibernatable WebSockets)。
 [durable_objects]
 bindings = [
@@ -57,6 +61,17 @@ secret_name = "INTERNAL_SHARED_SECRET"
 [[r2_buckets]]
 binding = "CRASH_LOGS"
 bucket_name = "alc-crash-logs"
+
+# CoreS3 バッテリー snapshot cron (30分おき、Refs #121) の保存先。
+# key: {tenant_id}/{device_id}/{取得時刻ms}.json。rust-alc-api hub_measurements は
+# 使わない (診断値であって測定データではないため、crash_log と同じ持ち方)。
+# 7日で自動削除する Object Lifecycle Rule はバケット側の運用設定でコードでは制御不可 —
+# 初回 deploy 前に以下を実行すること:
+#   npx wrangler r2 bucket create alc-battery-history
+#   npx wrangler r2 bucket lifecycle add alc-battery-history --expire-days 7
+[[r2_buckets]]
+binding = "BATTERY_HISTORY"
+bucket_name = "alc-battery-history"
 
 # crash_log のメール通知 (best-effort。R2 が正、メールは通知のみ)。
 # security-notification-app と同じ Email Routing send_email binding 方式 —
@@ -94,6 +109,12 @@ secret_name = "INTERNAL_SHARED_SECRET"
 [[env.staging.r2_buckets]]
 binding = "CRASH_LOGS"
 bucket_name = "alc-crash-logs"
+
+# staging は cron ([triggers] は top-level のみ) を持たないが、binding 自体は
+# 手動 scheduled() 検証用に prod と同じバケットを共有する (tenant_id で衝突しない)。
+[[env.staging.r2_buckets]]
+binding = "BATTERY_HISTORY"
+bucket_name = "alc-battery-history"
 
 [[env.staging.send_email]]
 name = "CRASH_EMAIL"


### PR DESCRIPTION
## 概要

`/device/setup` の手動照会 (WS command `{action:"battery"}` → `command_result`) は既にあるが履歴が残らない。DO が WS 接続を持っているので、DO 側 (cf-alc-recorder) で cron 定期取得するのが自然という結論になった。rust-alc-api の hub_measurements は使わない (診断値であって測定データではないため) — crash_log と同じく R2 に直接保存する。

## 設計

- `cf-alc-recorder` に `scheduled()` cron handler を追加 (`*/30 * * * *`、prod のみ)
- 対象 device 一覧は auth-worker の新規内部 API `GET /internal/hub-devices` (ippoan/auth-worker#401) から取得
- 接続中の device へ既存の `/command {action:"battery"}` → `/command-result/:id` を最大 3 秒ポーリング
- 結果を新規 R2 bucket `alc-battery-history` に `{tenantId}/{deviceId}/{取得時刻ms}.json` で保存
- 未接続 device / command_result timeout は silent skip (best-effort)
- **7日で自動削除** — R2 Object Lifecycle Rule (コード側では制御不可、初回 deploy 前の手動 setup として README に明記)

## 変更ファイル

- `src/battery-snapshot.ts` (新規): cron ロジック本体 (`fetchHubDevices` / `parseBatteryPayload` / `storeBatterySnapshot` / `runBatterySnapshotCron`)
- `src/index.ts`: `scheduled()` export + `BATTERY_HISTORY` binding を `Env` に追加
- `wrangler.toml`: `[triggers]` (prod のみ) + `[[r2_buckets]] BATTERY_HISTORY` (prod/staging)
- `test/battery-snapshot.test.ts` (新規): parse/store/fetch/cron 全体 (WS 経由の command_result 往復を含む) の workerd 実機テスト
- `test/mocks/auth-worker.mjs`: `/internal/hub-devices` モック追加
- `README.md`: cron の挙動 + 初回 setup 手順 (`wrangler r2 bucket create` / `lifecycle add`) を追記

## 依存

ippoan/auth-worker#401 (`GET /internal/hub-devices`) が先にマージされている必要がある。

## テスト

- `npx tsc --noEmit` / `npx vitest run` (45 tests, workerd 実機環境) green
- 初回 deploy 前に手動 setup が必要 (README 参照):
  ```sh
  npx wrangler r2 bucket create alc-battery-history
  npx wrangler r2 bucket lifecycle add alc-battery-history --expire-days 7
  ```

Refs #121

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkTfuuRQcFKwpCP21Jdjgy)_