### PR TITLE
chore: chunk load 失敗の自動復旧 module を有効化 (Refs ippoan/auth-worker#452)

### DIFF
--- a/web/nuxt.config.ts
+++ b/web/nuxt.config.ts
@@ -26,9 +26,13 @@ export default defineNuxtConfig({
     preset: 'cloudflare_module',
   },
 
+  // chunk load 失敗 (immutable キャッシュされた `/_nuxt/*.js` の 404) からの自動復旧。
+  // `experimental.emitRouteChunkError = 'manual'` と transpile 登録も module 側が行う
+  // ので consumer は 1 行で済む (Refs ippoan/auth-worker#452)。
   modules: [
     '@nuxtjs/tailwindcss',
     '@vite-pwa/nuxt',
+    '@ippoan/auth-client/module',
   ],
 
   vite: {


### PR DESCRIPTION
Refs ippoan/auth-worker#452 / Refs ippoan/nuxt-trouble#236

## 背景

Cloudflare Workers Static Assets は**存在しないアセットの 404 にも** immutable な長期キャッシュを付けて返します:

```console
$ curl -i https://trouble.ippoan.org/_nuxt/ZZZZnotexist.js
HTTP/2 404
cache-control: public, max-age=31536000, immutable
```

release 直後 (`versions upload` + traffic flip 直後) に `/_nuxt/*.js` の 404 を一度踏むと、ブラウザが
その 404 を 1 年間保持し、**通常のリロードでは永久に復旧しません**。2026-07-30 に nuxt-trouble の
本番がこれで「真っ暗なまま起動しない」状態になりました (`Ctrl+Shift+R` でのみ復旧)。

**この repo (`web/`) は nuxt-trouble と同じく `app.vue` が認証初期化までスピナーだけを描画する構成**
なので、同じ「真っ暗なまま起動しない」症状になります (spinner gate を持つのは trouble と web/ の 2 件)。

## 変更内容

`web/nuxt.config.ts` の `modules` に `'@ippoan/auth-client/module'` を追加するだけです。

auth-client `v0.2.153` (この repo の依存は既にこの版) に入った Nuxt module を有効化します。chunk load
失敗 (`app:chunkError` / `vite:preloadError` / `unhandledrejection`) を検知したら、失敗した URL を
`fetch(url, { cache: 'reload' })` で取り直してキャッシュ上の 404 を上書きしてからリロードします。
単純な `location.reload()` では immutable キャッシュの 404 が再利用されて直らないので、ここが要点です。
60 秒の時間窓で最大 2 回まで。上限に達したら勝手なリロードをやめて画面に案内を出します。

`experimental.emitRouteChunkError: 'manual'` (Nuxt 既定の `'automatic'` は HTTP キャッシュを
バイパスせず効かない) と transpile 登録も module 側が行うので、consumer 側の設定漏れで対策が黙って
無効化されることはありません。

## 検証

ロジックのテストは auth-client 側にあります (16 ケース / 対象ファイル 100%)。nuxt-trouble では module
適用後の**本番 bundle を grep して plugin が実際に注入されていることを確認済み**です
(`ippoan:chunk-reload` / `vite:preloadError` / `app:chunkError` / `cache:"reload"` が entry に含まれる)。

この repo では CI の typecheck / build / coverage が module 解決を検証します。deploy 後に DevTools
Console で以下を実行すると plugin の登録を実機確認できます:

```js
window.dispatchEvent(Object.assign(new Event('vite:preloadError'), {
  payload: new Error('Failed to fetch dynamically imported module: /_nuxt/ZZZZnotexist.js')
}))
```

`sessionStorage` に `ippoan:chunk-reload` が書かれてリロードされれば有効です。


---
_Generated by [Claude Code](https://claude.ai/code/session_01JWMhJSwnCZmunAbbCUtfGd)_