### PR TITLE
fix(web): cam-room の admin answer が ICE gathering 完了を待たず即送信されていた

### DIFF
--- a/web/app/composables/useWebRtc.ts
+++ b/web/app/composables/useWebRtc.ts
@@ -10,6 +10,12 @@ export function useWebRtc(role: 'device' | 'admin') {
   let pc: RTCPeerConnection | null = null
   let localStream: MediaStream | null = null
   let pingTimer: ReturnType<typeof setInterval> | null = null
+  // cam-room の device peer (P4/alc-gw-p4) は non-trickle 実装で、admin からの
+  // ice_candidate メッセージを受信しても無視する (alc-gw-p4/main/signaling_client.c)。
+  // そのため admin 側は answer を即送信せず、ICE gathering 完了を待って全候補を
+  // answer SDP 本体に埋め込んでから送る必要がある (path='cam-room' の時のみ)。
+  let waitForGatheringBeforeAnswer = false
+  const ICE_GATHERING_TIMEOUT_MS = 5000
 
   const rtcConfig: RTCConfiguration = {
     iceServers: [
@@ -112,6 +118,26 @@ export function useWebRtc(role: 'device' | 'admin') {
     return pc
   }
 
+  /** pc.iceGatheringState が 'complete' になるまで待つ (タイムアウト付き)。 */
+  function waitForIceGatheringComplete(): Promise<void> {
+    if (pc!.iceGatheringState === 'complete') return Promise.resolve()
+    return new Promise((resolve) => {
+      const timeoutId = setTimeout(() => {
+        pc!.removeEventListener('icegatheringstatechange', onChange)
+        log('waitForIceGatheringComplete: timeout, send with whatever gathered so far')
+        resolve()
+      }, ICE_GATHERING_TIMEOUT_MS)
+      const onChange = () => {
+        if (pc!.iceGatheringState === 'complete') {
+          clearTimeout(timeoutId)
+          pc!.removeEventListener('icegatheringstatechange', onChange)
+          resolve()
+        }
+      }
+      pc!.addEventListener('icegatheringstatechange', onChange)
+    })
+  }
+
   async function handleOffer(sdp: string) {
     log('handleOffer: sdp received, length=', sdp.length)
     if (!pc) createPeerConnection()
@@ -119,7 +145,19 @@ export function useWebRtc(role: 'device' | 'admin') {
     const answer = await pc!.createAnswer()
     await pc!.setLocalDescription(answer)
     log('handleOffer: answer created, length=', answer.sdp?.length)
-    sendSignaling({ type: 'sdp_answer', sdp: answer.sdp! })
+
+    if (waitForGatheringBeforeAnswer) {
+      // non-trickle peer (P4) は ice_candidate メッセージを無視するため、
+      // 全候補が embed された localDescription を待ってから送る。
+      log('handleOffer: non-trickle peer, waiting for ICE gathering to complete before sending answer')
+      await waitForIceGatheringComplete()
+    }
+
+    // gathering を待った場合は候補が追記された最新の localDescription を使う
+    // (createAnswer() が返した answer オブジェクトは候補を含まない静的スナップショット)。
+    const sdpToSend = pc!.localDescription!.sdp
+    log('handleOffer: sending answer, length=', sdpToSend.length, waitForGatheringBeforeAnswer ? '(候補embed済み)' : '(trickle)')
+    sendSignaling({ type: 'sdp_answer', sdp: sdpToSend })
   }
 
   async function handleAnswer(sdp: string) {
@@ -186,6 +224,7 @@ export function useWebRtc(role: 'device' | 'admin') {
     error.value = null
     disconnect()
 
+    waitForGatheringBeforeAnswer = path === 'cam-room'
     createPeerConnection()
 
     const tokenParam = token ? `&token=${encodeURIComponent(token)}` : ''

--- a/web/tests/composables/useWebRtc.test.ts
+++ b/web/tests/composables/useWebRtc.test.ts
@@ -44,16 +44,36 @@ class MockRTCPeerConnection {
   iceGatheringState = 'new'
   iceConnectionState = 'new'
   signalingState = 'stable'
+  localDescription: any = null
+
+  private gatheringListeners: Array<() => void> = []
 
   createOffer = vi.fn().mockResolvedValue({ type: 'offer', sdp: 'mock-offer-sdp' })
   createAnswer = vi.fn().mockResolvedValue({ type: 'answer', sdp: 'mock-answer-sdp' })
-  setLocalDescription = vi.fn().mockResolvedValue(undefined)
+  setLocalDescription = vi.fn(async (desc: any) => { this.localDescription = desc })
   setRemoteDescription = vi.fn().mockResolvedValue(undefined)
   addIceCandidate = vi.fn().mockResolvedValue(undefined)
   addTrack = vi.fn()
   getSenders = vi.fn().mockReturnValue([])
   getStats = vi.fn().mockResolvedValue(new Map())
   close = vi.fn()
+
+  addEventListener = vi.fn((type: string, listener: () => void) => {
+    if (type === 'icegatheringstatechange') this.gatheringListeners.push(listener)
+  })
+
+  removeEventListener = vi.fn((type: string, listener: () => void) => {
+    if (type === 'icegatheringstatechange') {
+      this.gatheringListeners = this.gatheringListeners.filter(l => l !== listener)
+    }
+  })
+
+  /** テストヘルパー: iceGatheringState を変更し on* ハンドラ + addEventListener 登録分の両方に通知する */
+  setIceGatheringState(state: string) {
+    this.iceGatheringState = state
+    this.onicegatheringstatechange?.()
+    for (const listener of [...this.gatheringListeners]) listener()
+  }
 
   constructor(_config?: any) {
     pcInstances.push(this)
@@ -217,6 +237,83 @@ describe('useWebRtc', () => {
     expect(pc.setRemoteDescription).toHaveBeenCalledWith({ type: 'offer', sdp: 'remote-offer-sdp' })
     expect(pc.createAnswer).toHaveBeenCalled()
     expect(pc.setLocalDescription).toHaveBeenCalledWith({ type: 'answer', sdp: 'mock-answer-sdp' })
+    expect(ws.send).toHaveBeenCalledWith(JSON.stringify({ type: 'sdp_answer', sdp: 'mock-answer-sdp' }))
+  })
+
+  // --- non-trickle peer (path='cam-room') 向け: ICE gathering 完了を待ってから answer 送信 ---
+
+  it('cam-room 接続時: ICE gathering 完了を待ってから answer を送信する (候補embed済みのlocalDescriptionを使う)', async () => {
+    const rtc = useWebRtc('admin')
+    await rtc.connect('wss://sig.example.com', 'site-1', 'cam-room')
+    const ws = getWs()
+    const pc = getPc()
+    ws.onopen?.()
+    ws.send.mockClear()
+
+    ws.onmessage?.({ data: JSON.stringify({ type: 'sdp_offer', sdp: 'remote-offer-sdp' }) } as any)
+    await vi.advanceTimersByTimeAsync(0)
+
+    // gathering 未完了のうちは answer を送らない
+    expect(ws.send).not.toHaveBeenCalledWith(expect.stringContaining('sdp_answer'))
+
+    // 'gathering' への遷移 (complete 以外) では待ち続ける (onChange の else 分岐)
+    pc.setIceGatheringState('gathering')
+    await vi.advanceTimersByTimeAsync(0)
+    expect(ws.send).not.toHaveBeenCalledWith(expect.stringContaining('sdp_answer'))
+
+    // 候補が追記された状態を模して localDescription を更新してから gathering 完了を通知
+    pc.localDescription = { type: 'answer', sdp: 'mock-answer-sdp\r\na=candidate:1 ...\r\n' }
+    pc.setIceGatheringState('complete')
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(ws.send).toHaveBeenCalledWith(JSON.stringify({
+      type: 'sdp_answer',
+      sdp: 'mock-answer-sdp\r\na=candidate:1 ...\r\n',
+    }))
+  })
+
+  it('cam-room 接続時: gathering が既に complete なら即座に answer を送信する', async () => {
+    const rtc = useWebRtc('admin')
+    await rtc.connect('wss://sig.example.com', 'site-1', 'cam-room')
+    const ws = getWs()
+    const pc = getPc()
+    ws.onopen?.()
+    pc.iceGatheringState = 'complete'
+    ws.send.mockClear()
+
+    ws.onmessage?.({ data: JSON.stringify({ type: 'sdp_offer', sdp: 'remote-offer-sdp' }) } as any)
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(ws.send).toHaveBeenCalledWith(JSON.stringify({ type: 'sdp_answer', sdp: 'mock-answer-sdp' }))
+  })
+
+  it('cam-room 接続時: gathering がタイムアウトしても、その時点のlocalDescriptionで送信する', async () => {
+    const rtc = useWebRtc('admin')
+    await rtc.connect('wss://sig.example.com', 'site-1', 'cam-room')
+    const ws = getWs()
+    const pc = getPc()
+    ws.onopen?.()
+    ws.send.mockClear()
+
+    ws.onmessage?.({ data: JSON.stringify({ type: 'sdp_offer', sdp: 'remote-offer-sdp' }) } as any)
+    await vi.advanceTimersByTimeAsync(0)
+
+    // gathering を complete にしないままタイムアウトまで進める
+    await vi.advanceTimersByTimeAsync(5000)
+
+    expect(ws.send).toHaveBeenCalledWith(JSON.stringify({ type: 'sdp_answer', sdp: 'mock-answer-sdp' }))
+  })
+
+  it('room (通常) 接続時: gathering を待たず即座に answer を送信する', async () => {
+    const rtc = useWebRtc('admin')
+    await rtc.connect('wss://sig.example.com', 'room-1') // path='room' (既定)
+    const ws = getWs()
+    ws.onopen?.()
+    ws.send.mockClear()
+
+    ws.onmessage?.({ data: JSON.stringify({ type: 'sdp_offer', sdp: 'remote-offer-sdp' }) } as any)
+    await vi.advanceTimersByTimeAsync(0)
+
     expect(ws.send).toHaveBeenCalledWith(JSON.stringify({ type: 'sdp_answer', sdp: 'mock-answer-sdp' }))
   })
 


### PR DESCRIPTION
## Summary
- P4/alc-gw-p4 (`main/signaling_client.c`) は non-trickle client で、admin から届く `ice_candidate` メッセージを明示的に無視する (`ESP_LOGW "ignoring ice_candidate from admin (non-trickle client)"`)
- 一方 `useWebRtc.ts` の `handleOffer()` は `setLocalDescription` 直後、ICE gathering の完了を待たず `answer` を送信していた。`createAnswer()` が返す SDP には候補が含まれない静的スナップショットのため、実質「候補ゼロの answer」を送っていたことになる
- P4 は ice_candidate を無視するため、admin 側の候補を知る手段が一切なく ICE 接続が必ず `failed` になっていた (実機での拠点カメラ視聴テストで発覚。ブラウザ側 `connectionState: failed` と P4 側 `esp_peer_send_video failed: -3` の継続的な失敗ログで確認)
- `path='cam-room'` で接続した場合のみ、answer 送信前に `pc.iceGatheringState` が `complete` になるまで待ち (タイムアウト5秒のフォールバック付き)、候補が embed された `pc.localDescription.sdp` を送るように修正。screen-share/tenko-call 等の `path='room'` (相手が人間のブラウザ、通常の trickle ICE) は従来通り即送信のまま

## Test plan
- [x] `npm test` (web/) — 全件パス
- [x] `node scripts/check_coverage_100.mjs` — 対象30ファイル全て100%
- [ ] マージ後、実機 (P4 + カメラ) で拠点カメラ視聴が実際に映像を受信できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)