### PR TITLE
feat(admin): 免許証タブに「解除」ボタン (交付日・有効期限・NFC を消す)

### DIFF
--- a/web/app/components/LicenseRegistration.vue
+++ b/web/app/components/LicenseRegistration.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { ApiEmployee, DriverMasterSyncResult, NfcLicenseReadEvent } from '~/types'
-import { getEmployees, runDriverMasterSync, updateEmployeeLicense, updateEmployeeNfcId } from '~/utils/api'
+import { clearEmployeeLicense, getEmployees, runDriverMasterSync, updateEmployeeLicense, updateEmployeeNfcId } from '~/utils/api'
 import {
   parseLicenseIssueDate,
   parseLicenseExpiryDate,
@@ -18,6 +18,8 @@ const editingId = ref<string | null>(null)
 const editIssueDate = ref('')
 const editExpiryDate = ref('')
 const isSaving = ref(false)
+// 解除中の従業員 (ボタン二度押し防止)
+const clearingId = ref<string | null>(null)
 
 // NFC 読み取り対象
 const nfcTargetId = ref<string | null>(null)
@@ -92,6 +94,24 @@ async function handleSave() {
     error.value = e instanceof Error ? e.message : '保存エラー'
   } finally {
     isSaving.value = false
+  }
+}
+
+/**
+ * 免許証の登録解除。交付年月日・有効期限に加えて **nfc_id も消える**。
+ * nfc_id を残すとハブ測定値の乗務員照合が効いたままになるため、まとめて消す。
+ */
+async function handleClear(emp: ApiEmployee) {
+  if (!confirm(`${emp.name} の免許証登録 (交付年月日・有効期限・NFC ID) を解除しますか？`)) return
+  clearingId.value = emp.id
+  error.value = null
+  try {
+    await clearEmployeeLicense(emp.id)
+    await fetchData()
+  } catch (e) {
+    error.value = e instanceof Error ? e.message : '解除エラー'
+  } finally {
+    clearingId.value = null
   }
 }
 
@@ -370,6 +390,14 @@ onMounted(() => {
                       @click="startNfcRead(emp)"
                     >
                       NFC読取
+                    </button>
+                    <button
+                      v-if="emp.license_expiry_date || emp.license_issue_date || emp.nfc_id"
+                      class="px-2 py-1 text-red-600 hover:bg-red-50 rounded text-xs disabled:opacity-50"
+                      :disabled="clearingId === emp.id"
+                      @click="handleClear(emp)"
+                    >
+                      {{ clearingId === emp.id ? '解除中...' : '解除' }}
                     </button>
                   </div>
                 </td>

--- a/web/app/utils/api.ts
+++ b/web/app/utils/api.ts
@@ -337,6 +337,15 @@ export async function updateEmployeeLicense(
 }
 
 /**
+ * 乗務員の免許証登録を解除 (交付年月日・有効期限・nfc_id を消す)。
+ * `updateEmployeeLicense` (PUT) は backend が COALESCE なので null では消せない。
+ * 消すのは専用の DELETE (Refs ippoan/rust-alc-api#611)。
+ */
+export async function clearEmployeeLicense(id: string): Promise<ApiEmployee> {
+  return request<ApiEmployee>(`/api/employees/${id}/license`, { method: 'DELETE' })
+}
+
+/**
  * 免許証タブ「theearth から乗務員マスタを同期」(Refs ippoan/alc-app-s3#125)。
  * rust-alc-api ではなく alc-app 自身の server route `/api/driver-master/run` を
  * same-origin で叩く (proxy 経由にしない)。route が admin browser JWT を introspect

--- a/web/tests/utils/api.test.ts
+++ b/web/tests/utils/api.test.ts
@@ -8,7 +8,7 @@ import {
   getEmployees, getEmployeeByNfcId, getEmployeeByCode, getEmployeeById,
   createEmployee, updateEmployee, deleteEmployee,
   updateEmployeeFace, approveFace, rejectFace, getFaceData,
-  updateEmployeeNfcId, updateEmployeeLicense,
+  updateEmployeeNfcId, updateEmployeeLicense, clearEmployeeLicense,
   // Face photo
   fetchFacePhoto, uploadFacePhoto, uploadReportAudio, uploadBlowVideo,
   // Tenko schedules
@@ -1067,6 +1067,16 @@ describe('api', () => {
         })
       },
     )
+
+    // 免許証の解除だけ 204 ではなく更新後の Employee を返すので it.each の外に置く
+    it('clearEmployeeLicense → DELETE /api/employees/{id}/license', async () => {
+      stubOk({})
+      await callApi(() => clearEmployeeLicense(DEL_EMPLOYEE_ID))
+      assertMock(() => {
+        expect(mockFetch.mock.calls[0][0]).toBe(`${API_BASE}/api/employees/${DEL_EMPLOYEE_ID}/license`)
+        expect(mockFetch.mock.calls[0][1].method).toBe('DELETE')
+      })
+    })
   })
 
   // ============================================================


### PR DESCRIPTION
## 何を

システム管理者 → 免許証タブの各行に **「解除」ボタン**を追加した。押すと確認ダイアログの後、その乗務員の **交付年月日・有効期限・NFC ID** をまとめて消す。

## なぜ

免許証の登録を消す手段が UI にも API にも無かった。

- 「編集」で日付を空にして保存しても消えない — backend が `license_issue_date = COALESCE($1, license_issue_date)` で **null = 変更なし**の扱いのため
- `nfc_id` はそもそもクリアする口が無い (`PUT /employees/{id}/nfc` は必須文字列)

`nfc_id` を残すと、ハブ測定値タブの「乗務員」列が免許証の nfc_id 照合で名前を出し続けるので、**3 つまとめて**消す仕様にした。

## 依存

backend の [ippoan/rust-alc-api#611](https://github.com/ippoan/rust-alc-api/pull/611) (`DELETE /api/employees/{id}/license`) が先に deploy されている必要がある。**そちらを先にマージ・デプロイしてからこの PR をマージ**すること。

## テスト

- `npx vitest run` → 38 files / 1106 passed
- `node scripts/check_coverage_100.mjs` → 全 30 ファイル 100% 維持 (`app/utils/api.ts` lines/branches 100%)
- `npx nuxi typecheck` → exit 0 (TS エラー 0)

Refs ippoan/alc-app#149

🤖 Generated with [Claude Code](https://claude.com/claude-code)