### PR TITLE
feat(signaling): 拠点カメラ中継用の CameraSignalingRoom DO を追加

### DIFF
--- a/.claude/skills/alc-app-map/SKILL.md
+++ b/.claude/skills/alc-app-map/SKILL.md
@@ -20,7 +20,7 @@ description: yhonda-ohishi-alc/alc-app (業務用アルコールチェッカー�
 | 区画 | 中身 | 役割 |
 |---|---|---|
 | **`web/`** | Nuxt 4 PWA (`app/` 構成) + `server/` + `wrangler.jsonc` | フロント本体 (Cloudflare Workers `cloudflare_module`)。下表参照 |
-| **`cf-alc-signaling/`** | `src/{index,signaling-room,room-registry}.ts` + `wrangler.toml` | WebRTC signaling worker。Durable Objects (Hibernatable WS) で SDP/ICE リレー。worker 名 `alc-signaling` |
+| **`cf-alc-signaling/`** | `src/{index,signaling-room,room-registry,camera-signaling-room}.ts` + `wrangler.toml` | WebRTC signaling worker。Durable Objects (Hibernatable WS) で SDP/ICE リレー。worker 名 `alc-signaling`。`CameraSignalingRoom` (`/cam-room/:siteId`) は拠点カメラ (C212) 中継用の別系統 DO — `SignalingRoom` と同じ device/admin 1:1 リレーだが `RoomRegistry` (着信通知) を呼ばない (ippoan/alc-app#129) |
 | **`cf-alc-recorder/`** | `src/{index,recorder-hub,auth,measurements}.ts` + `wrangler.toml` + `test/` | CoreS3 (alc-app-s3) 測定データ受口 worker (#106/#108)。上りは WS (`/ws`、テナント単位 DO `RecorderHub`) と Wi-Fi 客向け `POST /measurements` バッチ (#109、ステートレス) の 2 経路 — どちらも device JWT introspect (role allowlist: `device-hub` = CoreS3 / `device-print` = AtomS3 印刷ブリッジ ippoan/alc-app-s3#38。他 role は 403) → auth-worker `/alc-internal-proxy` → rust-alc-api `POST /api/hub/measurements` に転送。例外: `kind=crash_log` (CoreS3 異常リセット復帰レポート、ippoan/alc-app-s3#43) は backend へ転送せず R2 `CRASH_LOGS` (bucket `alc-crash-logs`、key `{tenant}/{device}/{seq 12桁0詰}.json`、再送冪等) へ直接保存して ack + メール通知 (`CRASH_EMAIL` send_email binding、best-effort、security-notification-app と同方式)。下り command push は WS のみ。worker 名 `alc-recorder` |
 | **`fc1200-wasm/`** | (git ignored) Rust → WASM | FC-1200 RS232C プロトコル実装を WASM に compile して**ソース秘匿**。`web` から `fc1200-wasm` import |
 | **`docs/`** | mkdocs (`mkdocs.yml`, admin/ operator/) | 運用ドキュメント。`docs/*.pdf` = Tanita Confidential で **.gitignore** |
@@ -48,7 +48,7 @@ description: yhonda-ohishi-alc/alc-app (業務用アルコールチェッカー�
 
 - **web nitro**: `web/nuxt.config.ts` → `nitro.preset = "cloudflare_module"`、`main = .output/server/index.mjs` (`web/wrangler.jsonc`)。`vite-plugin-wasm` + `optimizeDeps.exclude: ['fc1200-wasm']`。
 - **web wrangler (jsonc)**: top-level = prod (`alc-app`, alc.ippoan.org)。`env.staging` = `alc-app-staging` (alc-staging.ippoan.org)。`NUXT_PUBLIC_{API_BASE,GOOGLE_CLIENT_ID,AUTH_WORKER_URL,STAGING_TENANT_ID,SIGNALING_URL}` を env で切替。
-- **signaling**: `cf-alc-signaling/src/index.ts` (worker entry) → DO `SignalingRoom` (device/admin 2 ピア間リレー) + `RoomRegistry`。`wrangler.toml` に migration v1/v2、`BACKEND_API_URL` var。secret 不要 (STUN P2P のみ、TURN 後日)。
+- **signaling**: `cf-alc-signaling/src/index.ts` (worker entry) → DO `SignalingRoom` (device/admin 2 ピア間リレー、`/room/:roomId`) + `RoomRegistry` (着信通知) + `CameraSignalingRoom` (拠点カメラ中継、`/cam-room/:siteId`、`RoomRegistry` 非連携、ippoan/alc-app#129)。`wrangler.toml` に migration v1/v2/v3、`BACKEND_API_URL` var。secret 不要 (STUN P2P のみ、TURN 後日)。
 - **recorder**: `cf-alc-recorder/src/index.ts` (worker entry)。`/ws` → introspect 後にテナント単位 DO `RecorderHub` (Hibernatable WS、identity は WS attachment) へ routing。`POST /measurements` → DO を経由せず Worker 直で検証 + ingest 転送 (`src/measurements.ts` を WS 経路と共有)。下り `POST /tenants/:t/devices/:d/command` 等は `INTERNAL_SHARED_SECRET` の内部 API。binding: `AUTH_WORKER` (service) + `INTERNAL_SHARED_SECRET` (Secrets Store) + `CRASH_LOGS` (R2、crash_log 保存先) + `CRASH_EMAIL` (send_email、crash メール通知)。prod/staging 2 面 (`env.staging`)。
 - **接続**: `NUXT_PUBLIC_SIGNALING_URL` に signaling worker URL。Room ID = `tenko_session_id`。
 

--- a/cf-alc-signaling/src/camera-signaling-room.ts
+++ b/cf-alc-signaling/src/camera-signaling-room.ts
@@ -1,0 +1,160 @@
+import { DurableObject } from 'cloudflare:workers';
+
+// 拠点カメラ (C212) の全景映像を管理者へ中継するための signaling room。
+// SignalingRoom (遠隔点呼用) と同じ device/admin 1:1 リレーだが、こちらは
+// RoomRegistry (着信通知・スケジュールフィルタ・FCM連携) を一切呼ばない —
+// device が接続するたびに全監視端末へ着信を誤発火させないため、意図的に
+// 別クラスとして分離している (ippoan/alc-app#129)。
+//
+// device (P4 / alc-gw) は起動時に一度だけ接続し、以後は 1s→60s backoff で
+// 繋ぎっぱなしにする想定 (「常時接続」)。admin が接続してきた時点で SDP
+// offer/answer/ICE candidate をこのチャネル越しに中継し、確立後は DO を
+// 経由しない直接 P2P (STUN のみ) に移行する。
+
+type ClientRole = 'device' | 'admin';
+
+interface IceCandidate {
+  candidate: string;
+  sdpMid?: string | null;
+  sdpMLineIndex?: number | null;
+  usernameFragment?: string | null;
+}
+
+interface SignalingMessage {
+  type: 'sdp_offer' | 'sdp_answer' | 'ice_candidate' | 'ping';
+  sdp?: string;
+  candidate?: IceCandidate;
+}
+
+interface ServerMessage {
+  type: 'sdp_offer' | 'sdp_answer' | 'ice_candidate' | 'peer_joined' | 'peer_left' | 'error' | 'pong';
+  sdp?: string;
+  candidate?: IceCandidate;
+  role?: ClientRole;
+  message?: string;
+}
+
+export class CameraSignalingRoom extends DurableObject {
+  async fetch(request: Request): Promise<Response> {
+    const url = new URL(request.url);
+    const role = url.searchParams.get('role') as ClientRole;
+
+    if (request.headers.get('Upgrade') !== 'websocket') {
+      return new Response('Expected WebSocket', { status: 426 });
+    }
+    if (role !== 'device' && role !== 'admin') {
+      return new Response('Missing or invalid role query param. Use ?role=device or ?role=admin', {
+        status: 400,
+      });
+    }
+
+    // 同じ role が既に接続中なら拒否 (1ルーム = device 1本 + admin 1本)
+    const existing = this.ctx.getWebSockets(role);
+    if (existing.length > 0) {
+      return new Response(`Role "${role}" is already connected to this room`, { status: 409 });
+    }
+
+    const pair = new WebSocketPair();
+    this.ctx.acceptWebSocket(pair[1], [role]);
+
+    // 新規参加を相手役に通知
+    this.notifyPeer(role, { type: 'peer_joined', role });
+
+    // 相手役が既に接続済みなら、今接続した側にもそれを伝える
+    const peerRole: ClientRole = role === 'device' ? 'admin' : 'device';
+    const existingPeers = this.ctx.getWebSockets(peerRole);
+    if (existingPeers.length > 0) {
+      this.send(pair[1], { type: 'peer_joined', role: peerRole });
+    }
+
+    return new Response(null, { status: 101, webSocket: pair[0] });
+  }
+
+  async webSocketMessage(ws: WebSocket, message: string | ArrayBuffer): Promise<void> {
+    if (typeof message !== 'string') return;
+
+    let data: SignalingMessage;
+    try {
+      data = JSON.parse(message);
+    } catch {
+      this.send(ws, { type: 'error', message: 'Invalid JSON' });
+      return;
+    }
+
+    const senderRole = this.getRole(ws);
+    if (!senderRole) {
+      this.send(ws, { type: 'error', message: 'Unknown sender' });
+      return;
+    }
+
+    switch (data.type) {
+      case 'sdp_offer':
+        if (senderRole !== 'device') {
+          this.send(ws, { type: 'error', message: 'Only device can send sdp_offer' });
+          return;
+        }
+        this.notifyPeer(senderRole, { type: 'sdp_offer', sdp: data.sdp });
+        break;
+
+      case 'sdp_answer':
+        if (senderRole !== 'admin') {
+          this.send(ws, { type: 'error', message: 'Only admin can send sdp_answer' });
+          return;
+        }
+        this.notifyPeer(senderRole, { type: 'sdp_answer', sdp: data.sdp });
+        break;
+
+      case 'ice_candidate':
+        // trickle ICE を使うクライアント向け (任意)。alc-gw-p4 は non-trickle
+        // 運用の想定でこのメッセージ種別を送らない (Refs #129 の設計判断)
+        this.notifyPeer(senderRole, { type: 'ice_candidate', candidate: data.candidate });
+        break;
+
+      case 'ping':
+        this.send(ws, { type: 'pong' });
+        break;
+
+      default:
+        this.send(ws, { type: 'error', message: `Unknown message type: ${(data as { type: string }).type}` });
+    }
+  }
+
+  async webSocketClose(ws: WebSocket, code: number, reason: string): Promise<void> {
+    const role = this.getRole(ws);
+    if (role) {
+      this.notifyPeer(role, { type: 'peer_left', role });
+    }
+    ws.close(code, reason);
+  }
+
+  async webSocketError(ws: WebSocket): Promise<void> {
+    const role = this.getRole(ws);
+    if (role) {
+      this.notifyPeer(role, { type: 'peer_left', role });
+    }
+    ws.close(1011, 'WebSocket error');
+  }
+
+  private getRole(ws: WebSocket): ClientRole | null {
+    const tags = this.ctx.getTags(ws);
+    if (tags.includes('device')) return 'device';
+    if (tags.includes('admin')) return 'admin';
+    return null;
+  }
+
+  private notifyPeer(senderRole: ClientRole, message: ServerMessage): void {
+    const peerRole: ClientRole = senderRole === 'device' ? 'admin' : 'device';
+    const peers = this.ctx.getWebSockets(peerRole);
+    for (const peer of peers) {
+      this.send(peer, message);
+    }
+  }
+
+  private send(ws: WebSocket, message: ServerMessage): void {
+    try {
+      ws.send(JSON.stringify(message));
+    } catch {
+      // WebSocket already closed
+    }
+  }
+}

--- a/cf-alc-signaling/src/index.ts
+++ b/cf-alc-signaling/src/index.ts
@@ -1,9 +1,11 @@
 export { SignalingRoom } from './signaling-room';
 export { RoomRegistry } from './room-registry';
+export { CameraSignalingRoom } from './camera-signaling-room';
 
 export interface Env {
   SIGNALING_ROOM: DurableObjectNamespace;
   ROOM_REGISTRY: DurableObjectNamespace;
+  CAMERA_SIGNALING_ROOM: DurableObjectNamespace;
   BACKEND_API_URL?: string;
   FCM_INTERNAL_SECRET?: string;
 }
@@ -190,10 +192,26 @@ export default {
       return stub.fetch(new Request(`https://registry/watch?device_id=${encodeURIComponent(deviceId)}`, request));
     }
 
+    // WebSocket endpoint: /cam-room/:siteId → 拠点カメラ中継 (RoomRegistryを
+    // 経由しない独立系統、ippoan/alc-app#129)
+    const camMatch = url.pathname.match(/^\/cam-room\/([a-zA-Z0-9_-]+)$/);
+    if (camMatch) {
+      const roomId = camMatch[1];
+      const role = url.searchParams.get('role');
+      if (role !== 'device' && role !== 'admin') {
+        return new Response('Missing or invalid role query param. Use ?role=device or ?role=admin', {
+          status: 400,
+        });
+      }
+      const id = env.CAMERA_SIGNALING_ROOM.idFromName(roomId);
+      const stub = env.CAMERA_SIGNALING_ROOM.get(id);
+      return stub.fetch(request);
+    }
+
     // WebSocket endpoint: /room/:roomId
     const match = url.pathname.match(/^\/room\/([a-zA-Z0-9_-]+)$/);
     if (!match) {
-      return new Response('Not Found. Use /room/:roomId', { status: 404 });
+      return new Response('Not Found. Use /room/:roomId or /cam-room/:siteId', { status: 404 });
     }
 
     const roomId = match[1];

--- a/cf-alc-signaling/wrangler.toml
+++ b/cf-alc-signaling/wrangler.toml
@@ -17,7 +17,8 @@ BACKEND_API_URL = "https://rust-alc-api-566bls5vfq-an.a.run.app"
 [durable_objects]
 bindings = [
   { name = "SIGNALING_ROOM", class_name = "SignalingRoom" },
-  { name = "ROOM_REGISTRY", class_name = "RoomRegistry" }
+  { name = "ROOM_REGISTRY", class_name = "RoomRegistry" },
+  { name = "CAMERA_SIGNALING_ROOM", class_name = "CameraSignalingRoom" }
 ]
 
 [[migrations]]
@@ -27,3 +28,7 @@ new_classes = ["SignalingRoom"]
 [[migrations]]
 tag = "v2"
 new_classes = ["RoomRegistry"]
+
+[[migrations]]
+tag = "v3"
+new_classes = ["CameraSignalingRoom"]


### PR DESCRIPTION
## Summary
- ippoan/alc-app#129 の実装計画 手順1
- C212全景映像の中継を、WHIP+クラウドSFU方式から「P4/alc-gwが常時接続を保つDOシグナリング + P2P WebRTC (STUNのみ)」方式へ転換する第一歩
- `SignalingRoom` (遠隔点呼用) と同じ device/admin 1:1 リレーロジックを持つが、`RoomRegistry` (着信通知・スケジュールフィルタ・FCM連携) を一切呼ばない独立DOクラス `CameraSignalingRoom` として新設 — TenkoCallの着信フローを汚染しないため
- エンドポイント: `/cam-room/:siteId?role=device|admin`
- `wrangler.toml` に migration v3 (`CameraSignalingRoom`) を追加

## Test plan
- [x] `npx tsc --noEmit` 通過
- [ ] `wrangler dev` でローカルWS接続 (role=device / role=admin) の疎通確認
- [ ] deploy後、TenkoCallの着信 (RoomRegistry経由) に影響が無いことを確認
- 後続PR (alc-gw / alc-gw-p4 のシグナリング置き換え) で実際のP2P確立まで検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)