### PR TITLE
feat(types): ハブ測定 kind に timecard を追加 (Refs ippoan/alc-app-s3#134)

### DIFF
--- a/web/app/types/index.ts
+++ b/web/app/types/index.ts
@@ -1155,8 +1155,11 @@ export interface HubMeasurementsResponse {
   has_more: boolean
 }
 
-/** 受理される測定種別 (backend の HUB_MEASUREMENT_KINDS と一致。allowlist 外は 400)。 */
-export const HUB_MEASUREMENT_KINDS = ['temperature', 'blood_pressure', 'alcohol', 'license', 'fc1200_raw'] as const
+/**
+ * 受理される測定種別 (backend の HUB_MEASUREMENT_KINDS と一致。allowlist 外は 400)。
+ * timecard は NFC タイムカード端末の打刻イベント (Refs ippoan/alc-app-s3#134)。
+ */
+export const HUB_MEASUREMENT_KINDS = ['temperature', 'blood_pressure', 'alcohol', 'license', 'fc1200_raw', 'timecard'] as const
 
 // ============================================================
 // Driver master sync (theearth 乗務員マスタ → alc employees、Refs ippoan/alc-app-s3#125)


### PR DESCRIPTION
## 何を

`web/app/types/index.ts` の `HUB_MEASUREMENT_KINDS` に `'timecard'` を 1 種足すだけ。backend の同名 allowlist (ippoan/rust-alc-api#612) と一致させます。

NFC タイムカード端末 (ippoan/alc-app-s3#134) が既存の WS uplink に載せる打刻イベントの kind です。設計は ippoan/alc-app-s3 の `plan/standing-devices.md` §3.3 / §3.4。

効果は「ハブ測定値」タブの kind 絞り込みプルダウンに `timecard` が出ること。行の描画は kind 非依存 (payload をそのまま表示) なので `HubMeasurementsViewer.vue` は変更していません。

## 依存

**ippoan/rust-alc-api#612 が本番に出るまで、端末からの `kind: "timecard"` は 400 で弾かれます** (allowlist は backend 側が正)。この PR は表示側の同期のみ。

## スコープ外

- `cf-alc-recorder/src/auth.ts` の `RECORDER_DEVICE_ROLES` への `device-timecard` 追加。第 1 段階は device-print の credential を流用する運用で通すため、第 2 段階に回します
- `cf-alc-recorder` は `kind` を素通しする (非空チェックのみで allowlist を持たない) ので無改造で通る見込み

Refs ippoan/alc-app-s3#134

🤖 Generated with [Claude Code](https://claude.com/claude-code)