### PR TITLE
feat(web): ハブ測定値の閲覧ページを追加 (Refs ippoan/rust-alc-api#592)

### DIFF
--- a/.claude/skills/alc-app-map/SKILL.md
+++ b/.claude/skills/alc-app-map/SKILL.md
@@ -32,7 +32,7 @@ description: yhonda-ohishi-alc/alc-app (業務用アルコールチェッカー�
 
 | 区画 | 主要ファイル | 役割 |
 |---|---|---|
-| **pages** | `web/app/pages/{index,tenko,login,register,device-claim,device-approve,maintenance}.vue` + `pages/auth/` | 測定 / 点呼 / 認証 / デバイス登録承認 |
+| **pages** | `web/app/pages/{index,tenko,login,register,device-claim,device-approve,maintenance,hub-measurements}.vue` + `pages/auth/` | 測定 / 点呼 / 認証 / デバイス登録承認 / ハブ測定値ビューア。`hub-measurements.vue` は CoreS3 統合ハブ (alc-app-s3) が cf-alc-recorder 経由で溜めた測定を `GET /api/hub/measurements` (Refs ippoan/rust-alc-api#592) から読む閲覧専用ページ — 絞り込みは device_id / kind / 受信日時 (`created_at` の閉区間) で、並びは backend 固定の `created_at DESC`。**総件数は API が返さない** (ingest テーブルが伸び続けるため) ので、ページャは `has_more` + offset だけで組んである。`payload` は JSONB 素通しなので既定は畳んで JSON 表示。admin 認証必須 (`middleware/auth.global.ts` の protectedPaths) |
 | **composables (デバイス I/O)** | `useFc1200Serial.ts` (WebSerial) `useNfcWebSocket.ts` `useBleGateway.ts` `useSerialDeviceManager.ts` `useCamera.ts` | FC-1200 シリアル / NFC WS / BLE / シリアル管理 / カメラ。`useFc1200Serial.autoConnect` / `useBleGateway.startAutoConnect` は serial ポート 0 件が続くと `ws://127.0.0.1:{9878,9877}` の WS ブリッジ (alc-gw / Android) へ自動フォールバック (#123) |
 | **composables (顔認証)** | `useFaceAuth.ts` `useFaceDetection.ts` `useFaceSync.ts` `useFingerprint.ts` | 顔検出 (Web Worker) / 同期 / 指紋 |
 | **composables (点呼/通話)** | `useWebRtc.ts` `useTenkoKiosk.ts` `useTenkoAdmin.ts` `useScreenShare.ts` `useVideoRecorder.ts` | WebRTC 通話 / 点呼キオスク / 管理者 / 画面共有 / 録画 |

--- a/web/app/middleware/auth.global.ts
+++ b/web/app/middleware/auth.global.ts
@@ -4,7 +4,7 @@ export default defineNuxtRouteMiddleware((to) => {
   const config = useRuntimeConfig()
   if (config.public.stagingTenantId) return
 
-  const protectedPaths = ['/register', '/maintenance']
+  const protectedPaths = ['/register', '/maintenance', '/hub-measurements']
 
   if (!protectedPaths.some(p => to.path.startsWith(p))) {
     return // 測定ページ・ログインページは認証不要

--- a/web/app/pages/hub-measurements.vue
+++ b/web/app/pages/hub-measurements.vue
@@ -1,0 +1,250 @@
+<script setup lang="ts">
+// CoreS3 統合ハブ (alc-app-s3) の測定値ビューア (Refs ippoan/rust-alc-api#592)。
+//
+// 経路: CoreS3 →(WSS + device JWT)→ cf-alc-recorder →(service binding)→
+//       auth-worker /alc-internal-proxy → rust-alc-api `POST /api/hub/measurements`
+// で溜まった行を、同じ API の read 側 `GET /api/hub/measurements` から読む。
+// admin browser JWT があれば api.ts の request() が same-origin proxy
+// (/api/proxy → auth-worker /alc-proxy) 経由にするので、ここは素直に呼ぶだけでよい。
+//
+// 並びは backend 固定で `created_at DESC`。総件数は返らない (ingest テーブルが
+// 伸び続けるため) ので、ページャは has_more と offset だけで組む。
+import { listHubMeasurements } from '~/utils/api'
+import { HUB_MEASUREMENT_KINDS, type HubMeasurement } from '~/types'
+
+const PAGE_SIZE = 50
+
+const deviceId = ref('')
+const kind = ref('')
+const from = ref('')
+const to = ref('')
+const offset = ref(0)
+
+const items = ref<HubMeasurement[]>([])
+const hasMore = ref(false)
+const isLoading = ref(false)
+const error = ref<string | null>(null)
+/** payload を展開している行の id。JSONB は 1 行が長いので既定は畳んでおく。 */
+const expanded = ref<Set<string>>(new Set())
+
+/** `datetime-local` の値 (ローカル時刻、TZ 無し) を API に渡す ISO 文字列にする。 */
+function toIso(local: string): string | undefined {
+  if (!local) return undefined
+  const d = new Date(local)
+  return Number.isNaN(d.getTime()) ? undefined : d.toISOString()
+}
+
+async function load() {
+  isLoading.value = true
+  error.value = null
+  try {
+    const res = await listHubMeasurements({
+      device_id: deviceId.value || undefined,
+      kind: kind.value || undefined,
+      from: toIso(from.value),
+      to: toIso(to.value),
+      limit: PAGE_SIZE,
+      offset: offset.value,
+    })
+    items.value = res.items
+    hasMore.value = res.has_more
+    expanded.value = new Set()
+  }
+  catch (e) {
+    error.value = e instanceof Error ? e.message : '測定値の取得に失敗しました'
+    items.value = []
+    hasMore.value = false
+  }
+  finally {
+    isLoading.value = false
+  }
+}
+
+/** 絞り込みを変えたら 1 ページ目から引き直す (offset を残すと空ページが出る)。 */
+async function search() {
+  offset.value = 0
+  await load()
+}
+
+async function nextPage() {
+  offset.value += PAGE_SIZE
+  await load()
+}
+
+async function prevPage() {
+  offset.value = Math.max(0, offset.value - PAGE_SIZE)
+  await load()
+}
+
+async function reset() {
+  deviceId.value = ''
+  kind.value = ''
+  from.value = ''
+  to.value = ''
+  await search()
+}
+
+function toggle(id: string) {
+  const next = new Set(expanded.value)
+  if (next.has(id)) next.delete(id)
+  else next.add(id)
+  expanded.value = next
+}
+
+function formatDateTime(iso: string | null): string {
+  if (!iso) return '—'
+  const d = new Date(iso)
+  return Number.isNaN(d.getTime()) ? iso : d.toLocaleString('ja-JP')
+}
+
+function formatPayload(payload: unknown): string {
+  return JSON.stringify(payload, null, 2)
+}
+
+/** kind の色分け。alcohol だけ目立たせる (点呼で見る値のため)。 */
+function kindClass(k: string): string {
+  if (k === 'alcohol') return 'bg-amber-100 text-amber-800'
+  if (k === 'fc1200_raw') return 'bg-gray-100 text-gray-600'
+  return 'bg-blue-100 text-blue-800'
+}
+
+const pageLabel = computed(() => `${offset.value + 1}〜${offset.value + items.value.length} 件目`)
+
+onMounted(load)
+</script>
+
+<template>
+  <div class="flex flex-col items-center min-h-screen p-4">
+    <header class="w-full max-w-5xl text-center py-6">
+      <h1 class="text-2xl font-bold text-gray-800">ハブ測定値</h1>
+      <p class="text-sm text-gray-500 mt-1">CoreS3 統合ハブから届いた測定データ (新しい順)</p>
+    </header>
+
+    <main class="w-full max-w-5xl flex flex-col gap-4">
+      <!-- 絞り込み -->
+      <div class="bg-white rounded-2xl p-6 shadow-sm">
+        <h2 class="text-lg font-semibold text-gray-700 mb-3">絞り込み</h2>
+        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+          <label class="flex flex-col gap-1">
+            <span class="text-sm text-gray-500">デバイスID</span>
+            <input
+              v-model="deviceId"
+              type="text"
+              placeholder="すべて"
+              class="px-3 py-2 border border-gray-200 rounded-lg text-sm"
+              @keyup.enter="search"
+            >
+          </label>
+          <label class="flex flex-col gap-1">
+            <span class="text-sm text-gray-500">種別</span>
+            <select v-model="kind" class="px-3 py-2 border border-gray-200 rounded-lg text-sm">
+              <option value="">すべて</option>
+              <option v-for="k in HUB_MEASUREMENT_KINDS" :key="k" :value="k">{{ k }}</option>
+            </select>
+          </label>
+          <label class="flex flex-col gap-1">
+            <span class="text-sm text-gray-500">受信日時 (から)</span>
+            <input v-model="from" type="datetime-local" class="px-3 py-2 border border-gray-200 rounded-lg text-sm">
+          </label>
+          <label class="flex flex-col gap-1">
+            <span class="text-sm text-gray-500">受信日時 (まで)</span>
+            <input v-model="to" type="datetime-local" class="px-3 py-2 border border-gray-200 rounded-lg text-sm">
+          </label>
+        </div>
+        <div class="flex gap-2 mt-4">
+          <button
+            class="px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700 transition-colors disabled:opacity-50"
+            :disabled="isLoading"
+            @click="search"
+          >
+            検索
+          </button>
+          <button
+            class="px-4 py-2 bg-gray-200 text-gray-700 rounded-lg text-sm font-medium hover:bg-gray-300 transition-colors disabled:opacity-50"
+            :disabled="isLoading"
+            @click="reset"
+          >
+            条件クリア
+          </button>
+        </div>
+      </div>
+
+      <!-- 一覧 -->
+      <div class="bg-white rounded-2xl p-6 shadow-sm">
+        <div v-if="error" class="text-sm text-red-600 mb-3">{{ error }}</div>
+
+        <div v-if="isLoading" class="text-sm text-gray-500 py-8 text-center">読み込み中...</div>
+
+        <div v-else-if="items.length === 0" class="text-sm text-gray-500 py-8 text-center">
+          該当する測定値がありません
+        </div>
+
+        <div v-else class="overflow-x-auto">
+          <table class="w-full text-sm">
+            <thead class="bg-gray-50">
+              <tr>
+                <th class="px-2 py-2 text-left text-gray-500">受信日時</th>
+                <th class="px-2 py-2 text-left text-gray-500">端末計時</th>
+                <th class="px-2 py-2 text-left text-gray-500">デバイスID</th>
+                <th class="px-2 py-2 text-left text-gray-500">種別</th>
+                <th class="px-2 py-2 text-right text-gray-500">seq</th>
+                <th class="px-2 py-2 text-left text-gray-500">内容</th>
+              </tr>
+            </thead>
+            <tbody>
+              <template v-for="item in items" :key="item.id">
+                <tr class="border-t border-gray-100">
+                  <td class="px-2 py-2 text-gray-700 whitespace-nowrap">{{ formatDateTime(item.created_at) }}</td>
+                  <td class="px-2 py-2 text-gray-500 whitespace-nowrap">{{ formatDateTime(item.recorded_at) }}</td>
+                  <td class="px-2 py-2 font-mono text-gray-700">{{ item.device_id }}</td>
+                  <td class="px-2 py-2">
+                    <span class="px-2 py-0.5 rounded text-xs font-medium" :class="kindClass(item.kind)">{{ item.kind }}</span>
+                  </td>
+                  <td class="px-2 py-2 text-right text-gray-500">{{ item.seq }}</td>
+                  <td class="px-2 py-2">
+                    <button class="text-blue-600 hover:underline text-xs" @click="toggle(item.id)">
+                      {{ expanded.has(item.id) ? '閉じる' : 'JSON を表示' }}
+                    </button>
+                  </td>
+                </tr>
+                <tr v-if="expanded.has(item.id)" class="bg-gray-50">
+                  <td colspan="6" class="px-2 py-2">
+                    <pre class="text-xs text-gray-700 overflow-x-auto">{{ formatPayload(item.payload) }}</pre>
+                  </td>
+                </tr>
+              </template>
+            </tbody>
+          </table>
+        </div>
+
+        <!-- ページャ: 総件数は API が返さないので has_more と offset だけで組む -->
+        <div v-if="items.length > 0" class="flex items-center justify-between mt-4">
+          <span class="text-sm text-gray-500">{{ pageLabel }}</span>
+          <div class="flex gap-2">
+            <button
+              class="px-3 py-2 bg-gray-200 text-gray-700 rounded-lg text-sm hover:bg-gray-300 disabled:opacity-50"
+              :disabled="offset === 0 || isLoading"
+              @click="prevPage"
+            >
+              前へ
+            </button>
+            <button
+              class="px-3 py-2 bg-gray-200 text-gray-700 rounded-lg text-sm hover:bg-gray-300 disabled:opacity-50"
+              :disabled="!hasMore || isLoading"
+              @click="nextPage"
+            >
+              次へ
+            </button>
+          </div>
+        </div>
+      </div>
+    </main>
+
+    <footer class="w-full max-w-5xl py-4">
+      <div class="flex justify-center gap-4">
+        <NuxtLink to="/" class="text-blue-600 hover:underline text-sm">測定画面</NuxtLink>
+        <NuxtLink to="/?role=admin" class="text-blue-600 hover:underline text-sm">管理画面</NuxtLink>
+      </div>
+    </footer>
+  </div>
+</template>

--- a/web/app/types/index.ts
+++ b/web/app/types/index.ts
@@ -1123,6 +1123,39 @@ export interface DtakoDailyHoursResponse {
   per_page: number
 }
 
+// --- Hub measurements (CoreS3 統合ハブ、Refs ippoan/rust-alc-api#592) ---
+
+/** `GET /api/hub/measurements` の 1 行。`payload` は JSONB 素通し (kind 別の型付けは別 issue)。 */
+export interface HubMeasurement {
+  id: string
+  tenant_id: string
+  device_id: string
+  /** temperature / blood_pressure / alcohol / fc1200_raw */
+  kind: string
+  payload: unknown
+  seq: number
+  /** 端末計時。時計未同期端末では null */
+  recorded_at: string | null
+  /** サーバ受信時刻。一覧の並び順・期間絞り込みはこの列が基準 */
+  created_at: string
+}
+
+/**
+ * `GET /api/hub/measurements` のレスポンス。
+ * 総件数は返らない (ingest テーブルが伸び続けるため) ので、次ページの有無は
+ * `has_more` で判断する。
+ */
+export interface HubMeasurementsResponse {
+  items: HubMeasurement[]
+  /** 実際に適用された limit (backend で clamp 済み) */
+  limit: number
+  offset: number
+  has_more: boolean
+}
+
+/** 受理される測定種別 (backend の HUB_MEASUREMENT_KINDS と一致。allowlist 外は 400)。 */
+export const HUB_MEASUREMENT_KINDS = ['temperature', 'blood_pressure', 'alcohol', 'fc1200_raw'] as const
+
 // --- ts-rs 自動生成型 (Rust backend → TypeScript) ---
 // `cargo test -p alc-core --features ts-export --test export_ts` で再生成
 // 段階的に手動型からの移行を進める。まずは Backend prefix 付きで参照可能にする。

--- a/web/app/utils/api.ts
+++ b/web/app/utils/api.ts
@@ -20,6 +20,8 @@ import type {
   DailyHealthResponse, VehicleCategories,
   GuidanceRecord, CreateGuidanceRecord, GuidanceRecordsResponse, GuidanceRecordAttachment,
   CommunicationItem, CreateCommunicationItem, CommunicationItemsResponse,
+  // Hub measurements (CoreS3 統合ハブ)
+  HubMeasurementsResponse,
 } from '~/types'
 import { createAuthFetch } from '@ippoan/auth-client'
 
@@ -1027,4 +1029,25 @@ export async function updateCommunicationItem(id: string, data: Partial<Communic
 
 export async function deleteCommunicationItem(id: string): Promise<void> {
   await request<void>(`/api/communication-items/${id}`, { method: 'DELETE' })
+}
+
+// --- Hub measurements (CoreS3 統合ハブ、Refs ippoan/rust-alc-api#592) ---
+
+/**
+ * CoreS3 ハブ測定の一覧。並びは `created_at DESC` 固定。
+ *
+ * `from` / `to` は `created_at` に対する閉区間 (端末計時 `recorded_at` は時計未同期で
+ * null になり得るため基準に使わない)。`limit` は backend が 1〜200 に clamp し、
+ * 実際に適用された値がレスポンスの `limit` に入る。総件数は返らないので、
+ * 次ページの有無は `has_more` を見る。
+ */
+export async function listHubMeasurements(filter: {
+  device_id?: string
+  kind?: string
+  from?: string
+  to?: string
+  limit?: number
+  offset?: number
+} = {}): Promise<HubMeasurementsResponse> {
+  return request<HubMeasurementsResponse>(`/api/hub/measurements${toParams(filter)}`)
 }

--- a/web/tests/utils/api.test.ts
+++ b/web/tests/utils/api.test.ts
@@ -54,6 +54,8 @@ import {
   listCommunicationItems, getActiveCommunicationItems, createCommunicationItem, updateCommunicationItem, deleteCommunicationItem,
   // TenkoCall admin (#434 step 3d)
   getTenkoCallNumbers, addTenkoCallNumber, deleteTenkoCallNumber, getTenkoCallDrivers,
+  // Hub measurements (CoreS3 統合ハブ、Refs ippoan/rust-alc-api#592)
+  listHubMeasurements,
 } from '~/utils/api'
 import type { MeasurementResult } from '~/types'
 import {
@@ -649,6 +651,7 @@ describe('api', () => {
       ['listGuidanceRecords', () => listGuidanceRecords({}), '/api/guidance-records'],
       ['listCommunicationItems', () => listCommunicationItems({}), '/api/communication-items'],
       ['getDtakoDailyHours', () => getDtakoDailyHours({}), '/api/daily-hours'],
+      ['listHubMeasurements', () => listHubMeasurements(), '/api/hub/measurements'],
     ] as [string, () => Promise<unknown>, string][])(
       '%s({}) → GET %s',
       async (_name, fn, expectedPath) => {
@@ -657,6 +660,25 @@ describe('api', () => {
         assertMock(() => { expect(mockFetch.mock.calls[0][0]).toBe(`https://api.example.com${expectedPath}`) })
       },
     )
+
+    it('listHubMeasurements with filter', async () => {
+      await verifyApi(() => listHubMeasurements({
+        device_id: 'hub-dev-1',
+        kind: 'alcohol',
+        from: '2026-08-01T00:00:00.000Z',
+        to: '2026-08-31T23:59:59.000Z',
+        limit: 50,
+        offset: 50,
+      }))
+      assertMock(() => {
+        const url = String(mockFetch.mock.calls[0][0])
+        expect(url).toContain('/api/hub/measurements?')
+        expect(url).toContain('device_id=hub-dev-1')
+        expect(url).toContain('kind=alcohol')
+        expect(url).toContain('limit=50')
+        expect(url).toContain('offset=50')
+      })
+    })
 
     it('listTimecardCards without employeeId', async () => {
       await verifyApi(() => listTimecardCards(), [])


### PR DESCRIPTION
## 背景

CoreS3 統合ハブ (alc-app-s3) の測定値は cf-alc-recorder → auth-worker → rust-alc-api の経路で `alc_api.hub_measurements` に溜まっているのに、**web に見る画面が無い**状態でした。ippoan/rust-alc-api#593 で読み出し API (`GET /api/hub/measurements`) が入ったので、その表示を足します。

ippoan/rust-alc-api#592 で「管理画面の表示は任意 (別 issue でよい)」とされていた分の実装です。

## 変更

| ファイル | 内容 |
|---|---|
| `app/pages/hub-measurements.vue` (新規) | 閲覧専用ページ。絞り込み (device_id / kind / 受信日時) + ページャ + payload の JSON 表示 |
| `app/utils/api.ts` | `listHubMeasurements()` を追加 |
| `app/types/index.ts` | `HubMeasurement` / `HubMeasurementsResponse` / `HUB_MEASUREMENT_KINDS` |
| `app/middleware/auth.global.ts` | protectedPaths に `/hub-measurements` を追加 (admin 認証必須) |
| `tests/utils/api.test.ts` | 引数なし / フィルタ付きの 2 本 |
| `.claude/skills/alc-app-map/SKILL.md` | pages 行を更新 |

## 設計判断

- **server route は追加していません** — 既存の汎用 proxy (`server/api/proxy/[...path].ts`) と `api.ts` の `request()` が、admin browser JWT があれば same-origin proxy (`/api/proxy` → auth-worker `/alc-proxy`) 経由に切り替えるため、`/api/hub/measurements` はそのまま通ります
- **ページャは `has_more` + offset だけ** — backend は総件数 (`COUNT(*)`) を返しません (ingest テーブルが無制限に伸びるため)。「前へ / 次へ」と件数レンジ表示に留めています
- **型は `types/index.ts` に手動 interface** — generated (ts-rs) 側は i64 が `bigint` になり front から扱いづらいので、既存の `MeasurementsResponse` と同じ流儀に揃えました。`app/types/**` は vitest coverage の exclude 対象です
- **`payload` は既定で畳む** — JSONB 素通しで 1 行が長くなるため、行ごとに「JSON を表示」で開きます
- 期間の絞り込みは **`created_at` (サーバ受信時刻) 基準** — backend の仕様どおり。`recorded_at` は端末の時計未同期で null になり得るためです

## カバレッジ

vitest の coverage は `include: ['app/**/*.ts']` なので、新規の `.vue` は対象外です。影響するのは `coverage_100.toml` 登録済みの 2 本:

- `app/utils/api.ts` — 追加した `listHubMeasurements` は分岐なし。デフォルト引数の分岐込みでテスト 2 本を足しています
- `app/middleware/auth.global.ts` — 配列リテラルへの要素追加のみ

## 検証について

**この作業環境では `npm install` が通らず、ローカルで vitest を回せていません。** `@ippoan/*` が GitHub Packages にあり、手元の token に `read:packages` scope が無いためです (E403)。CI の Vitest+Coverage に検証を委ねています。落ちたら直します。

## 動作確認の目安

admin ログイン後 `/hub-measurements` を開くと、直近の測定が新しい順に並びます。実機からの送信は ippoan/alc-app-s3#111 で疎通確認済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)