### PR TITLE
fix(cf-alc-signaling): webSocketClose/Error でのws.close()再呼び出しを削除

### DIFF
--- a/cf-alc-signaling/src/camera-signaling-room.ts
+++ b/cf-alc-signaling/src/camera-signaling-room.ts
@@ -119,12 +119,17 @@ export class CameraSignalingRoom extends DurableObject {
     }
   }
 
-  async webSocketClose(ws: WebSocket, code: number, reason: string): Promise<void> {
+  async webSocketClose(ws: WebSocket, _code: number, _reason: string): Promise<void> {
+    // ws は runtime 側で既に close 済み (このハンドラが呼ばれる契機そのもの)。
+    // 再度 ws.close() を呼ぶと、abrupt disconnect (ページリロード等) で
+    // client 側が返す予約コード (1005 "No Status Received" 等) をそのまま
+    // 渡すことになり InvalidAccessError で例外になる。例外になると DO 側の
+    // タグ解除が完了せず、再接続が「role already connected」(409) で
+    // 弾かれ続けるゾンビ状態になっていた。
     const role = this.getRole(ws);
     if (role) {
       this.notifyPeer(role, { type: 'peer_left', role });
     }
-    ws.close(code, reason);
   }
 
   async webSocketError(ws: WebSocket): Promise<void> {
@@ -132,7 +137,6 @@ export class CameraSignalingRoom extends DurableObject {
     if (role) {
       this.notifyPeer(role, { type: 'peer_left', role });
     }
-    ws.close(1011, 'WebSocket error');
   }
 
   private getRole(ws: WebSocket): ClientRole | null {

--- a/cf-alc-signaling/src/signaling-room.ts
+++ b/cf-alc-signaling/src/signaling-room.ts
@@ -116,7 +116,13 @@ export class SignalingRoom extends DurableObject<Env> {
     }
   }
 
-  async webSocketClose(ws: WebSocket, code: number, reason: string, _wasClean: boolean): Promise<void> {
+  // ws は runtime 側で既に close 済み (このハンドラが呼ばれる契機そのもの)。
+  // 再度 ws.close() を呼ぶと、abrupt disconnect (ページリロード等) で client
+  // 側が返す予約コード (1005 "No Status Received" 等) をそのまま渡すことに
+  // なり InvalidAccessError で例外になる。例外になると DO 側のタグ解除が
+  // 完了せず、再接続が「role already connected」(409) で弾かれ続ける
+  // ゾンビ状態になっていた (ippoan/alc-app cam-room で実機検証中に発覚)。
+  async webSocketClose(ws: WebSocket, _code: number, _reason: string, _wasClean: boolean): Promise<void> {
     const role = this.getRole(ws);
     if (role) {
       this.notifyPeer(role, { type: 'peer_left', role });
@@ -126,7 +132,6 @@ export class SignalingRoom extends DurableObject<Env> {
         if (roomId) await this.registryRequest('DELETE', roomId);
       }
     }
-    ws.close(code, reason);
   }
 
   async webSocketError(ws: WebSocket, _error: unknown): Promise<void> {
@@ -138,7 +143,6 @@ export class SignalingRoom extends DurableObject<Env> {
         if (roomId) await this.registryRequest('DELETE', roomId);
       }
     }
-    ws.close(1011, 'WebSocket error');
   }
 
   /** Get the role tag attached to a WebSocket */


### PR DESCRIPTION
## Summary
- `SignalingRoom` / `CameraSignalingRoom` の `webSocketClose`/`webSocketError` が、既に close 済みの ws に対して `ws.close(code, reason)` を再度呼んでいた
- abrupt disconnect (ページリロード等) で client 側が予約コード `1005` (No Status Received) を返すケースがあり、そのまま渡すと `InvalidAccessError: Invalid WebSocket close code: 1005` で例外になっていた
- 例外になると DO 側の role tag 解除が完了せず、再接続が「role already connected」(409) で弾かれ続けるゾンビ状態になる — cam-room の実機 (P4/alc-gw-p4) 再接続テスト中に本番で発覚
- 両ファイルとも `ws.close()` の再呼び出しを削除 (このハンドラが呼ばれる契機そのものが「ws は既に close 済み」なので不要)

## Test plan
- [x] `npx tsc --noEmit`
- [ ] マージ後、実機 P4 の再接続 (電源断→復帰、ファーム書き換え後の再起動等) が 409 なしで通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)