### PR TITLE
feat(admin): 免許証タブに「theearth から乗務員マスタを同期」ボタン (Refs ippoan/alc-app-s3#125)

### DIFF
--- a/web/app/components/LicenseRegistration.vue
+++ b/web/app/components/LicenseRegistration.vue
@@ -128,6 +128,11 @@ async function fetchData() {
 // theearth 側で、relay が cron で流している。管理者が今すぐ回して結果を見るためのボタン。
 const isSyncing = ref(false)
 const syncResult = ref<DriverMasterSyncResult | null>(null)
+// server route (server/api/driver-master/run.post.ts) は role=admin 以外を 403 にする。
+// 押してから 403 を見せるより先に分かるよう、viewer にはボタンを disabled で出す
+// (最終判定は route 側。ここは表示だけ)。
+const { user } = useAuth()
+const canSyncDriverMaster = computed(() => user.value?.role === 'admin')
 
 async function handleDriverMasterSync() {
   isSyncing.value = true
@@ -190,8 +195,9 @@ onMounted(() => {
             NFC {{ isConnected ? '接続中' : '未接続' }}
           </span>
           <button
-            :disabled="isSyncing"
-            class="px-3 py-1.5 bg-emerald-600 text-white rounded-lg text-sm hover:bg-emerald-700 transition-colors disabled:opacity-50"
+            :disabled="isSyncing || !canSyncDriverMaster"
+            :title="canSyncDriverMaster ? '' : '管理者のみ'"
+            class="px-3 py-1.5 bg-emerald-600 text-white rounded-lg text-sm hover:bg-emerald-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
             @click="handleDriverMasterSync"
           >
             {{ isSyncing ? '同期中...' : 'theearth から乗務員マスタを同期' }}

--- a/web/app/components/LicenseRegistration.vue
+++ b/web/app/components/LicenseRegistration.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import type { ApiEmployee, NfcLicenseReadEvent } from '~/types'
-import { getEmployees, updateEmployeeLicense, updateEmployeeNfcId } from '~/utils/api'
+import type { ApiEmployee, DriverMasterSyncResult, NfcLicenseReadEvent } from '~/types'
+import { getEmployees, runDriverMasterSync, updateEmployeeLicense, updateEmployeeNfcId } from '~/utils/api'
 import {
   parseLicenseIssueDate,
   parseLicenseExpiryDate,
@@ -124,6 +124,30 @@ async function fetchData() {
   }
 }
 
+// theearth 乗務員マスタ同期 (Refs ippoan/alc-app-s3#125)。免許の交付日・有効期限の正は
+// theearth 側で、relay が cron で流している。管理者が今すぐ回して結果を見るためのボタン。
+const isSyncing = ref(false)
+const syncResult = ref<DriverMasterSyncResult | null>(null)
+
+async function handleDriverMasterSync() {
+  isSyncing.value = true
+  error.value = null
+  syncResult.value = null
+  try {
+    syncResult.value = await runDriverMasterSync()
+    // 免許日付が入った行が増えるので一覧を再読込
+    await fetchData()
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : '同期エラー'
+  } finally {
+    isSyncing.value = false
+  }
+}
+
+function syncStatusLabel(status: number): string {
+  return status === 200 ? '成功' : `HTTP ${status}`
+}
+
 function statusLabel(status: LicenseExpiryStatus | null): string {
   switch (status) {
     case 'valid': return '有効'
@@ -166,12 +190,60 @@ onMounted(() => {
             NFC {{ isConnected ? '接続中' : '未接続' }}
           </span>
           <button
+            :disabled="isSyncing"
+            class="px-3 py-1.5 bg-emerald-600 text-white rounded-lg text-sm hover:bg-emerald-700 transition-colors disabled:opacity-50"
+            @click="handleDriverMasterSync"
+          >
+            {{ isSyncing ? '同期中...' : 'theearth から乗務員マスタを同期' }}
+          </button>
+          <button
             class="px-3 py-1.5 bg-blue-600 text-white rounded-lg text-sm hover:bg-blue-700 transition-colors"
             @click="fetchData"
           >
             更新
           </button>
         </div>
+      </div>
+    </div>
+
+    <!-- 乗務員マスタ同期の結果 (comp = theearth の会社 ごと) -->
+    <div v-if="syncResult" class="bg-white rounded-xl p-4 shadow-sm mb-4 text-sm">
+      <div class="flex items-center justify-between mb-2">
+        <span class="font-medium text-gray-800">乗務員マスタ同期の結果</span>
+        <button class="text-xs text-gray-500 hover:text-gray-700" @click="syncResult = null">閉じる</button>
+      </div>
+      <div v-if="syncResult.results.length === 0" class="text-gray-500">
+        同期対象の会社がありません
+      </div>
+      <div v-for="r in syncResult.results" :key="r.comp_id" class="border-t border-gray-100 py-2">
+        <div class="flex items-center gap-4">
+          <span class="font-mono text-gray-800">comp {{ r.comp_id }}</span>
+          <span
+            class="inline-block px-2 py-0.5 rounded-full text-xs font-medium"
+            :class="r.status === 200 ? 'bg-green-100 text-green-800' : 'bg-red-100 text-red-800'"
+          >
+            {{ syncStatusLabel(r.status) }}
+          </span>
+          <template v-if="!r.error">
+            <span>作成: <strong class="text-gray-800">{{ r.created ?? '-' }}</strong></span>
+            <span>更新: <strong class="text-gray-800">{{ r.updated ?? '-' }}</strong></span>
+          </template>
+          <span v-if="r.error" class="text-red-700">{{ r.error }}</span>
+        </div>
+        <table v-if="r.skipped && r.skipped.length > 0" class="mt-2 text-xs">
+          <thead class="text-gray-500">
+            <tr>
+              <th class="pr-4 text-left font-medium">スキップした社員番号</th>
+              <th class="text-left font-medium">理由</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="sk in r.skipped" :key="sk.code">
+              <td class="pr-4 font-mono text-gray-800">{{ sk.code }}</td>
+              <td class="text-amber-700">{{ sk.reason }}</td>
+            </tr>
+          </tbody>
+        </table>
       </div>
     </div>
 

--- a/web/app/types/index.ts
+++ b/web/app/types/index.ts
@@ -1156,6 +1156,25 @@ export interface HubMeasurementsResponse {
 /** 受理される測定種別 (backend の HUB_MEASUREMENT_KINDS と一致。allowlist 外は 400)。 */
 export const HUB_MEASUREMENT_KINDS = ['temperature', 'blood_pressure', 'alcohol', 'fc1200_raw'] as const
 
+// ============================================================
+// Driver master sync (theearth 乗務員マスタ → alc employees、Refs ippoan/alc-app-s3#125)
+// ============================================================
+
+/** 1 comp (theearth の会社) 分の同期結果。`status` は relay が DO から受けた HTTP status。 */
+export interface DriverMasterSyncCompResult {
+  comp_id: string
+  status: number
+  created?: number | null
+  updated?: number | null
+  skipped?: Array<{ code: string; reason: string }>
+  error?: string
+}
+
+/** `POST /api/driver-master/run` (same-origin server route) の応答。 */
+export interface DriverMasterSyncResult {
+  results: DriverMasterSyncCompResult[]
+}
+
 // --- ts-rs 自動生成型 (Rust backend → TypeScript) ---
 // `cargo test -p alc-core --features ts-export --test export_ts` で再生成
 // 段階的に手動型からの移行を進める。まずは Backend prefix 付きで参照可能にする。

--- a/web/app/utils/api.ts
+++ b/web/app/utils/api.ts
@@ -22,6 +22,8 @@ import type {
   CommunicationItem, CreateCommunicationItem, CommunicationItemsResponse,
   // Hub measurements (CoreS3 統合ハブ)
   HubMeasurementsResponse,
+  // Driver master sync (Refs ippoan/alc-app-s3#125)
+  DriverMasterSyncResult,
 } from '~/types'
 import { createAuthFetch } from '@ippoan/auth-client'
 
@@ -115,10 +117,14 @@ async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
 
 /** device JWT を Bearer に載せて same-origin proxy (/api/proxy) に転送する。 */
 async function proxyRequest<T>(path: string, jwt: string, options: RequestInit): Promise<T> {
-  const proxyPath = toProxyPath(path)
+  return bearerRequest<T>(toProxyPath(path), jwt, options)
+}
+
+/** JWT を Bearer に載せて same-origin URL を叩く (proxy 経路と server route 直叩きの共通部)。 */
+async function bearerRequest<T>(url: string, jwt: string, options: RequestInit): Promise<T> {
   const headers = new Headers(options.headers)
   headers.set('Authorization', `Bearer ${jwt}`)
-  const res = await fetch(proxyPath, { ...options, headers })
+  const res = await fetch(url, { ...options, headers })
   if (!res.ok) {
     const body = await res.text()
     throw new Error(`API エラー (${res.status}): ${body || res.statusText}`)
@@ -328,6 +334,19 @@ export async function updateEmployeeLicense(
       license_expiry_date: licenseExpiryDate ?? null,
     }),
   })
+}
+
+/**
+ * 免許証タブ「theearth から乗務員マスタを同期」(Refs ippoan/alc-app-s3#125)。
+ * rust-alc-api ではなく alc-app 自身の server route `/api/driver-master/run` を
+ * same-origin で叩く (proxy 経由にしない)。route が admin browser JWT を introspect
+ * して tenant_id を決め、dtako-scraper-relay に同期を依頼する — ここからは
+ * tenant_id を送らない (送っても route は読まない)。
+ */
+export async function runDriverMasterSync(): Promise<DriverMasterSyncResult> {
+  const jwt = getAccessToken?.()
+  if (!jwt) throw new Error('ログインが必要です')
+  return bearerRequest<DriverMasterSyncResult>('/api/driver-master/run', jwt, { method: 'POST' })
 }
 
 /** 測定の顔写真を取得 (認証付きプロキシ経由) */

--- a/web/server/api/driver-master/run.post.ts
+++ b/web/server/api/driver-master/run.post.ts
@@ -1,0 +1,75 @@
+/**
+ * 免許証タブ「theearth から乗務員マスタを同期」(Refs ippoan/alc-app-s3#125)。
+ *
+ * 経路: 管理者ブラウザ (browser JWT を Bearer、body 無し)
+ *   → 本 route: token を auth-worker `/auth/introspect` (AUTH_WORKER service binding)
+ *     で検証して active / tenant_id / role を得る (print/[deviceId].post.ts と同型)
+ *   → role が管理者でなければ 403
+ *   → dtako-scraper-relay `POST /kintai-relay/driver-master-run` (SCRAPER_RELAY
+ *     service binding + X-Alc-Proxy-Secret = INTERNAL_SHARED_SECRET) に `{tenant_id}`
+ *   → relay の応答 (status と JSON) をそのまま返す。
+ *
+ * ★ tenant_id は introspect の結果だけを使う。ブラウザからの body / query は読まない。
+ * ★ INTERNAL_SHARED_SECRET はこの route の中だけ (ブラウザに返さない・ログしない)。
+ *
+ * 純粋ロジック (認可判定・forward 構築) は server/utils/driver-master-sync.ts。
+ */
+import type { H3Event } from 'h3'
+import { buildIntrospectForward } from '../../utils/print-relay'
+import { buildDriverMasterRunForward, decideDriverMasterAccess } from '../../utils/driver-master-sync'
+
+function cfEnv(event: H3Event): Record<string, unknown> {
+  return (event.context.cloudflare as { env?: Record<string, unknown> } | undefined)?.env ?? {}
+}
+
+async function resolveSecret(binding: unknown): Promise<string | null> {
+  if (typeof binding === 'string') return binding
+  if (binding && typeof (binding as { get?: unknown }).get === 'function') {
+    return (await (binding as { get(): Promise<string> }).get()) ?? null
+  }
+  return null
+}
+
+function bearerToken(authHeader: string | undefined): string | undefined {
+  if (!authHeader) return undefined
+  const m = /^Bearer\s+(.+)$/i.exec(authHeader)
+  return m ? m[1] : undefined
+}
+
+export default defineEventHandler(async (event) => {
+  const token = bearerToken(getHeader(event, 'authorization'))
+  if (!token) {
+    throw createError({ statusCode: 401, statusMessage: '認証が必要です' })
+  }
+
+  const env = cfEnv(event)
+  const sharedSecret = await resolveSecret(env.INTERNAL_SHARED_SECRET)
+  const authWorker = env.AUTH_WORKER as { fetch: typeof fetch } | undefined
+  const relay = env.SCRAPER_RELAY as { fetch: typeof fetch } | undefined
+  if (!sharedSecret || !authWorker || !relay) {
+    throw createError({ statusCode: 503, statusMessage: 'binding が未設定です' })
+  }
+
+  // 1. 管理者の browser JWT を introspect → active / tenant_id / role
+  const introspect = buildIntrospectForward({
+    sharedSecret,
+    token,
+    origin: getRequestURL(event).origin,
+  })
+  const introRes = await authWorker.fetch(introspect.url, introspect.init)
+  if (introRes.status !== 200) {
+    throw createError({ statusCode: 503, statusMessage: 'introspect に失敗しました' })
+  }
+  const access = decideDriverMasterAccess(await introRes.json())
+  if (!access.ok) {
+    throw createError({ statusCode: access.status, statusMessage: access.message })
+  }
+
+  // 2. relay へ同期を依頼し、応答 (status + JSON) を素通しする
+  const fwd = buildDriverMasterRunForward({ sharedSecret, tenantId: access.tenantId })
+  const res = await relay.fetch(fwd.url, fwd.init)
+  setResponseStatus(event, res.status)
+  setResponseHeader(event, 'Content-Type', 'application/json')
+  setResponseHeader(event, 'Cache-Control', 'no-store')
+  return await res.text()
+})

--- a/web/server/utils/driver-master-sync.ts
+++ b/web/server/utils/driver-master-sync.ts
@@ -1,0 +1,71 @@
+/**
+ * 免許証タブ「theearth から乗務員マスタを同期」(Refs ippoan/alc-app-s3#125) の
+ * 純粋ロジック。副作用 (introspect / relay への fetch) は
+ * server/api/driver-master/run.post.ts。
+ *
+ * 乗務員の免許 (交付日・有効期限 = nfc_id 16 桁) の正は theearth (web地球号) の
+ * 乗務員マスタで、nuxt-dtako-admin の dtako-scraper-relay が cron で alc の
+ * employees へ流している。管理者が「今すぐ同期」を押せるよう、relay の
+ * `POST /kintai-relay/driver-master-run` を server-to-server で叩く。
+ *
+ * alc-app は theearth の comp_id を知らず tenant_id しか持たない。relay 側が
+ * `{tenant_id}` を DTAKO_ACCOUNTS で comp_id 群に写し、comp ごとの結果
+ * `{results:[{comp_id,status,created,updated,skipped,error?}]}` を返す。
+ *
+ * ★ tenant_id は auth-worker introspect の結果だけを使う — ブラウザからの
+ * body / query は route で一切読まない (読むと任意テナントへ書ける、#434 の再現)。
+ */
+import type { Forward } from './print-relay'
+
+const RELAY_BASE = 'https://scraper-relay.internal'
+
+/**
+ * 同期を起動できる role の allowlist。employees への書き込みを起こす操作なので
+ * `admin` (auth-worker の user.role) だけ。`viewer` (閲覧者) は 403。
+ */
+export const DRIVER_MASTER_SYNC_ROLES: ReadonlySet<string> = new Set(['admin'])
+
+/** auth-worker `/auth/introspect` 応答のうち、ここで見る field。 */
+export interface IntrospectClaims {
+  active?: boolean
+  tenant_id?: string
+  role?: string
+}
+
+export type DriverMasterAccess =
+  | { ok: true; tenantId: string }
+  | { ok: false; status: 401 | 403; message: string }
+
+/**
+ * introspect 結果から「同期を起動してよいか」と書き先 tenant_id を決める (pure)。
+ * - inactive / tenant_id 無し → 401
+ * - role が allowlist 外 → 403
+ */
+export function decideDriverMasterAccess(claims: IntrospectClaims): DriverMasterAccess {
+  if (!claims.active || !claims.tenant_id) {
+    return { ok: false, status: 401, message: 'token が無効です' }
+  }
+  if (typeof claims.role !== 'string' || !DRIVER_MASTER_SYNC_ROLES.has(claims.role)) {
+    return { ok: false, status: 403, message: '乗務員マスタ同期は管理者のみ実行できます' }
+  }
+  return { ok: true, tenantId: claims.tenant_id }
+}
+
+/**
+ * relay `POST /kintai-relay/driver-master-run` への forward request を組む。
+ * 認証は `X-Alc-Proxy-Secret` (= INTERNAL_SHARED_SECRET、relay が constant-time 比較)。
+ * body は `{tenant_id}` だけ (introspect 由来の値以外を運ばない)。
+ */
+export function buildDriverMasterRunForward(input: { sharedSecret: string; tenantId: string }): Forward {
+  return {
+    url: `${RELAY_BASE}/kintai-relay/driver-master-run`,
+    init: {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Alc-Proxy-Secret': input.sharedSecret,
+      },
+      body: JSON.stringify({ tenant_id: input.tenantId }),
+    },
+  }
+}

--- a/web/tests/server/driver-master-sync.test.ts
+++ b/web/tests/server/driver-master-sync.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import {
+  DRIVER_MASTER_SYNC_ROLES,
+  buildDriverMasterRunForward,
+  decideDriverMasterAccess,
+} from '../../server/utils/driver-master-sync'
+
+const SECRET = 'test-internal-shared-secret-32!!'
+
+describe('decideDriverMasterAccess (乗務員マスタ同期 #125、introspect 結果の認可判定)', () => {
+  it('inactive → 401', () => {
+    expect(decideDriverMasterAccess({ active: false, tenant_id: 't1', role: 'admin' })).toEqual({
+      ok: false,
+      status: 401,
+      message: 'token が無効です',
+    })
+  })
+
+  it('active でも tenant_id 無し → 401', () => {
+    expect(decideDriverMasterAccess({ active: true, role: 'admin' })).toMatchObject({ ok: false, status: 401 })
+    expect(decideDriverMasterAccess({ active: true, tenant_id: '', role: 'admin' })).toMatchObject({ ok: false, status: 401 })
+  })
+
+  it('role が viewer (閲覧者) → 403', () => {
+    expect(decideDriverMasterAccess({ active: true, tenant_id: 't1', role: 'viewer' })).toEqual({
+      ok: false,
+      status: 403,
+      message: '乗務員マスタ同期は管理者のみ実行できます',
+    })
+  })
+
+  it('role 欠落 / 文字列以外 → 403', () => {
+    expect(decideDriverMasterAccess({ active: true, tenant_id: 't1' })).toMatchObject({ ok: false, status: 403 })
+    expect(decideDriverMasterAccess({ active: true, tenant_id: 't1', role: 1 as unknown as string })).toMatchObject({
+      ok: false,
+      status: 403,
+    })
+  })
+
+  it('admin → ok、tenant_id は introspect の値', () => {
+    expect(decideDriverMasterAccess({ active: true, tenant_id: 'tenant-9', role: 'admin' })).toEqual({
+      ok: true,
+      tenantId: 'tenant-9',
+    })
+  })
+
+  it('許可 role の集合は admin だけ', () => {
+    expect([...DRIVER_MASTER_SYNC_ROLES]).toEqual(['admin'])
+  })
+})
+
+describe('buildDriverMasterRunForward', () => {
+  it('/kintai-relay/driver-master-run に POST、X-Alc-Proxy-Secret と {tenant_id} だけを載せる', () => {
+    const { url, init } = buildDriverMasterRunForward({ sharedSecret: SECRET, tenantId: 'tenant-9' })
+    expect(url).toBe('https://scraper-relay.internal/kintai-relay/driver-master-run')
+    expect(init.method).toBe('POST')
+    const h = init.headers as Record<string, string>
+    expect(h['X-Alc-Proxy-Secret']).toBe(SECRET)
+    expect(h['Content-Type']).toBe('application/json')
+    expect(JSON.parse(init.body as string)).toEqual({ tenant_id: 'tenant-9' })
+  })
+})
+
+describe('server/api/driver-master/run.post.ts (route 本体の不変条件)', () => {
+  const src = readFileSync(resolve(__dirname, '../../server/api/driver-master/run.post.ts'), 'utf-8')
+
+  it('ブラウザからの body / query を読まない (tenant_id は introspect 由来のみ)', () => {
+    expect(src).not.toMatch(/readBody|readRawBody|getQuery|getRouterParam/)
+    expect(src).toContain('decideDriverMasterAccess(await introRes.json())')
+    expect(src).toContain('tenantId: access.tenantId')
+  })
+
+  it('SCRAPER_RELAY / AUTH_WORKER / INTERNAL_SHARED_SECRET の binding を使い、secret を応答に載せない', () => {
+    expect(src).toContain('env.SCRAPER_RELAY')
+    expect(src).toContain('env.AUTH_WORKER')
+    expect(src).toContain('env.INTERNAL_SHARED_SECRET')
+    expect(src).not.toMatch(/console\.(log|warn|error)/)
+  })
+})

--- a/web/tests/utils/api.test.ts
+++ b/web/tests/utils/api.test.ts
@@ -56,6 +56,8 @@ import {
   getTenkoCallNumbers, addTenkoCallNumber, deleteTenkoCallNumber, getTenkoCallDrivers,
   // Hub measurements (CoreS3 統合ハブ、Refs ippoan/rust-alc-api#592)
   listHubMeasurements,
+  // Driver master sync (theearth 乗務員マスタ、Refs ippoan/alc-app-s3#125)
+  runDriverMasterSync,
 } from '~/utils/api'
 import type { MeasurementResult } from '~/types'
 import {
@@ -1976,6 +1978,46 @@ restoreNativeApis()
       initApi(API_BASE, () => 'invalid-token')
       await expect(getEmployees()).rejects.toThrow()
     })
+  })
+})
+
+// 免許証タブ「theearth から乗務員マスタを同期」(Refs ippoan/alc-app-s3#125)。
+// alc-app 自身の server route (/api/driver-master/run) を same-origin で叩くので
+// mock 専用 (live の rust-alc-api には無い)。
+describe.skipIf(isLive)('runDriverMasterSync (#125)', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', mockFetch)
+    mockFetch.mockReset()
+  })
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('admin JWT を Bearer に載せて /api/driver-master/run に POST (proxy 経由にしない・body 無し)', async () => {
+    initApi(API_BASE, () => 'admin-jwt', () => 'tid')
+    const payload = { results: [{ comp_id: '1', status: 200, created: 1, updated: 2, skipped: [] }] }
+    mockFetch.mockResolvedValueOnce(okJson(payload))
+    const result = await runDriverMasterSync()
+    expect(result).toEqual(payload)
+    const [url, init] = mockFetch.mock.calls[0]
+    expect(url).toBe('/api/driver-master/run')
+    expect(init.method).toBe('POST')
+    expect(init.body).toBeUndefined()
+    const h = new Headers(init.headers)
+    expect(h.get('Authorization')).toBe('Bearer admin-jwt')
+    expect(h.get('X-Tenant-ID')).toBeNull()
+  })
+
+  it('admin JWT が無ければ fetch せずに throw', async () => {
+    initApi(API_BASE, () => null, () => 'tid')
+    await expect(runDriverMasterSync()).rejects.toThrow('ログインが必要です')
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('route の 403 (role 不許可) は API エラーとして throw', async () => {
+    initApi(API_BASE, () => 'viewer-jwt')
+    mockFetch.mockResolvedValueOnce(errResponse(403, '乗務員マスタ同期は管理者のみ実行できます'))
+    await expect(runDriverMasterSync()).rejects.toThrow('API エラー (403): 乗務員マスタ同期は管理者のみ実行できます')
   })
 })
 

--- a/web/wrangler.jsonc
+++ b/web/wrangler.jsonc
@@ -34,6 +34,14 @@
 			// cf-alc-recorder の内部 command endpoint に PDF チャンクを push する。
 			"binding": "RECORDER",
 			"service": "alc-recorder"
+		},
+		{
+			// 免許証タブ「theearth から乗務員マスタを同期」(Refs ippoan/alc-app-s3#125):
+			// server route (server/api/driver-master/run.post.ts) が nuxt-dtako-admin の
+			// dtako-scraper-relay `POST /kintai-relay/driver-master-run` を叩く。認証は
+			// X-Alc-Proxy-Secret (= 上の INTERNAL_SHARED_SECRET、relay / kyuyo-mcp と同じ entry)。
+			"binding": "SCRAPER_RELAY",
+			"service": "nuxt-dtako-admin-scraper-relay"
 		}
 	],
 	"secrets_store_secrets": [
@@ -74,6 +82,10 @@
 				{
 					"binding": "RECORDER",
 					"service": "alc-recorder-staging"
+				},
+				{
+					"binding": "SCRAPER_RELAY",
+					"service": "nuxt-dtako-admin-scraper-relay-staging"
 				}
 			],
 			"secrets_store_secrets": [


### PR DESCRIPTION
## 何を

管理画面の免許証タブに「theearth から乗務員マスタを同期」ボタンを追加する。押すと自テナントぶんの乗務員マスタ (乗務員CD / 氏名 / 免許証の交付日・有効期限 = `nfc_id` 16 桁) を theearth (web地球号) から取得して employees へ一括 upsert し、結果を表示する。

- `web/server/api/driver-master/run.post.ts`: ブラウザの Bearer JWT を **auth-worker introspect** で検証 → `role === 'admin'` のみ許可 (それ以外 403、inactive 401) → introspect 由来の `tenant_id` だけを relay `POST /kintai-relay/driver-master-run` (ohishi-exp/nuxt-dtako-admin#1080、v0.0.671) に渡す。**body / query の tenant_id は読まない**。relay への認証はサーバ内の `INTERNAL_SHARED_SECRET` (kyuyo-mcp / relay と同一の secrets-store エントリ) を `X-Alc-Proxy-Secret` に載せる。ブラウザに secret は出ない、CORS も開けない (same-origin)
- `web/wrangler.jsonc`: service binding `SCRAPER_RELAY` → `nuxt-dtako-admin-scraper-relay` (production) / `-staging` (staging)
- `web/app/utils/api.ts`: `runDriverMasterSync()` (same-origin)。既存 `proxyRequest` の Bearer fetch 部を `bearerRequest` に切り出し (挙動不変)
- `web/app/components/LicenseRegistration.vue`: ボタン (viewer は disabled + 「管理者のみ」)、comp ごとの created / updated、skipped の code・reason 表、error 赤字、完了後に一覧を再読込

## 検証

- `npm test` 1105 pass、coverage 100% (30 files)、`nuxi typecheck` 0
- `tests/server/driver-master-sync.test.ts`: inactive 401 / viewer 403 / 正常 pass-through / body の tenant_id を読まないことをソース不変条件として固定
- 実機確認は親がマージ後に本番で行う

Refs ippoan/alc-app-s3#125

🤖 Generated with [Claude Code](https://claude.com/claude-code)
