### PR TITLE
fix(web): serial ポート 0 件が続いたら WS ブリッジへフォールバック

### DIFF
--- a/.claude/skills/alc-app-map/SKILL.md
+++ b/.claude/skills/alc-app-map/SKILL.md
@@ -33,7 +33,7 @@ description: yhonda-ohishi-alc/alc-app (業務用アルコールチェッカー�
 | 区画 | 主要ファイル | 役割 |
 |---|---|---|
 | **pages** | `web/app/pages/{index,tenko,login,register,device-claim,device-approve,maintenance}.vue` + `pages/auth/` | 測定 / 点呼 / 認証 / デバイス登録承認 |
-| **composables (デバイス I/O)** | `useFc1200Serial.ts` (WebSerial) `useNfcWebSocket.ts` `useBleGateway.ts` `useSerialDeviceManager.ts` `useCamera.ts` | FC-1200 シリアル / NFC WS / BLE / シリアル管理 / カメラ |
+| **composables (デバイス I/O)** | `useFc1200Serial.ts` (WebSerial) `useNfcWebSocket.ts` `useBleGateway.ts` `useSerialDeviceManager.ts` `useCamera.ts` | FC-1200 シリアル / NFC WS / BLE / シリアル管理 / カメラ。`useFc1200Serial.autoConnect` / `useBleGateway.startAutoConnect` は serial ポート 0 件が続くと `ws://127.0.0.1:{9878,9877}` の WS ブリッジ (alc-gw / Android) へ自動フォールバック (#123) |
 | **composables (顔認証)** | `useFaceAuth.ts` `useFaceDetection.ts` `useFaceSync.ts` `useFingerprint.ts` | 顔検出 (Web Worker) / 同期 / 指紋 |
 | **composables (点呼/通話)** | `useWebRtc.ts` `useTenkoKiosk.ts` `useTenkoAdmin.ts` `useScreenShare.ts` `useVideoRecorder.ts` | WebRTC 通話 / 点呼キオスク / 管理者 / 画面共有 / 録画 |
 | **composables (その他)** | `useAuth.ts` `useManagerAuth.ts` `useOfflineSync.ts` `useDemoMode.ts` `useAndroidLandscape.ts` `useNfcBridgeUpdate.ts` | 認証 / オフライン同期 / デモ / Android |
@@ -57,7 +57,7 @@ description: yhonda-ohishi-alc/alc-app (業務用アルコールチェッカー�
 - **public repo + 秘匿ファイル**: repo は public。`docs/*.pdf` (FC-1200 通信仕様 = Tanita Confidential)・`fc1200-wasm/{src,Cargo.toml,Cargo.lock}` は **.gitignore 済み = 絶対コミットしない** (WASM に compile してプロトコル秘匿)。
 - **semver patch のみ**: バージョンアップは常に patch (0.2.1→0.2.2)。minor/major は上げない。
 - **WebRTC は Hibernatable WebSockets API 必須** (Durable Objects)。
-- **テスト (CLAUDE.md に詳細)**: Vitest 4 + `@nuxt/test-utils` (happy-dom)。fc1200-wasm は `tests/mocks/` でモック (CI に wasm-pack 不要)。ブラウザ API (WebSerial/BLE/NFC) は `Object.defineProperty(navigator, ...)` でモック。**`v8 ignore` 禁止** (`withSetup` / テスト追加 / 到達不能コード削除で対処)。モジュールスコープ状態を持つ composable (`useBleGateway` `useFaceDetection` `useFc1200Serial`) は `vi.resetModules()` + dynamic import で分離。
+- **テスト (CLAUDE.md に詳細)**: Vitest 4 + `@nuxt/test-utils` (happy-dom)。fc1200-wasm と `virtual:pwa-register/vue` は `tests/mocks/` でモック (CI に wasm-pack 不要 / Windows での virtual module 解決エラー回避)。ブラウザ API (WebSerial/BLE/NFC) は `Object.defineProperty(navigator, ...)` でモック。**`v8 ignore` 禁止** (`withSetup` / テスト追加 / 到達不能コード削除で対処)。モジュールスコープ状態を持つ composable (`useBleGateway` `useFaceDetection` `useFc1200Serial`) は `vi.resetModules()` + dynamic import で分離。
 - **mock/live 統一テスト**: `web/tests/utils/api.test.ts` は 1 ファイルで mock と live (実 rust-alc-api コンテナ) 両対応。`API_BASE_URL` 環境変数の有無で切替。fake ID 禁止 (`api-test-data.ts` の実在 UUID を使う)。`docker-compose.test.yml` で GHCR `rust-alc-api:latest` + PG 起動。
 - **型同期**: `cd ~/rust/rust-alc-api && bash scripts/sync-types.sh` → `web/app/types/generated/` に生成 (git 管理、CI で差分チェック)。
 

--- a/web/app/composables/useBleGateway.ts
+++ b/web/app/composables/useBleGateway.ts
@@ -25,6 +25,9 @@ const BLE_WS_URL = 'ws://127.0.0.1:9877'
 const BLE_WS_RECONNECT_DELAY = 3000
 const BLE_WS_MAX_RECONNECT = 10
 
+// serial 探索がこの回数連続で失敗したら WS ブリッジも試す (#123)
+const SERIAL_WS_FALLBACK_AFTER = 2
+
 // シングルトン: 全コンポーネントで共有
 const isConnected = ref(false)
 const error = ref<string | null>(null)
@@ -426,11 +429,25 @@ export function useBleGateway() {
     }
   }
 
-  /** 初回自動接続（複数回リトライ） */
+  /** WS ブリッジへの単発フォールバック試行 — 接続できなければ後始末して false */
+  async function tryWsFallback(): Promise<boolean> {
+    connectWebSocket()
+    await new Promise(r => setTimeout(r, 500))
+    if (isConnected.value) return true
+    disconnectWebSocket()
+    return false
+  }
+
+  /** 初回自動接続（複数回リトライ）。serial 探索の失敗が続いたら WS ブリッジへフォールバック (#123) */
   async function startAutoConnect(maxAttempts = 5, intervalMs = 3000): Promise<boolean> {
     for (let i = 0; i < maxAttempts; i++) {
       const success = await autoConnect()
       if (success) return true
+      // WebSerial があるのにポートが見つからない (GW の WebView で Serial 無効化フラグが
+      // 効いていない等) → alc-gw / Android の WS ブリッジを試す
+      if (isWebSerialSupported() && i + 1 >= SERIAL_WS_FALLBACK_AFTER) {
+        if (await tryWsFallback()) return true
+      }
       if (i < maxAttempts - 1) {
         await new Promise(r => setTimeout(r, intervalMs))
       }

--- a/web/app/composables/useFc1200Serial.ts
+++ b/web/app/composables/useFc1200Serial.ts
@@ -24,6 +24,10 @@ const FC1200_WS_URL = 'ws://127.0.0.1:9878'
 const FC1200_WS_RECONNECT_DELAY = 3000
 const FC1200_WS_MAX_RECONNECT = 10
 
+// serial ポート探索リトライ — 0 件が続いたら WS ブリッジへフォールバック (#123)
+const SERIAL_SCAN_ATTEMPTS = 3
+const SERIAL_SCAN_DELAY = 500
+
 function isBleGwPort(info: SerialPortInfo): boolean {
   // 呼び出し元で usbVendorId !== undefined を確認済み
   return BLE_GW_DEVICES.some(d =>
@@ -154,27 +158,23 @@ export function useFc1200Serial() {
 
   // --- WebSerial transport (PC) ---
 
-  /** 許可済みポートに自動接続（ダイアログなし） */
-  async function autoConnect(): Promise<boolean> {
-    error.value = null
-
-    // WebSerial 非対応 → WebSocket で接続
-    if (!isWebSerialSupported()) {
-      connectWebSocket()
-      await new Promise(r => setTimeout(r, 500))
-      return isConnected.value
-    }
-
+  /** FC-1200 候補の許可済みポートを探す (BLE GW 以外で USB VID があるポートを優先) */
+  async function findSerialPort(): Promise<SerialPort | null> {
     try {
       const ports = await navigator.serial.getPorts()
-      if (ports.length === 0) return false
-
-      // BLE GW 以外で USB VID があるポートを優先
-      port = ports.find(p => {
+      return ports.find((p) => {
         const info = p.getInfo()
         return info.usbVendorId !== undefined && !isBleGwPort(info)
       }) ?? null
-      if (!port) return false
+    }
+    catch {
+      return null
+    }
+  }
+
+  async function openSerialPort(candidate: SerialPort): Promise<boolean> {
+    try {
+      port = candidate
 
       await initFc1200Wasm()
       isWasmReady.value = true
@@ -204,6 +204,36 @@ export function useFc1200Serial() {
       await cleanup()
       return false
     }
+  }
+
+  /** 許可済みポートに自動接続（ダイアログなし）。serial ポート 0 件が続いたら WS ブリッジへフォールバック (#123) */
+  async function autoConnect(): Promise<boolean> {
+    error.value = null
+
+    // WebSerial 非対応 → WebSocket で接続
+    if (!isWebSerialSupported()) {
+      connectWebSocket()
+      await new Promise(r => setTimeout(r, 500))
+      return isConnected.value
+    }
+
+    for (let attempt = 0; attempt < SERIAL_SCAN_ATTEMPTS; attempt++) {
+      const candidate = await findSerialPort()
+      if (candidate) {
+        return openSerialPort(candidate)
+      }
+      if (attempt < SERIAL_SCAN_ATTEMPTS - 1) {
+        await new Promise(r => setTimeout(r, SERIAL_SCAN_DELAY))
+      }
+    }
+
+    // WebSerial はあるのにポートが見つからない (GW の WebView で Serial 無効化フラグが
+    // 効いていない等) → alc-gw / Android の WS ブリッジへフォールバック
+    connectWebSocket()
+    await new Promise(r => setTimeout(r, 500))
+    if (isConnected.value) return true
+    disconnectWebSocket()
+    return false
   }
 
   async function connect(): Promise<void> {

--- a/web/tests/composables/useBleGateway.test.ts
+++ b/web/tests/composables/useBleGateway.test.ts
@@ -474,6 +474,44 @@ describe('useBleGateway', () => {
       await vi.advanceTimersByTimeAsync(500)
       expect(await promise).toBe(false)
     })
+
+    it('serial 接続成功 → 即 true (WS フォールバックなし)', async () => {
+      const { port } = createMockPort({
+        readValues: [{ value: null, done: true }],
+      })
+      installSerialMock({ getPorts: vi.fn(async () => [port]) })
+      const result = await gw.startAutoConnect(2, 10)
+      expect(result).toBe(true)
+      expect(gw.transport.value).toBe('serial')
+      expect(MockWebSocket.instances).toHaveLength(0)
+    })
+
+    it('serial ポート 0 件が続く → 2 回目以降 WS ブリッジへフォールバック (#123)', async () => {
+      installSerialMock({ getPorts: vi.fn(async () => []) })
+      const promise = gw.startAutoConnect(3, 10)
+      // 1 回目の失敗ではまだ WS を試さない
+      await vi.advanceTimersByTimeAsync(0)
+      expect(MockWebSocket.instances).toHaveLength(0)
+      // interval → 2 回目の serial 失敗 → WS フォールバック開始
+      await vi.advanceTimersByTimeAsync(10)
+      expect(MockWebSocket.instances).toHaveLength(1)
+      expect(MockWebSocket.instances[0]!.url).toBe('ws://127.0.0.1:9877')
+      MockWebSocket.instances[0]!.simulateOpen()
+      await vi.advanceTimersByTimeAsync(500)
+      expect(await promise).toBe(true)
+      expect(gw.transport.value).toBe('websocket')
+    })
+
+    it('serial 0 件 + WS ブリッジも不在 → WS を後始末して false (#123)', async () => {
+      installSerialMock({ getPorts: vi.fn(async () => []) })
+      const promise = gw.startAutoConnect(2, 10)
+      await vi.advanceTimersByTimeAsync(10)  // 1 回目失敗 + interval → 2 回目失敗 → WS フォールバック
+      await vi.advanceTimersByTimeAsync(500) // WS 未接続 → disconnect
+      expect(await promise).toBe(false)
+      expect(gw.isConnected.value).toBe(false)
+      expect(MockWebSocket.instances).toHaveLength(1)
+      expect(MockWebSocket.instances[0]!.readyState).toBe(MockWebSocket.CLOSED)
+    })
   })
 
   // =============================================

--- a/web/tests/composables/useFc1200Serial.test.ts
+++ b/web/tests/composables/useFc1200Serial.test.ts
@@ -455,17 +455,66 @@ describe('useFc1200Serial', () => {
       vi.useFakeTimers({ toFake: ['setTimeout', 'setInterval', 'clearTimeout', 'clearInterval'] })
     })
 
-    it('getPorts empty -> returns false', async () => {
+    it('getPorts empty (3 回) -> WS ブリッジへフォールバック、未接続なら false (#123)', async () => {
       installSerialMock({ getPorts: vi.fn(async () => []) })
-      const result = await fc.autoConnect()
-      expect(result).toBe(false)
+      const promise = fc.autoConnect()
+      await vi.advanceTimersByTimeAsync(500) // scan retry 1
+      await vi.advanceTimersByTimeAsync(500) // scan retry 2
+      expect(MockWebSocket.instances.length).toBe(1)
+      expect(MockWebSocket.instances[0]!.url).toBe('ws://127.0.0.1:9878')
+      await vi.advanceTimersByTimeAsync(500) // WS 接続待ち
+      expect(await promise).toBe(false)
+      // フォールバック失敗時は WS を後始末 (バックグラウンド再接続を残さない)
+      expect(MockWebSocket.instances[0]!.readyState).toBe(MockWebSocket.CLOSED)
     })
 
-    it('port found but is BLE GW -> returns false', async () => {
+    it('getPorts empty -> WS フォールバックが接続成功 -> true, transport=websocket (#123)', async () => {
+      installSerialMock({ getPorts: vi.fn(async () => []) })
+      const promise = fc.autoConnect()
+      await vi.advanceTimersByTimeAsync(500) // scan retry 1
+      await vi.advanceTimersByTimeAsync(500) // scan retry 2
+      MockWebSocket.instances[0]!.simulateOpen()
+      await vi.advanceTimersByTimeAsync(500) // WS 接続待ち
+      expect(await promise).toBe(true)
+      expect(fc.isConnected.value).toBe(true)
+      expect(fc.transport.value).toBe('websocket')
+    })
+
+    it('getPorts throws -> ポートなし扱いで WS フォールバック (#123)', async () => {
+      installSerialMock({ getPorts: vi.fn(async () => { throw new Error('boom') }) })
+      const promise = fc.autoConnect()
+      await vi.advanceTimersByTimeAsync(500)
+      await vi.advanceTimersByTimeAsync(500)
+      await vi.advanceTimersByTimeAsync(500)
+      expect(await promise).toBe(false)
+      expect(MockWebSocket.instances.length).toBe(1)
+    })
+
+    it('2 回目のスキャンでポート検出 -> serial 接続 (#123)', async () => {
+      const { port } = createMockPort({
+        getInfoResult: { usbVendorId: 0x9999 },
+        readValues: [{ value: null, done: true }],
+      })
+      const getPorts = vi.fn(async () => [])
+        .mockResolvedValueOnce([])
+        .mockResolvedValue([port])
+      installSerialMock({ getPorts })
+      const promise = fc.autoConnect()
+      await vi.advanceTimersByTimeAsync(500) // scan retry 1 → 検出
+      expect(await promise).toBe(true)
+      expect(fc.transport.value).toBe('serial')
+      expect(MockWebSocket.instances.length).toBe(0)
+    })
+
+    it('port found but is BLE GW -> ポートなし扱いで WS フォールバック', async () => {
       const { port } = createMockPort({ getInfoResult: { usbVendorId: 0x1A86 } }) // CH340
       installSerialMock({ getPorts: vi.fn(async () => [port]) })
-      const result = await fc.autoConnect()
-      expect(result).toBe(false)
+      const promise = fc.autoConnect()
+      await vi.advanceTimersByTimeAsync(500)
+      await vi.advanceTimersByTimeAsync(500)
+      await vi.advanceTimersByTimeAsync(500)
+      expect(await promise).toBe(false)
+      expect(fc.transport.value).toBeNull()
     })
 
     it('port found, connects successfully -> returns true', async () => {
@@ -1328,32 +1377,38 @@ describe('useFc1200Serial', () => {
   // ---------- isBleGwPort ----------
 
   describe('isBleGwPort (tested via autoConnect port filtering)', () => {
+    // 候補ポート 0 件の autoConnect は scan retry ×2 + WS フォールバック (#123)
+    // のタイマーを進めて完走させる
+    async function autoConnectNoCandidate(): Promise<boolean> {
+      const promise = fc.autoConnect()
+      await vi.advanceTimersByTimeAsync(500) // scan retry 1
+      await vi.advanceTimersByTimeAsync(500) // scan retry 2
+      await vi.advanceTimersByTimeAsync(500) // WS 接続待ち
+      return promise
+    }
+
     it('VID matches CH340 -> excluded (BLE GW)', async () => {
       const { port } = createMockPort({ getInfoResult: { usbVendorId: 0x1A86 } })
       installSerialMock({ getPorts: vi.fn(async () => [port]) })
-      const result = await fc.autoConnect()
-      expect(result).toBe(false)
+      expect(await autoConnectNoCandidate()).toBe(false)
     })
 
     it('VID matches CP210x -> excluded', async () => {
       const { port } = createMockPort({ getInfoResult: { usbVendorId: 0x10C4 } })
       installSerialMock({ getPorts: vi.fn(async () => [port]) })
-      const result = await fc.autoConnect()
-      expect(result).toBe(false)
+      expect(await autoConnectNoCandidate()).toBe(false)
     })
 
     it('VID matches Espressif -> excluded', async () => {
       const { port } = createMockPort({ getInfoResult: { usbVendorId: 0x303A } })
       installSerialMock({ getPorts: vi.fn(async () => [port]) })
-      const result = await fc.autoConnect()
-      expect(result).toBe(false)
+      expect(await autoConnectNoCandidate()).toBe(false)
     })
 
     it('VID matches FTDI with matching PID -> excluded', async () => {
       const { port } = createMockPort({ getInfoResult: { usbVendorId: 0x0403, usbProductId: 0x6001 } })
       installSerialMock({ getPorts: vi.fn(async () => [port]) })
-      const result = await fc.autoConnect()
-      expect(result).toBe(false)
+      expect(await autoConnectNoCandidate()).toBe(false)
     })
 
     it('VID matches FTDI but PID does not -> not excluded', async () => {
@@ -1371,8 +1426,7 @@ describe('useFc1200Serial', () => {
       installSerialMock({ getPorts: vi.fn(async () => [port]) })
       // usbVendorId is undefined -> isBleGwPort returns false
       // but autoConnect also requires usbVendorId !== undefined to select port
-      const result = await fc.autoConnect()
-      expect(result).toBe(false)
+      expect(await autoConnectNoCandidate()).toBe(false)
     })
 
     it('unknown VID -> not excluded', async () => {
@@ -1605,8 +1659,12 @@ describe('useFc1200Serial', () => {
 
       // usbVendorId=undefined → isBleGwPort returns false → port is NOT a BLE GW
       // But port also has undefined usbVendorId so autoConnect's find() skips it
-      const result = await fc.autoConnect()
-      expect(result).toBe(false) // No suitable port found
+      // → 候補 0 件 → scan retry ×2 + WS フォールバック (#123) のタイマーを進める
+      const promise = fc.autoConnect()
+      await vi.advanceTimersByTimeAsync(500)
+      await vi.advanceTimersByTimeAsync(500)
+      await vi.advanceTimersByTimeAsync(500)
+      expect(await promise).toBe(false) // No suitable port found
     })
 
     it('sendWsCommand: ws=null → no crash (optional chaining)', async () => {

--- a/web/tests/mocks/pwa-register.ts
+++ b/web/tests/mocks/pwa-register.ts
@@ -1,0 +1,13 @@
+import { ref } from 'vue'
+
+// virtual:pwa-register/vue のテスト用スタブ。
+// Windows では vitest (environment: nuxt) がこの virtual module を
+// `file:///@vite-plugin-pwa/...` として解決しようとして落ちるため、
+// fc1200-wasm と同様に alias で差し替える (テストは Service Worker を使わない)。
+export function useRegisterSW() {
+  return {
+    needRefresh: ref(false),
+    offlineReady: ref(false),
+    updateServiceWorker: async () => {},
+  }
+}

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -26,6 +26,8 @@ export default defineVitestConfig({
   resolve: {
     alias: {
       'fc1200-wasm': resolve(import.meta.dirname!, 'tests/mocks/fc1200-wasm.ts'),
+      // Windows で virtual module の file URL 解決が落ちるためスタブに差し替え
+      'virtual:pwa-register/vue': resolve(import.meta.dirname!, 'tests/mocks/pwa-register.ts'),
     },
   },
 })


### PR DESCRIPTION
## 概要

Closes #123

GW (alc-gw) の WebView で点呼の体温・血圧ステップが「BLE ゲートウェイに接続中...」のまま進まない問題の修正 (Issue の修正候補 A)。`isWebSerialSupported()` が true のとき serial 探索しかせず、WS ブリッジ (9877/9878) へ一切フォールバックしなかった。

## 変更内容

- **useBleGateway.startAutoConnect**: serial 探索の失敗が 2 回続いたら、以降の各試行で `connectWebSocket()` (ws://127.0.0.1:9877) も試す。接続できなければ後始末 (バックグラウンド再接続を残さない) して serial リトライを継続するので、PC/タブレット運用への影響は最小
- **useFc1200Serial.autoConnect**: ポート探索を 3 回 (500ms 間隔) リトライ → 0 件が続いたら WS ブリッジ (ws://127.0.0.1:9878) へフォールバック。測定ステップ (FC-1200) も同じ構造で止まるため両方まとめて対応 (Issue 指示どおり)
- serial 接続処理を `findSerialPort` / `openSerialPort` に分離 (挙動は従来どおり: 実ポートがあって open に失敗した場合は WS へは行かない)
- **vitest 環境修正**: `virtual:pwa-register/vue` を `tests/mocks/pwa-register.ts` に alias。Windows では virtual module の file URL 解決で全スイートが落ちてローカル実行不能だった (CI = Linux では発生しない)。map SKILL.md にも追記

## テスト

- フォールバック経路 (成功 / 失敗後の後始末 / しきい値前は WS を試さない / getPorts 例外 / 2 回目スキャンで serial 検出) を追加
- `npm run test:coverage`: 36 files / 1060 passed、`check_coverage_100.mjs` OK (useBleGateway / useFc1200Serial とも 100% 維持)

## 実機検証 (マージ後)

1. GW の WebView で 通常点呼 → NFC → 顔認証 → 体温・血圧が CoreS3 経由の測定値を受けること (`POST http://127.0.0.1:11984/api/hub/inject` で注入可)
2. 測定ステップ (FC-1200) も同様に進むこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)