### PR TITLE
拠点カメラ視聴を AdminDashboard に追加 + admin接続の認証を必須化

### DIFF
--- a/cf-alc-signaling/src/auth.ts
+++ b/cf-alc-signaling/src/auth.ts
@@ -1,0 +1,68 @@
+/**
+ * admin (ブラウザ) 接続の認証ヘルパー。
+ *
+ * JWT の検証は auth-worker `POST /auth/introspect` に委譲する (JWT_SECRET を本
+ * Worker に配布しない、cf-alc-recorder/src/auth.ts と同パターン)。
+ *
+ * introspect の認証は `Authorization: <INTERNAL_SHARED_SECRET>` (生の値、Bearer
+ * prefix なし)。secret の値は log / response に一切出さない。
+ */
+
+/** auth-worker `/auth/introspect` 応答の必要 field。 */
+export interface IntrospectResult {
+  active: boolean;
+  tenant_id?: string;
+  role?: string;
+  sub?: string;
+  email?: string;
+  exp?: number;
+}
+
+/** cam-room admin 接続を許可する role (Google ログイン JWT の role claim、Refs alc-app#129)。 */
+export const CAM_ADMIN_ROLE = "admin";
+
+/** Secrets Store binding (`.get()`) / 文字列 のいずれでも値を取り出す。 */
+export async function resolveSecret(binding: unknown): Promise<string | null> {
+  if (typeof binding === "string") return binding;
+  if (binding && typeof (binding as { get?: unknown }).get === "function") {
+    return (await (binding as { get(): Promise<string> }).get()) ?? null;
+  }
+  return null;
+}
+
+/**
+ * auth-worker `/auth/introspect` を service binding 経由で叩く。
+ * 応答が 200 以外 / JSON でない場合は null (設定不備扱い、caller が 503 を返す)。
+ */
+export async function introspectToken(
+  authWorker: Fetcher,
+  sharedSecret: string,
+  token: string,
+  origin: string,
+): Promise<IntrospectResult | null> {
+  try {
+    const res = await authWorker.fetch("https://auth-worker.internal/auth/introspect", {
+      method: "POST",
+      headers: {
+        Authorization: sharedSecret,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ token, origin }),
+    });
+    if (res.status !== 200) return null;
+    return (await res.json()) as IntrospectResult;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * introspect 結果から admin WS ハンドシェイクの可否を決める (純粋関数)。
+ * - `active` でない (署名不正 / exp 切れ / env 不一致) → 401
+ * - role が "admin" でない (manager / viewer 等) → 403
+ */
+export function decideCamAdminAuth(result: IntrospectResult | null | undefined): 401 | 403 | 101 {
+  if (!result || result.active !== true) return 401;
+  if (result.role !== CAM_ADMIN_ROLE) return 403;
+  return 101;
+}

--- a/cf-alc-signaling/src/index.ts
+++ b/cf-alc-signaling/src/index.ts
@@ -1,3 +1,5 @@
+import { introspectToken, resolveSecret, decideCamAdminAuth } from './auth';
+
 export { SignalingRoom } from './signaling-room';
 export { RoomRegistry } from './room-registry';
 export { CameraSignalingRoom } from './camera-signaling-room';
@@ -8,6 +10,8 @@ export interface Env {
   CAMERA_SIGNALING_ROOM: DurableObjectNamespace;
   BACKEND_API_URL?: string;
   FCM_INTERNAL_SECRET?: string;
+  AUTH_WORKER: Fetcher;
+  INTERNAL_SHARED_SECRET: unknown;
 }
 
 export default {
@@ -203,6 +207,26 @@ export default {
           status: 400,
         });
       }
+
+      // admin (ブラウザ) 接続のみ、Google ログイン JWT (role=admin) を要求する。
+      // device (P4/alc-gw) 側は cam-relay-token の転送経路が未整備のため、
+      // このステップでは未着手 (別途調整、Refs alc-app#129)。
+      if (role === 'admin') {
+        const token = url.searchParams.get('token');
+        if (!token) {
+          return new Response('Missing token query param for role=admin', { status: 401 });
+        }
+        const sharedSecret = await resolveSecret(env.INTERNAL_SHARED_SECRET);
+        if (!sharedSecret) {
+          return new Response('Server misconfigured', { status: 503 });
+        }
+        const result = await introspectToken(env.AUTH_WORKER, sharedSecret, token, url.origin);
+        const status = decideCamAdminAuth(result);
+        if (status !== 101) {
+          return new Response('Unauthorized', { status });
+        }
+      }
+
       const id = env.CAMERA_SIGNALING_ROOM.idFromName(roomId);
       const stub = env.CAMERA_SIGNALING_ROOM.get(id);
       return stub.fetch(request);

--- a/cf-alc-signaling/wrangler.toml
+++ b/cf-alc-signaling/wrangler.toml
@@ -14,6 +14,19 @@ head_sampling_rate = 1
 [vars]
 BACKEND_API_URL = "https://rust-alc-api-566bls5vfq-an.a.run.app"
 
+# cam-room admin (ブラウザ) 接続の Google ログイン JWT を auth-worker /auth/introspect
+# で検証するための service binding (cf-alc-recorder/src/auth.ts と同パターン、Refs alc-app#129)。
+[[services]]
+binding = "AUTH_WORKER"
+service = "auth-worker"
+
+# /auth/introspect の consumer proof。cf-alc-recorder / web/ の kiosk proxy と同じ
+# CF Secrets Store entry を物理共有 (新規 secret ではない)。
+[[secrets_store_secrets]]
+binding = "INTERNAL_SHARED_SECRET"
+store_id = "bd7bc91a3e5f4111add4acf6cb4b8733"
+secret_name = "INTERNAL_SHARED_SECRET"
+
 [durable_objects]
 bindings = [
   { name = "SIGNALING_ROOM", class_name = "SignalingRoom" },

--- a/web/app/components/AdminDashboard.vue
+++ b/web/app/components/AdminDashboard.vue
@@ -25,7 +25,7 @@ function disconnectRtc() {
   isRtcActive.value = false
 }
 
-type TabKey = 'employees' | 'license' | 'queue' | 'webhooks' | 'tenko_call' | 'camera' | 'timecard' | 'devices'
+type TabKey = 'employees' | 'license' | 'queue' | 'webhooks' | 'tenko_call' | 'camera' | 'site_camera' | 'timecard' | 'devices'
 const activeTab = ref<TabKey>('employees')
 const cameraActive = computed(() => activeTab.value === 'camera')
 </script>
@@ -42,6 +42,7 @@ const cameraActive = computed(() => activeTab.value === 'camera')
             { key: 'webhooks', label: 'Webhook' },
             { key: 'tenko_call', label: '中間点呼' },
             { key: 'camera', label: 'リモートカメラ' },
+            { key: 'site_camera', label: '拠点カメラ' },
             { key: 'timecard', label: 'タイムカード' },
             { key: 'devices', label: 'デバイス管理' },
           ]"
@@ -78,6 +79,10 @@ const cameraActive = computed(() => activeTab.value === 'camera')
 
       <div v-if="activeTab === 'tenko_call'">
         <TenkoCallManager />
+      </div>
+
+      <div v-if="activeTab === 'site_camera'">
+        <TenkoCameraView />
       </div>
 
       <div v-if="activeTab === 'timecard'">

--- a/web/app/components/TenkoCameraView.vue
+++ b/web/app/components/TenkoCameraView.vue
@@ -1,0 +1,166 @@
+<script setup lang="ts">
+const config = useRuntimeConfig()
+const { accessToken } = useAuth()
+const webRtc = useWebRtc('admin')
+
+const siteIdInput = ref('')
+const connectedSiteId = ref<string | null>(null)
+const isViewActive = ref(false)
+const isConnecting = ref(false)
+const connectError = ref<string | null>(null)
+
+const videoContainer = ref<HTMLElement | null>(null)
+const videoRef = ref<HTMLVideoElement | null>(null)
+const isFullscreen = ref(false)
+
+const signalingWsUrl = (config.public.signalingUrl as string).replace(/^https/, 'wss').replace(/^http:/, 'ws:')
+
+function toggleFullscreen() {
+  if (!videoContainer.value) return
+  if (!document.fullscreenElement) {
+    videoContainer.value.requestFullscreen()
+  } else {
+    document.exitFullscreen()
+  }
+}
+
+async function startViewing() {
+  const siteId = siteIdInput.value.trim()
+  if (!siteId) return
+
+  if (!accessToken.value) {
+    connectError.value = 'ログインセッションが見つかりません。再ログインしてください。'
+    return
+  }
+
+  if (isViewActive.value) {
+    webRtc.disconnect()
+    isViewActive.value = false
+  }
+
+  connectError.value = null
+  isConnecting.value = true
+  try {
+    await webRtc.connect(signalingWsUrl, siteId, 'cam-room', accessToken.value)
+    connectedSiteId.value = siteId
+    isViewActive.value = true
+  } catch {
+    connectError.value = '接続に失敗しました'
+  } finally {
+    isConnecting.value = false
+  }
+}
+
+function stopViewing() {
+  webRtc.disconnect()
+  isViewActive.value = false
+  connectedSiteId.value = null
+}
+
+watch(() => webRtc.error.value, (e) => {
+  if (e) connectError.value = e
+})
+
+watch(() => webRtc.remoteStream.value, (stream) => {
+  if (videoRef.value) videoRef.value.srcObject = stream
+})
+
+onMounted(() => {
+  document.addEventListener('fullscreenchange', () => {
+    isFullscreen.value = !!document.fullscreenElement
+  })
+})
+
+onUnmounted(() => {
+  webRtc.disconnect()
+})
+</script>
+
+<template>
+  <div class="space-y-4">
+    <!-- 接続フォーム -->
+    <div class="bg-white rounded-xl p-4 shadow-sm space-y-3">
+      <h3 class="text-sm font-medium text-gray-700">拠点カメラ接続</h3>
+      <p class="text-sm text-gray-500">
+        視聴する拠点の site_id を入力してください (hub デバイスの device_id と一致)。
+      </p>
+      <div class="flex gap-2">
+        <input
+          v-model="siteIdInput"
+          type="text"
+          placeholder="site_id"
+          class="flex-1 px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:bg-gray-100"
+          :disabled="isConnecting || isViewActive"
+          @keyup.enter="startViewing"
+        >
+        <button
+          v-if="!isViewActive"
+          class="px-4 py-2 text-sm rounded-lg bg-blue-600 hover:bg-blue-700 text-white font-medium disabled:opacity-50 transition-colors"
+          :disabled="!siteIdInput.trim() || isConnecting"
+          @click="startViewing"
+        >
+          {{ isConnecting ? '接続中...' : '接続' }}
+        </button>
+        <button
+          v-else
+          class="px-4 py-2 text-sm rounded-lg bg-red-100 hover:bg-red-200 text-red-700 font-medium transition-colors"
+          @click="stopViewing"
+        >
+          視聴終了
+        </button>
+      </div>
+      <div v-if="connectError" class="rounded-lg bg-red-50 border border-red-200 px-3 py-2 text-sm text-red-700">
+        {{ connectError }}
+      </div>
+    </div>
+
+    <!-- 映像 -->
+    <div v-if="isViewActive" class="bg-white rounded-xl p-4 shadow-sm space-y-3">
+      <div class="flex items-center justify-between">
+        <div class="flex items-center gap-2 text-sm">
+          <span
+            class="w-2 h-2 rounded-full"
+            :class="webRtc.isPeerConnected.value ? 'bg-green-500 animate-pulse' : 'bg-yellow-400 animate-pulse'"
+          />
+          <span class="text-gray-600">
+            {{ webRtc.isPeerConnected.value ? '受信中' : 'デバイス接続待ち...' }}
+          </span>
+        </div>
+        <span class="text-xs px-2 py-0.5 rounded-full bg-blue-100 text-blue-700 font-mono truncate max-w-[180px]">
+          {{ connectedSiteId }}
+        </span>
+      </div>
+
+      <div ref="videoContainer" class="relative group bg-black rounded-xl overflow-hidden">
+        <video
+          v-show="webRtc.remoteStream.value"
+          ref="videoRef"
+          autoplay
+          playsinline
+          muted
+          class="w-full max-h-[70vh] object-contain mx-auto"
+        />
+        <div
+          v-if="!webRtc.remoteStream.value"
+          class="flex items-center justify-center h-48 text-gray-400 text-sm"
+        >
+          デバイス接続待ち...
+        </div>
+        <button
+          class="absolute top-2 right-2 p-1.5 rounded-lg bg-black/40 hover:bg-black/60 text-white opacity-0 group-hover:opacity-100 transition-opacity"
+          :title="isFullscreen ? '全画面解除' : '全画面表示'"
+          @click="toggleFullscreen"
+        >
+          <svg v-if="!isFullscreen" class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+              d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5l-5-5m5 5v-4m0 4h-4" />
+          </svg>
+          <svg v-else class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+              d="M9 9V4m0 5H4m16 0h-5m5 0V4M9 15v5m0-5H4m16 0h-5m5 0v5" />
+          </svg>
+        </button>
+      </div>
+    </div>
+  </div>
+</template>

--- a/web/app/composables/useWebRtc.ts
+++ b/web/app/composables/useWebRtc.ts
@@ -109,14 +109,15 @@ export function useWebRtc(role: 'device' | 'admin') {
     sendSignaling({ type: 'sdp_offer', sdp: offer.sdp! })
   }
 
-  /** シグナリングサーバーに接続 */
-  async function connect(signalingUrl: string, roomId: string) {
+  /** シグナリングサーバーに接続。token は cam-room 等サーバー側で認証を要求する path 向け (省略可) */
+  async function connect(signalingUrl: string, roomId: string, path: 'room' | 'cam-room' = 'room', token?: string) {
     error.value = null
     disconnect()
 
     createPeerConnection()
 
-    const url = `${signalingUrl}/room/${roomId}?role=${role}`
+    const tokenParam = token ? `&token=${encodeURIComponent(token)}` : ''
+    const url = `${signalingUrl}/${path}/${roomId}?role=${role}${tokenParam}`
     ws = new WebSocket(url)
 
     ws.onopen = () => {

--- a/web/tests/composables/useWebRtc.test.ts
+++ b/web/tests/composables/useWebRtc.test.ts
@@ -93,6 +93,20 @@ describe('useWebRtc', () => {
     expect(rtc.isConnected.value).toBe(true)
   })
 
+  it('connect: path="cam-room" 指定で /cam-room/:siteId に接続する', async () => {
+    const rtc = useWebRtc('admin')
+    await rtc.connect('wss://sig.example.com', 'site-1', 'cam-room')
+    const ws = getWs()
+    expect(ws.url).toBe('wss://sig.example.com/cam-room/site-1?role=admin')
+  })
+
+  it('connect: token 指定時は &token=... がURLに付与される', async () => {
+    const rtc = useWebRtc('admin')
+    await rtc.connect('wss://sig.example.com', 'site-1', 'cam-room', 'jwt.abc def')
+    const ws = getWs()
+    expect(ws.url).toBe('wss://sig.example.com/cam-room/site-1?role=admin&token=jwt.abc%20def')
+  })
+
   it('connect: onopen で ping timer が開始される', async () => {
     const rtc = useWebRtc('admin')
     await rtc.connect('wss://sig.example.com', 'room-1')


### PR DESCRIPTION
## Summary
- Refs #129 手順6。拠点カメラ視聴UIを `AdminDashboard.vue`(Google ログインJWTで保護)の新規タブ「拠点カメラ」として実装。site_id を手入力して `/cam-room/:siteId` に接続する構成 (登録済み拠点一覧APIは現状無いため)。
- `cf-alc-signaling` に admin接続の認証を追加: `role=admin` は `token` クエリパラメータ(Google ログインJWT)必須にし、auth-worker `/auth/introspect`(`cf-alc-recorder` が既に使用中の既存エンドポイント)で検証、`role !== 'admin'` は403、無効なら401で拒否。これまで site_id さえ知っていれば誰でも閲覧できていた状態を admin ログイン必須に変更。
- `wrangler.toml` に `AUTH_WORKER` service binding と、`cf-alc-recorder`/`web/` の kiosk proxy と同じ既存 Secrets Store 項目 `INTERNAL_SHARED_SECRET` を追加(新規シークレットではない)。

## スコープ外 (フォローアップ)
- `role=device` (P4/alc-gw) 側の認証は未着手。P4は既に実機検証済みの接続経路で、`cam-relay-token` の実際の送信方法(ヘッダー/クエリ)を確認できていないため、実機を壊すリスクを避けて別途対応する。

## Test plan
- [x] `npm test` (web/) — 1081件パス
- [x] `node scripts/check_coverage_100.mjs` — 対象30ファイル全て100%
- [x] `npx tsc --noEmit` (cf-alc-signaling、テストランナー無しのため型チェックのみ)
- [ ] デプロイ後、実際に Google ログイン管理者がカメラ視聴できること・非adminロールが403で弾かれることを staging で確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)