### PR TITLE
feat(recorder): device-timecard role を WS 接続の allowlist に追加 (Refs ippoan/alc-app-s3#134)

### DIFF
--- a/cf-alc-recorder/src/auth.ts
+++ b/cf-alc-recorder/src/auth.ts
@@ -39,6 +39,15 @@ export const DEVICE_ROLE_PRINT = "device-print";
 export const DEVICE_ROLE_GATEWAY = "device-gateway";
 
 /**
+ * NFC タイムカード端末 role (ippoan/alc-app-s3#134)。
+ * 上りは `kind: "timecard"` の打刻イベント、下りは ota command の待受。
+ * **印刷ブリッジと同じ role にしない** — /device/setup は role で firmware を
+ * 分けるため、混ぜると打刻機へ印刷ブリッジを push できてしまう
+ * (role と kind を 1:1 に保つ既存の設計)。
+ */
+export const DEVICE_ROLE_TIMECARD = "device-timecard";
+
+/**
  * recorder への接続を許可する device role の allowlist。
  * kiosk / uploader 等の他 role は従来どおり 403 (blast radius 分離) —
  * 広げるのは「recorder の下り command で遠隔管理したいデバイス」だけ。
@@ -47,6 +56,7 @@ export const RECORDER_DEVICE_ROLES: ReadonlySet<string> = new Set([
   DEVICE_ROLE_HUB,
   DEVICE_ROLE_PRINT,
   DEVICE_ROLE_GATEWAY,
+  DEVICE_ROLE_TIMECARD,
 ]);
 
 /** Secrets Store binding (`.get()`) / 文字列 のいずれでも値を取り出す。 */

--- a/cf-alc-recorder/test/recorder.test.ts
+++ b/cf-alc-recorder/test/recorder.test.ts
@@ -120,13 +120,15 @@ describe("ハンドシェイク認証 (introspect)", () => {
     expect(decideRecorderAuth(null).status).toBe(401);
   });
 
-  it("decideRecorderAuth: allowlist role の判定 (hub/print/gateway は 101、他は 403)", () => {
+  it("decideRecorderAuth: allowlist role の判定 (hub/print/gateway/timecard は 101、他は 403)", () => {
     const claims = { active: true, tenant_id: "t", sub: "d" };
     // AtomS3 印刷ブリッジ (ippoan/alc-app-s3#38) — 下り print/ota command 待受
     expect(decideRecorderAuth({ ...claims, role: "device-print" }).status).toBe(101);
     expect(decideRecorderAuth({ ...claims, role: "device-hub" }).status).toBe(101);
     // P4 GW (Unit PoE-P4、ippoan/alc-gw-p4#15) — 下り version/ota command 待受
     expect(decideRecorderAuth({ ...claims, role: "device-gateway" }).status).toBe(101);
+    // NFC タイムカード端末 (ippoan/alc-app-s3#134) — 上り kind=timecard / 下り ota
+    expect(decideRecorderAuth({ ...claims, role: "device-timecard" }).status).toBe(101);
     // blast radius 分離: 他 role・role 欠落は従来どおり 403
     expect(decideRecorderAuth({ ...claims, role: "device-kiosk" }).status).toBe(403);
     expect(decideRecorderAuth({ ...claims, role: "device-uploader" }).status).toBe(403);


### PR DESCRIPTION
NFC タイムカード端末 ([ippoan/alc-app-s3#134](https://github.com/ippoan/alc-app-s3/issues/134)) が cf-alc-recorder へ WS 接続できるようにする。設計は [`plan/standing-devices.md`](https://github.com/ippoan/alc-app-s3/blob/main/plan/standing-devices.md)。

## 変更

- `cf-alc-recorder/src/auth.ts` に `DEVICE_ROLE_TIMECARD = "device-timecard"` を定義し、`RECORDER_DEVICE_ROLES` に追加
- `decideRecorderAuth` のテストに 1 行 (timecard は 101、他 role は従来どおり 403)

## なぜ専用 role にするか

`/device/setup` は **role で firmware を分ける**設計なので、印刷ブリッジ (`device-print`) と混ぜると打刻機へ印刷ブリッジを push できてしまう。role と kind を 1:1 に保つ既存の方針どおり新 role を立てる。

## 影響範囲

allowlist の**純粋な拡大**で、既存 3 role (`device-hub` / `device-print` / `device-gateway`) の判定は一切変わらない。`device-timecard` の端末はまだ 1 台も存在しないため、この PR 単独では挙動が変化しない。blast radius 分離 (`device-kiosk` / `device-uploader` は 403) もテストで維持を確認している。

## 関連 PR (この順で出す)

1. **本 PR** — 無いと端末の WS が 403
2. ippoan/alc-app-s3 — Pages インストーラ (`timecard.html` + `manifest-timecard.json`)
3. ippoan/auth-worker — `DEVICE_ROLE_TIMECARD` + `/device/setup` の機種エントリ

打刻の中継 (rust-alc-api) は [ippoan/alc-app-s3#103](https://github.com/ippoan/alc-app-s3/issues/103) (1 タップ 2 重読み) の修正後。

🤖 Generated with [Claude Code](https://claude.com/claude-code)