### PR TITLE
feat(web): useWebRtc に詳細ログを追加、拠点カメラのsite_idをlocalStorage保存

### DIFF
--- a/web/app/components/TenkoCameraView.vue
+++ b/web/app/components/TenkoCameraView.vue
@@ -1,7 +1,11 @@
 <script setup lang="ts">
+import { isClient } from '~/utils/env'
+
 const config = useRuntimeConfig()
 const { accessToken } = useAuth()
 const webRtc = useWebRtc('admin')
+
+const SITE_ID_STORAGE_KEY = 'alc_camera_site_id'
 
 const siteIdInput = ref('')
 const connectedSiteId = ref<string | null>(null)
@@ -32,6 +36,9 @@ async function startViewing() {
     connectError.value = 'ログインセッションが見つかりません。再ログインしてください。'
     return
   }
+
+  // デバッグ用: 次回このページを開いた時に site_id を再入力しなくて済むように保存
+  if (isClient) localStorage.setItem(SITE_ID_STORAGE_KEY, siteId)
 
   if (isViewActive.value) {
     webRtc.disconnect()
@@ -66,6 +73,10 @@ watch(() => webRtc.remoteStream.value, (stream) => {
 })
 
 onMounted(() => {
+  if (isClient) {
+    const saved = localStorage.getItem(SITE_ID_STORAGE_KEY)
+    if (saved) siteIdInput.value = saved
+  }
   document.addEventListener('fullscreenchange', () => {
     isFullscreen.value = !!document.fullscreenElement
   })

--- a/web/app/composables/useWebRtc.ts
+++ b/web/app/composables/useWebRtc.ts
@@ -18,36 +18,93 @@ export function useWebRtc(role: 'device' | 'admin') {
     ],
   }
 
+  const log = (...args: unknown[]) => console.log(`[useWebRtc:${role}]`, ...args)
+
   function sendSignaling(msg: SignalingOutMessage) {
+    log('sendSignaling ->', msg.type, msg)
     if (ws?.readyState === WebSocket.OPEN) {
       ws.send(JSON.stringify(msg))
+    } else {
+      log('sendSignaling skipped: ws not OPEN (readyState=', ws?.readyState, ')')
     }
+  }
+
+  // 接続中の統計 (bytesReceived等) を定期ログするタイマー。「peer_joined したのに
+  // 映像が固まる」系の切り分け用 (受信データが本当に増えているか vs 増えているのに
+  // 描画されていないかを区別する)。
+  let statsTimer: ReturnType<typeof setInterval> | null = null
+  let lastStatsBytes = -1
+
+  function startStatsLogging() {
+    stopStatsLogging()
+    statsTimer = setInterval(async () => {
+      // disconnect() は stopStatsLogging() (このタイマーの clearInterval) を
+      // pc=null にする前に必ず呼ぶので、このコールバックが動く時点で pc は非null。
+      const stats = await pc!.getStats()
+      stats.forEach((report) => {
+        if (report.type === 'inbound-rtp' && report.kind === 'video') {
+          const delta = lastStatsBytes >= 0 ? report.bytesReceived - lastStatsBytes : 0
+          log(
+            `inbound-rtp video: bytesReceived=${report.bytesReceived} (+${delta}/5s) `
+            + `framesDecoded=${report.framesDecoded} framesDropped=${report.framesDropped} `
+            + `packetsLost=${report.packetsLost} jitter=${report.jitter}`,
+          )
+          lastStatsBytes = report.bytesReceived
+        }
+      })
+    }, 5000)
+  }
+
+  function stopStatsLogging() {
+    if (statsTimer) {
+      clearInterval(statsTimer)
+      statsTimer = null
+    }
+    lastStatsBytes = -1
   }
 
   function createPeerConnection() {
     pc = new RTCPeerConnection(rtcConfig)
 
     pc.onicecandidate = (event) => {
+      log('onicecandidate:', event.candidate ? event.candidate.candidate : '(gathering complete)')
       if (event.candidate) {
         sendSignaling({ type: 'ice_candidate', candidate: event.candidate.toJSON() })
       }
     }
 
+    pc.onicegatheringstatechange = () => {
+      log('iceGatheringState:', pc?.iceGatheringState)
+    }
+
+    pc.oniceconnectionstatechange = () => {
+      log('iceConnectionState:', pc?.iceConnectionState)
+    }
+
+    pc.onsignalingstatechange = () => {
+      log('signalingState:', pc?.signalingState)
+    }
+
     pc.ontrack = (event) => {
+      log('ontrack:', event.track?.kind, event.track?.readyState, 'streams=', event.streams.length)
       remoteStream.value = event.streams[0] || null
+      startStatsLogging()
     }
 
     pc.onconnectionstatechange = () => {
+      log('connectionState:', pc?.connectionState)
       if (pc?.connectionState === 'failed' || pc?.connectionState === 'disconnected') {
         error.value = 'P2P 接続が切断されました'
         isPeerConnected.value = false
         remoteStream.value = null
+        stopStatsLogging()
       }
     }
 
     // ローカルストリームのトラックを追加
     if (localStream) {
       for (const track of localStream.getTracks()) {
+        log('createPeerConnection: adding local track', track.kind)
         pc.addTrack(track, localStream)
       }
     }
@@ -56,26 +113,35 @@ export function useWebRtc(role: 'device' | 'admin') {
   }
 
   async function handleOffer(sdp: string) {
+    log('handleOffer: sdp received, length=', sdp.length)
     if (!pc) createPeerConnection()
     await pc!.setRemoteDescription({ type: 'offer', sdp })
     const answer = await pc!.createAnswer()
     await pc!.setLocalDescription(answer)
+    log('handleOffer: answer created, length=', answer.sdp?.length)
     sendSignaling({ type: 'sdp_answer', sdp: answer.sdp! })
   }
 
   async function handleAnswer(sdp: string) {
+    log('handleAnswer: sdp received, length=', sdp.length)
     if (pc) {
       await pc.setRemoteDescription({ type: 'answer', sdp })
+    } else {
+      log('handleAnswer: pc is null, ignored')
     }
   }
 
   async function handleIceCandidate(candidate: RTCIceCandidateInit) {
+    log('handleIceCandidate:', candidate.candidate)
     if (pc) {
       await pc.addIceCandidate(new RTCIceCandidate(candidate))
+    } else {
+      log('handleIceCandidate: pc is null, ignored')
     }
   }
 
   function handleSignalingMessage(data: SignalingInMessage) {
+    log('handleSignalingMessage <-', data.type, data)
     switch (data.type) {
       case 'sdp_offer':
         if (data.sdp) handleOffer(data.sdp)
@@ -87,6 +153,7 @@ export function useWebRtc(role: 'device' | 'admin') {
         if (data.candidate) handleIceCandidate(data.candidate)
         break
       case 'peer_joined':
+        log('peer_joined')
         isPeerConnected.value = true
         // Device 側: peer(admin)が来たら offer を作成
         if (role === 'device' && pc) {
@@ -94,18 +161,23 @@ export function useWebRtc(role: 'device' | 'admin') {
         }
         break
       case 'peer_left':
+        log('peer_left')
         isPeerConnected.value = false
         remoteStream.value = null
         break
       case 'error':
+        log('server error:', data.message)
         error.value = data.message || 'シグナリングエラー'
         break
+      default:
+        log('unhandled message type:', data.type)
     }
   }
 
   async function createAndSendOffer() {
     const offer = await pc!.createOffer()
     await pc!.setLocalDescription(offer)
+    log('createAndSendOffer: offer created, length=', offer.sdp?.length)
     sendSignaling({ type: 'sdp_offer', sdp: offer.sdp! })
   }
 
@@ -118,9 +190,11 @@ export function useWebRtc(role: 'device' | 'admin') {
 
     const tokenParam = token ? `&token=${encodeURIComponent(token)}` : ''
     const url = `${signalingUrl}/${path}/${roomId}?role=${role}${tokenParam}`
+    log('connect:', `${signalingUrl}/${path}/${roomId}?role=${role}`, token ? '(token付き)' : '(token無し)')
     ws = new WebSocket(url)
 
     ws.onopen = () => {
+      log('ws.onopen')
       isConnected.value = true
       // Keep-alive ping
       pingTimer = setInterval(() => sendSignaling({ type: 'ping' }), 30000)
@@ -130,16 +204,18 @@ export function useWebRtc(role: 'device' | 'admin') {
       try {
         const data: SignalingInMessage = JSON.parse(event.data)
         handleSignalingMessage(data)
-      } catch {
-        // ignore invalid messages
+      } catch (e) {
+        log('ws.onmessage: invalid JSON, ignored', event.data, e)
       }
     }
 
-    ws.onerror = () => {
+    ws.onerror = (event) => {
+      log('ws.onerror', event)
       error.value = 'シグナリングサーバー接続エラー'
     }
 
-    ws.onclose = () => {
+    ws.onclose = (event) => {
+      log('ws.onclose code=', event?.code, 'reason=', event?.reason, 'wasClean=', event?.wasClean)
       isConnected.value = false
       if (pingTimer) {
         clearInterval(pingTimer)
@@ -150,6 +226,7 @@ export function useWebRtc(role: 'device' | 'admin') {
 
   /** カメラ映像の P2P 送信を開始 */
   async function startStreaming(stream: MediaStream) {
+    log('startStreaming: tracks=', stream.getTracks().map(t => t.kind))
     localStream = stream
 
     if (pc) {
@@ -172,6 +249,8 @@ export function useWebRtc(role: 'device' | 'admin') {
 
   /** 切断 */
   function disconnect() {
+    log('disconnect')
+    stopStatsLogging()
     if (pingTimer) {
       clearInterval(pingTimer)
       pingTimer = null

--- a/web/tests/composables/useWebRtc.test.ts
+++ b/web/tests/composables/useWebRtc.test.ts
@@ -37,7 +37,13 @@ class MockRTCPeerConnection {
   onicecandidate: any = null
   ontrack: any = null
   onconnectionstatechange: any = null
+  onicegatheringstatechange: any = null
+  oniceconnectionstatechange: any = null
+  onsignalingstatechange: any = null
   connectionState = 'new'
+  iceGatheringState = 'new'
+  iceConnectionState = 'new'
+  signalingState = 'stable'
 
   createOffer = vi.fn().mockResolvedValue({ type: 'offer', sdp: 'mock-offer-sdp' })
   createAnswer = vi.fn().mockResolvedValue({ type: 'answer', sdp: 'mock-answer-sdp' })
@@ -46,6 +52,7 @@ class MockRTCPeerConnection {
   addIceCandidate = vi.fn().mockResolvedValue(undefined)
   addTrack = vi.fn()
   getSenders = vi.fn().mockReturnValue([])
+  getStats = vi.fn().mockResolvedValue(new Map())
   close = vi.fn()
 
   constructor(_config?: any) {
@@ -499,6 +506,94 @@ describe('useWebRtc', () => {
 
     pc.ontrack?.({ streams: [] } as any)
     expect(rtc.remoteStream.value).toBeNull()
+  })
+
+  // --- pc.onicegatheringstatechange / oniceconnectionstatechange / onsignalingstatechange ---
+
+  it('pc.onicegatheringstatechange → ログのみ (例外にならない)', async () => {
+    const rtc = useWebRtc('device')
+    await rtc.connect('wss://sig.example.com', 'room-1')
+    const pc = getPc()
+
+    pc.iceGatheringState = 'gathering'
+    expect(() => pc.onicegatheringstatechange?.()).not.toThrow()
+  })
+
+  it('pc.oniceconnectionstatechange → ログのみ (例外にならない)', async () => {
+    const rtc = useWebRtc('device')
+    await rtc.connect('wss://sig.example.com', 'room-1')
+    const pc = getPc()
+
+    pc.iceConnectionState = 'checking'
+    expect(() => pc.oniceconnectionstatechange?.()).not.toThrow()
+  })
+
+  it('pc.onsignalingstatechange → ログのみ (例外にならない)', async () => {
+    const rtc = useWebRtc('device')
+    await rtc.connect('wss://sig.example.com', 'room-1')
+    const pc = getPc()
+
+    pc.signalingState = 'have-local-offer'
+    expect(() => pc.onsignalingstatechange?.()).not.toThrow()
+  })
+
+  // --- 統計ログ (startStatsLogging / stopStatsLogging) ---
+
+  it('ontrack 後、5秒ごとに getStats が呼ばれ inbound-rtp video を集計する', async () => {
+    const rtc = useWebRtc('device')
+    await rtc.connect('wss://sig.example.com', 'room-1')
+    const pc = getPc()
+
+    const statsReport = new Map([
+      ['rtp1', {
+        type: 'inbound-rtp', kind: 'video', bytesReceived: 1000,
+        framesDecoded: 10, framesDropped: 0, packetsLost: 0, jitter: 0.01,
+      }],
+      // video 以外 / inbound-rtp 以外は集計対象外 (if 分岐の else 相当を踏む)
+      ['rtp2', { type: 'inbound-rtp', kind: 'audio', bytesReceived: 500 }],
+    ])
+    pc.getStats.mockResolvedValue(statsReport)
+
+    pc.ontrack?.({ streams: [{ id: 's1' } as any as MediaStream] } as any)
+
+    await vi.advanceTimersByTimeAsync(5000)
+    expect(pc.getStats).toHaveBeenCalled()
+
+    // 2回目: bytesReceived の差分 (delta) 計算分岐も踏む
+    statsReport.set('rtp1', { ...statsReport.get('rtp1'), bytesReceived: 2000 } as any)
+    await vi.advanceTimersByTimeAsync(5000)
+    expect(pc.getStats).toHaveBeenCalledTimes(2)
+  })
+
+  it('pc が null になった後の統計tick → getStats を呼ばず早期return', async () => {
+    const rtc = useWebRtc('device')
+    await rtc.connect('wss://sig.example.com', 'room-1')
+    const pc = getPc()
+
+    pc.ontrack?.({ streams: [{ id: 's1' } as any as MediaStream] } as any)
+    rtc.disconnect() // pc=null, かつ stopStatsLogging でタイマー自体もクリアされる
+
+    // タイマーは止まっているはずなので getStats はこれ以上増えない
+    const callsBefore = pc.getStats.mock.calls.length
+    await vi.advanceTimersByTimeAsync(10000)
+    expect(pc.getStats.mock.calls.length).toBe(callsBefore)
+  })
+
+  it('onconnectionstatechange: failed で統計タイマーも停止する (2回目の failed でも安全)', async () => {
+    const rtc = useWebRtc('device')
+    await rtc.connect('wss://sig.example.com', 'room-1')
+    const pc = getPc()
+
+    pc.ontrack?.({ streams: [{ id: 's1' } as any as MediaStream] } as any)
+    pc.connectionState = 'failed'
+    pc.onconnectionstatechange?.()
+
+    const callsAtFail = pc.getStats.mock.calls.length
+    await vi.advanceTimersByTimeAsync(10000)
+    expect(pc.getStats.mock.calls.length).toBe(callsAtFail)
+
+    // 既にタイマーが無い状態で再度 failed → stopStatsLogging の if(statsTimer) が false 分岐
+    expect(() => pc.onconnectionstatechange?.()).not.toThrow()
   })
 
   // --- pc.onconnectionstatechange ---


### PR DESCRIPTION
## Summary
- WebRTC接続 (signaling / ICE / P2P) の切り分けが毎回困難だったため、`useWebRtc.ts` にシグナリングメッセージ送受信・ICE/接続状態変化・5秒毎のinbound-rtp統計 (bytesReceived等) の console.log を追加
- `TenkoCameraView.vue`: デバッグ用に site_id を localStorage に保存・復元 (`alc.ippoan.org/?role=admin` を毎回開き直しても再入力不要にする)

## Test plan
- [x] `npm test` (web/) — 全件パス
- [x] `node scripts/check_coverage_100.mjs` — 対象30ファイル全て100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)