### PR TITLE
cf-alc-signaling に custom domain (alc-signaling.ippoan.org) を追加

### DIFF
--- a/.claude/skills/alc-app-map/SKILL.md
+++ b/.claude/skills/alc-app-map/SKILL.md
@@ -112,8 +112,9 @@ description: yhonda-ohishi-alc/alc-app (業務用アルコールチェッカー�
     - URL: https://alc.ippoan.org (custom domain) / alc-app.m-tama-ramu.workers.dev
   - 緊急時 fallback (手動): `cd web && npm run deploy` (= `nuxt build && wrangler deploy`)
 - **cf-alc-signaling (Cloudflare Workers)**: `cd cf-alc-signaling && wrangler deploy`
-  - URL: https://alc-signaling.m-tama-ramu.workers.dev
-  - シークレット不要 (現在 STUN P2P のみ。TURN は後日対応予定)
+  - URL: https://alc-signaling.ippoan.org (custom domain) / alc-signaling.m-tama-ramu.workers.dev
+  - シークレット不要 (STUN P2P のみ。TURN は後日対応予定)。cam-room admin 接続の JWT 検証用に
+    AUTH_WORKER service binding + INTERNAL_SHARED_SECRET (既存 Secrets Store 共有) を追加済み
 - **cf-alc-recorder (Cloudflare Workers)**: CI 経由 (`recorder-deploy.yml`: `npx vitest run` → staging / release deploy)。手動 fallback: `cd cf-alc-recorder && wrangler deploy`
 - **rust-alc-api (GCP Cloud Run)**: 別リポジトリで管理
 - **rust-nfc-bridge**: `v*` タグ push で GitHub Actions が自動リリース (Windows ビルド + MSI 作成 + GitHub Release にアップロード)

--- a/cf-alc-signaling/wrangler.toml
+++ b/cf-alc-signaling/wrangler.toml
@@ -14,6 +14,13 @@ head_sampling_rate = 1
 [vars]
 BACKEND_API_URL = "https://rust-alc-api-566bls5vfq-an.a.run.app"
 
+# workers.dev はプロダクション非推奨 (Cloudflare 公式にも custom domain 推奨と明記)。
+# P4/alc-gw ファームウェアの RELAY_SIGNALING_URL に埋め込む先を安定させるため、
+# 他 Worker (auth.ippoan.org / alc.ippoan.org) と揃えて custom domain を付ける。
+[[routes]]
+pattern = "alc-signaling.ippoan.org"
+custom_domain = true
+
 # cam-room admin (ブラウザ) 接続の Google ログイン JWT を auth-worker /auth/introspect
 # で検証するための service binding (cf-alc-recorder/src/auth.ts と同パターン、Refs alc-app#129)。
 [[services]]

--- a/web/wrangler.jsonc
+++ b/web/wrangler.jsonc
@@ -62,7 +62,7 @@
 				// 未設定だと nuxt.config.ts のデフォルト (http://localhost:8787) にフォールバックし、
 				// 管理画面の一斉テスト/着信テストが ERR_CONNECTION_REFUSED になる。cf-alc-signaling は
 				// 単一環境運用なので prod と同じ URL (Refs ippoan/rust-alc-api#480)。
-				"NUXT_PUBLIC_SIGNALING_URL": "https://alc-signaling.m-tama-ramu.workers.dev"
+				"NUXT_PUBLIC_SIGNALING_URL": "https://alc-signaling.ippoan.org"
 			},
 			// named env は top-level binding を継承しないので再宣言する。
 			// staging は auth-worker-staging を叩く。
@@ -91,7 +91,7 @@
 		"NUXT_ALC_API_URL": "https://alc-api.ippoan.org",
 		"NUXT_PUBLIC_GOOGLE_CLIENT_ID": "747065218280-ugkrbgaoik32f5mmi94sso4b0026j3cp.apps.googleusercontent.com",
 		"NUXT_PUBLIC_AUTH_WORKER_URL": "https://auth.ippoan.org",
-		"NUXT_PUBLIC_SIGNALING_URL": "https://alc-signaling.m-tama-ramu.workers.dev"
+		"NUXT_PUBLIC_SIGNALING_URL": "https://alc-signaling.ippoan.org"
 	},
 	"routes": [
 		{


### PR DESCRIPTION
## Summary
- `cf-alc-signaling` は custom domain 未設定で `*.workers.dev` のまま運用されていた。他 Worker (auth.ippoan.org / alc.ippoan.org) と揃えて `alc-signaling.ippoan.org` の custom domain を追加
- `web/wrangler.jsonc` の `NUXT_PUBLIC_SIGNALING_URL` (prod/staging とも同値) を新ドメインに更新
- 動機: P4/alc-gw ファームウェアの `RELAY_SIGNALING_URL`(カメラ中継先URL、Refs #129)に埋め込む先として、workers.dev より安定した custom domain を使いたい

## Test plan
- [x] `npx tsc --noEmit` (cf-alc-signaling)
- [x] `npm test` (web/) — 1081件パス
- [ ] マージ後デプロイされたら `https://alc-signaling.ippoan.org/health` が 200 を返すこと、既存の `/room`・`/cam-room` 接続が引き続き動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)