### PR TITLE
feat(admin): 点呼タブを追加し、打刻履歴に点呼も並べる (Refs ippoan/alc-app-s3#134)

### DIFF
--- a/web/app/components/AdminDashboard.vue
+++ b/web/app/components/AdminDashboard.vue
@@ -25,7 +25,7 @@ function disconnectRtc() {
   isRtcActive.value = false
 }
 
-type TabKey = 'employees' | 'license' | 'queue' | 'webhooks' | 'tenko_call' | 'camera' | 'site_camera' | 'timecard' | 'devices' | 'hub_measurements'
+type TabKey = 'employees' | 'license' | 'queue' | 'webhooks' | 'tenko_call' | 'camera' | 'site_camera' | 'timecard' | 'devices' | 'tenko' | 'hub_measurements'
 const activeTab = ref<TabKey>('employees')
 const cameraActive = computed(() => activeTab.value === 'camera')
 </script>
@@ -45,6 +45,7 @@ const cameraActive = computed(() => activeTab.value === 'camera')
             { key: 'site_camera', label: '拠点カメラ' },
             { key: 'timecard', label: 'タイムカード' },
             { key: 'devices', label: 'デバイス管理' },
+            { key: 'tenko', label: '点呼' },
             { key: 'hub_measurements', label: 'ハブ測定値' },
           ]"
           :key="tab.key"
@@ -94,7 +95,14 @@ const cameraActive = computed(() => activeTab.value === 'camera')
         <DeviceRegistrationManager />
       </div>
 
-      <!-- CoreS3 統合ハブ (alc-app-s3) の測定値 (Refs ippoan/rust-alc-api#592) -->
+      <!-- 点呼だけ (打刻を除く)。打刻は 1 タップ 1 行で数が多く、混ぜると
+           点呼が埋もれる (Refs ippoan/alc-app-s3#134) -->
+      <div v-if="activeTab === 'tenko'">
+        <HubMeasurementsViewer scope="tenko" />
+      </div>
+
+      <!-- CoreS3 統合ハブ (alc-app-s3) の測定値 (Refs ippoan/rust-alc-api#592)。
+           点呼と打刻の両方を出す「全部入り」ビュー -->
       <div v-if="activeTab === 'hub_measurements'">
         <HubMeasurementsViewer />
       </div>

--- a/web/app/components/HubMeasurementsViewer.vue
+++ b/web/app/components/HubMeasurementsViewer.vue
@@ -15,6 +15,32 @@ import { HUB_MEASUREMENT_KINDS, type ApiEmployee, type HubMeasurement } from '~/
 
 const PAGE_SIZE = 50
 
+/** 打刻 (NFC タイムカード端末、Refs ippoan/alc-app-s3#134) の kind。
+ * 点呼の測定と混ざると 1 行 1 タップの行が延々挟まって読めなくなるので、
+ * タブごとにどちらを見るかを決める。 */
+const KIND_TIMECARD = 'timecard'
+
+const props = withDefaults(defineProps<{
+  /**
+   * 表示する範囲。
+   * - `tenko`   … 点呼の測定だけ (打刻を除く)
+   * - `timecard`… 打刻だけ
+   * - `all`     … 両方 (既定。従来の「ハブ測定値」タブ)
+   *
+   * `timecard` は API の kind 絞り込みに載せられるが、`tenko` は「timecard 以外」
+   * という否定条件で API 側に無いので**取得後に落とす**。そのため 1 ページの
+   * 表示件数が PAGE_SIZE より少なくなることがある (次ページは has_more で辿れる)。
+   */
+  scope?: 'all' | 'tenko' | 'timecard'
+}>(), { scope: 'all' })
+
+/** 種別プルダウンに出す選択肢。範囲外の kind は選ばせない。 */
+const kindOptions = computed(() => {
+  if (props.scope === 'timecard') return [KIND_TIMECARD]
+  if (props.scope === 'tenko') return HUB_MEASUREMENT_KINDS.filter(k => k !== KIND_TIMECARD)
+  return [...HUB_MEASUREMENT_KINDS]
+})
+
 const deviceId = ref('')
 const kind = ref('')
 const from = ref('')
@@ -47,6 +73,27 @@ interface SessionRow {
   alcohol: { value: number | null, result: string | null } | null
   /** 体温 (℃)。測っていなければ null。 */
   temperature: number | null
+  /** 打刻 (kind=timecard)。かざしたカードの生値と種別。打刻でなければ null。 */
+  card: { cardId: string, cardKind: string | null } | null
+}
+
+/** 打刻の payload から card_id / card_kind を取り出す (形が違えば null)。 */
+function readCard(payload: unknown): SessionRow['card'] {
+  if (typeof payload !== 'object' || payload === null) return null
+  const p = payload as { card_id?: unknown, card_kind?: unknown }
+  if (typeof p.card_id !== 'string' || p.card_id === '') return null
+  return {
+    cardId: p.card_id,
+    cardKind: typeof p.card_kind === 'string' ? p.card_kind : null,
+  }
+}
+
+/** card_kind の表示名。未知の値はそのまま出す (隠すと診断できない)。 */
+function cardKindLabel(k: string | null): string {
+  if (k === 'felica_idm') return '交通系IC等'
+  if (k === 'license') return '免許証'
+  if (k === 'nfca_uid') return 'NFC-A'
+  return k ?? 'カード'
 }
 
 /** 免許証の payload から nfc_id / 交付 / 有効期限 を取り出す (形が違えば null)。 */
@@ -111,6 +158,7 @@ const sessions = computed<SessionRow[]>(() => {
         license: null,
         alcohol: null,
         temperature: null,
+        card: null,
       }
       byKey.set(key, row)
       rows.push(row)
@@ -120,6 +168,7 @@ const sessions = computed<SessionRow[]>(() => {
     if (item.kind === 'license' && !row.license) row.license = readLicense(item.payload)
     if (item.kind === 'alcohol' && !row.alcohol) row.alcohol = readAlcohol(item.payload)
     if (item.kind === 'temperature' && row.temperature === null) row.temperature = readTemperature(item.payload)
+    if (item.kind === KIND_TIMECARD && !row.card) row.card = readCard(item.payload)
   }
   return rows
 })
@@ -135,15 +184,19 @@ async function load() {
   isLoading.value = true
   error.value = null
   try {
+    // scope=timecard は kind を API 側で固定できる。scope=tenko は
+    // 「timecard 以外」= 否定条件で API に無いので取得後に落とす (props の doc 参照)
     const res = await listHubMeasurements({
       device_id: deviceId.value || undefined,
-      kind: kind.value || undefined,
+      kind: kind.value || (props.scope === 'timecard' ? KIND_TIMECARD : undefined),
       from: toIso(from.value),
       to: toIso(to.value),
       limit: PAGE_SIZE,
       offset: offset.value,
     })
-    items.value = res.items
+    items.value = props.scope === 'tenko'
+      ? res.items.filter(i => i.kind !== KIND_TIMECARD)
+      : res.items
     hasMore.value = res.has_more
     expanded.value = new Set()
   }
@@ -268,14 +321,14 @@ onMounted(() => {
             @keyup.enter="search"
           >
         </label>
-        <label class="flex flex-col gap-1">
+        <label v-if="scope !== 'timecard'" class="flex flex-col gap-1">
           <span class="text-sm text-gray-500">種別</span>
           <select
             v-model="kind"
             class="px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
           >
             <option value="">すべて</option>
-            <option v-for="k in HUB_MEASUREMENT_KINDS" :key="k" :value="k">{{ k }}</option>
+            <option v-for="k in kindOptions" :key="k" :value="k">{{ k }}</option>
           </select>
         </label>
         <label class="flex flex-col gap-1">
@@ -333,6 +386,7 @@ onMounted(() => {
               <th class="px-2 py-2 text-left text-gray-500">免許 有効期限</th>
               <th class="px-2 py-2 text-left text-gray-500">アルコール</th>
               <th class="px-2 py-2 text-left text-gray-500">体温</th>
+              <th v-if="scope !== 'tenko'" class="px-2 py-2 text-left text-gray-500">カード</th>
               <th class="px-2 py-2 text-left text-gray-500">種別</th>
               <th class="px-2 py-2 text-left text-gray-500">内容</th>
             </tr>
@@ -376,6 +430,15 @@ onMounted(() => {
                   <template v-if="row.temperature !== null">{{ row.temperature.toFixed(1) }} &#8451;</template>
                   <span v-else class="text-gray-400">—</span>
                 </td>
+                <!-- 打刻 (kind=timecard) の中身。これが無いと「—」だらけの
+                     読み取れない行になる (Refs ippoan/alc-app-s3#134) -->
+                <td v-if="scope !== 'tenko'" class="px-2 py-2 whitespace-nowrap">
+                  <template v-if="row.card">
+                    <span class="font-mono text-gray-700">{{ row.card.cardId }}</span>
+                    <span class="ml-1 text-gray-400 text-xs">{{ cardKindLabel(row.card.cardKind) }}</span>
+                  </template>
+                  <span v-else class="text-gray-400">—</span>
+                </td>
                 <td class="px-2 py-2">
                   <span
                     v-for="item in row.items"
@@ -391,7 +454,7 @@ onMounted(() => {
                 </td>
               </tr>
               <tr v-if="expanded.has(row.key)" class="bg-gray-50">
-                <td colspan="8" class="px-2 py-2">
+                <td :colspan="scope === 'tenko' ? 8 : 9" class="px-2 py-2">
                   <div v-for="item in row.items" :key="item.id" class="mb-2 last:mb-0">
                     <div class="text-xs text-gray-500">
                       {{ item.kind }} / seq {{ item.seq }} / 端末計時 {{ formatDateTime(item.recorded_at) }}

--- a/web/app/components/TimecardManager.vue
+++ b/web/app/components/TimecardManager.vue
@@ -2,7 +2,7 @@
 import type { ApiEmployee, TimecardCard, TimePunch } from '~/types'
 import {
   getEmployees, listTimecardCards, createTimecardCard, deleteTimecardCard,
-  listTimePunches, downloadTimePunchesCsv,
+  listTimePunches, downloadTimePunchesCsv, listHubMeasurements,
 } from '~/utils/api'
 
 type SubTab = 'cards' | 'punches'
@@ -91,6 +91,52 @@ const isLoadingPunches = ref(false)
 const filterDate = ref(new Date().toISOString().slice(0, 10))
 const filterEmployeeId = ref('')
 
+/**
+ * 点呼から拾った「打刻に相当する記録」(Refs ippoan/alc-app-s3#134)。
+ *
+ * **始業点呼 = 始業打刻**のように、点呼そのものが打刻を兼ねることがあるため、
+ * カードをかざした打刻 (`time_punches`) と同じ表に並べて出す。
+ *
+ * **表示だけで `time_punches` に行は作らない。** 勤怠の一次データを画面の都合で
+ * 書き足すと、あとから「これは実際に打刻されたのか」を区別できなくなる。
+ * どちらから来た記録かは「区分」列で分かるようにしてある。
+ */
+const tenkoRows = ref<HistoryRow[]>([])
+
+/** 打刻履歴の 1 行。カード打刻と点呼を同じ形に均して並べる。 */
+interface HistoryRow {
+  key: string
+  /** 並び替えと表示に使う時刻 (ISO) */
+  at: string
+  employeeName: string
+  deviceName: string
+  /** どこから来た記録か。`punch` = カードをかざした打刻、`tenko` = 点呼 */
+  origin: 'punch' | 'tenko'
+}
+
+/** nfc_id (免許証の交付日 8 桁 + 有効期限 8 桁) → 乗務員。点呼を人に結びつける。 */
+const employeeByNfc = computed(() => {
+  const map = new Map<string, ApiEmployee>()
+  for (const e of employees.value) {
+    if (e.nfc_id) map.set(e.nfc_id, e)
+  }
+  return map
+})
+
+/** 打刻 + 点呼をまとめて新しい順に並べたもの。 */
+const historyRows = computed<HistoryRow[]>(() => {
+  const rows: HistoryRow[] = punches.value.map(p => ({
+    key: `p:${p.id}`,
+    at: p.punched_at,
+    employeeName: employeeName(p.employee_id),
+    deviceName: p.device_name ?? '-',
+    origin: 'punch' as const,
+  }))
+  rows.push(...tenkoRows.value)
+  // 表示は日付で絞ってあるので、同日内の新しい順に並べれば足りる
+  return rows.sort((a, b) => b.at.localeCompare(a.at))
+})
+
 async function loadPunches() {
   isLoadingPunches.value = true
   try {
@@ -108,6 +154,44 @@ async function loadPunches() {
   }
   catch { /* ignore */ }
   finally { isLoadingPunches.value = false }
+  await loadTenkoRows()
+}
+
+/**
+ * 同じ日の点呼 (ハブ測定値の `kind=license`) を拾って打刻履歴に混ぜる。
+ *
+ * 失敗しても打刻履歴自体は出す (点呼が出ないだけ) — ハブ測定値の API は
+ * 端末が繋がっていない環境では空でも正常なので、ここで表を落とさない。
+ * 乗務員で絞っているときは、その人の点呼だけに絞る。
+ */
+async function loadTenkoRows() {
+  try {
+    const res = await listHubMeasurements({
+      kind: 'license',
+      from: new Date(`${filterDate.value}T00:00:00+09:00`).toISOString(),
+      to: new Date(`${filterDate.value}T23:59:59+09:00`).toISOString(),
+      limit: 200,
+    })
+    const rows: HistoryRow[] = []
+    for (const item of res.items) {
+      const payload = item.payload as { nfc_id?: unknown } | null
+      const nfcId = payload && typeof payload.nfc_id === 'string' ? payload.nfc_id : null
+      const emp = nfcId ? employeeByNfc.value.get(nfcId) : undefined
+      // 乗務員で絞り込み中は、その人の点呼だけ残す (誰か分からない点呼も落とす)
+      if (filterEmployeeId.value && emp?.id !== filterEmployeeId.value) continue
+      rows.push({
+        key: `t:${item.id}`,
+        at: item.created_at,
+        employeeName: emp?.name ?? (nfcId ? '未登録の免許証' : '不明'),
+        deviceName: item.device_id,
+        origin: 'tenko',
+      })
+    }
+    tenkoRows.value = rows
+  }
+  catch {
+    tenkoRows.value = []
+  }
 }
 
 watch(subTab, (tab) => {
@@ -271,20 +355,27 @@ async function exportCsv() {
             <tr>
               <th class="text-left px-4 py-2 font-medium text-gray-600">社員名</th>
               <th class="text-left px-4 py-2 font-medium text-gray-600">打刻日時</th>
+              <th class="text-left px-4 py-2 font-medium text-gray-600">区分</th>
               <th class="text-left px-4 py-2 font-medium text-gray-600">デバイス</th>
             </tr>
           </thead>
           <tbody>
             <tr v-if="isLoadingPunches">
-              <td colspan="3" class="px-4 py-6 text-center text-gray-500">読み込み中...</td>
+              <td colspan="4" class="px-4 py-6 text-center text-gray-500">読み込み中...</td>
             </tr>
-            <tr v-else-if="punches.length === 0">
-              <td colspan="3" class="px-4 py-6 text-center text-gray-500">打刻記録なし</td>
+            <tr v-else-if="historyRows.length === 0">
+              <td colspan="4" class="px-4 py-6 text-center text-gray-500">打刻記録なし</td>
             </tr>
-            <tr v-for="p in punches" :key="p.id" class="border-t">
-              <td class="px-4 py-2">{{ employeeName(p.employee_id) }}</td>
-              <td class="px-4 py-2">{{ formatTime(p.punched_at) }}</td>
-              <td class="px-4 py-2 text-gray-500">{{ p.device_name ?? '-' }}</td>
+            <tr v-for="row in historyRows" :key="row.key" class="border-t">
+              <td class="px-4 py-2">{{ row.employeeName }}</td>
+              <td class="px-4 py-2">{{ formatTime(row.at) }}</td>
+              <td class="px-4 py-2">
+                <span
+                  class="px-2 py-0.5 rounded text-xs font-medium"
+                  :class="row.origin === 'tenko' ? 'bg-blue-100 text-blue-800' : 'bg-gray-100 text-gray-700'"
+                >{{ row.origin === 'tenko' ? '点呼' : '打刻' }}</span>
+              </td>
+              <td class="px-4 py-2 text-gray-500">{{ row.deviceName }}</td>
             </tr>
           </tbody>
         </table>


### PR DESCRIPTION
NFC タイムカード端末 (ippoan/alc-app-s3#134) の打刻が入り始めたことで既存の画面が読みづらくなったため、3 点直します。

## 1. 点呼タブを追加 (打刻と混ぜない)

打刻は 1 タップ 1 行で数が多く、ハブ測定値タブに混ざると点呼が埋もれます。`HubMeasurementsViewer` に `scope` prop を足して 3 通りに使い分けます:

| scope | 中身 | 置き場所 |
|---|---|---|
| `tenko` | 点呼だけ (打刻を除く) | **新しい「点呼」タブ** |
| `timecard` | 打刻だけ | (今後の利用向け) |
| `all` (既定) | 両方 | 従来の「ハブ測定値」タブ |

`timecard` は API の `kind` 絞り込みに載せられますが、`tenko` は「timecard 以外」という否定条件で API 側に無いので**取得後に落としています**。そのため 1 ページの表示件数が `PAGE_SIZE` より少なくなることがあります (次ページは `has_more` で辿れる)。この事情は prop の doc に書きました。種別プルダウンの選択肢も scope に合わせて絞ります。

## 2. 打刻行が「—」だらけだったのを直す

`kind=timecard` の行は 乗務員 / 免許 有効期限 / アルコール / 体温 が全部空になり、実際に持っている `card_id` / `card_kind` が画面に一切出ていませんでした。「読んだのに何も分からない行」が並ぶ状態です。

**カード列**を足して生値と種別を出します。`card_kind` は 交通系IC等 / 免許証 / NFC-A に読み替え、未知の値はそのまま出します (隠すと診断できないため)。

## 3. 打刻履歴に点呼も並べる

**始業点呼 = 始業打刻**のように、点呼そのものが打刻を兼ねることがあります。タイムカードタブの打刻履歴に、同じ日の点呼 (ハブ測定値の `kind=license`) を混ぜて時刻順に並べ、**「区分」列**で 打刻 / 点呼 を見分けられるようにしました。点呼は免許証の `nfc_id` (交付日 8 桁 + 有効期限 8 桁) から乗務員に結びつけます。

**表示だけで `time_punches` に行は作りません。** 勤怠の一次データを画面の都合で書き足すと、あとから「実際に打刻されたのか」を区別できなくなるためです。

点呼の取得に失敗しても打刻履歴自体は出します (点呼が出ないだけ) — 端末が繋がっていない環境ではハブ測定値が空でも正常なので、そこで表を落としません。乗務員で絞り込み中は、その人の点呼だけに絞ります。

## 検証

ローカルに `node_modules` が無く `npm ci` が実行できない環境のため、typecheck / test は CI に委ねています。

## 関連

- ippoan/rust-alc-api#613 (マージ済み) — `kind=timecard` を `time_punches` へ中継。これが本番反映されると打刻履歴に打刻行が出ます
- ippoan/alc-app-s3#138 / #139 — 1 タップで複数行になる不具合の修正

Refs ippoan/alc-app-s3#134

🤖 Generated with [Claude Code](https://claude.com/claude-code)