### PR TITLE
fix(timecard): card_id を正規化してから照合する (Refs ippoan/alc-app-s3#134)

### DIFF
--- a/web/app/components/TimecardManager.vue
+++ b/web/app/components/TimecardManager.vue
@@ -4,6 +4,7 @@ import {
   getEmployees, listTimecardCards, createTimecardCard, deleteTimecardCard,
   listTimePunches, downloadTimePunchesCsv, listHubMeasurements,
 } from '~/utils/api'
+import { normalizeCardId } from '~/utils/card-id'
 
 type SubTab = 'cards' | 'punches'
 const subTab = ref<SubTab>('cards')
@@ -119,12 +120,19 @@ interface HistoryRow {
   dedupe?: string
 }
 
-/** card_id → 乗務員 (登録済みカード)。打刻を人に結びつける 1 本目の経路。 */
+/**
+ * card_id → 乗務員 (登録済みカード)。打刻を人に結びつける 1 本目の経路。
+ *
+ * **キーは正規化形にする。** ハブ測定値の payload には端末が読んだ生値
+ * (大文字 IDm) が入るのに対し、`timecard_cards.card_id` はサーバが正規化した
+ * 小文字なので、素の値で引くと登録済みカードが「未登録カード」に見える
+ * (Refs ippoan/alc-app-s3#134)。
+ */
 const employeeByCardId = computed(() => {
   const map = new Map<string, ApiEmployee>()
   for (const c of cards.value) {
     const emp = employeeMap.value[c.employee_id]
-    if (emp) map.set(c.card_id, emp)
+    if (emp) map.set(normalizeCardId(c.card_id), emp)
   }
   return map
 })
@@ -208,8 +216,11 @@ async function loadHubRows() {
       const cardId = p && typeof p.card_id === 'string' ? p.card_id : null
       // 登録済みカード → 免許証の 16 桁 (employees.nfc_id) の順に引く。
       // どちらでも引けなければ「誰の打刻か分からない」= カード未登録
+      // 登録カードは正規化形で引く。免許証 (employees.nfc_id) は 16 桁の数字で
+      // 正規化が no-op なので、生値のまま引いて既存の挙動を変えない
       const emp = cardId
-        ? employeeByCardId.value.get(cardId) ?? employeeByNfc.value.get(cardId)
+        ? employeeByCardId.value.get(normalizeCardId(cardId))
+          ?? employeeByNfc.value.get(cardId)
         : undefined
       if (filterEmployeeId.value && emp?.id !== filterEmployeeId.value) continue
       const name = emp?.name ?? (cardId ? `未登録カード ${cardId}` : '不明')

--- a/web/app/utils/card-id.ts
+++ b/web/app/utils/card-id.ts
@@ -1,0 +1,18 @@
+/**
+ * カード ID の正規化。**rust-alc-api の `normalize_card_id` と同じ規則**
+ * (`crates/alc-core/src/repository/timecard.rs`、Refs ippoan/alc-app-s3#134)。
+ *
+ * 同じ物理カードでも読み取り側で表記が揺れる (NFC タイムカード端末は `%02X` の
+ * 大文字 IDm、ローカル NFC ブリッジは小文字、`AA:BB:..` と区切る実装もある)。
+ * サーバは `timecard_cards.card_id` を正規化形 (小文字) で持つので、
+ * **端末の生値 (ハブ測定値の payload) で引くときは必ずこれを通す。**
+ *
+ * 免許証の `employees.nfc_id` (交付日 8 桁 + 有効期限 8 桁 = 16 桁の数字) に
+ * 対しては no-op なので、免許証経路には影響しない。
+ *
+ * 両者がずれると「登録済みなのに『未登録カード』と表示される」形で壊れる。
+ * 規則を変えるときは必ずサーバ側と同時に変えること。
+ */
+export function normalizeCardId(cardId: string): string {
+  return cardId.trim().toLowerCase().replace(/:/g, '')
+}

--- a/web/tests/utils/card-id.test.ts
+++ b/web/tests/utils/card-id.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest'
+
+import { normalizeCardId } from '~/utils/card-id'
+
+// rust-alc-api の normalize_card_id (crates/alc-core/src/repository/timecard.rs)
+// と同じ規則であることを固定する。ずれると「登録済みなのに未登録カードと出る」
+// 形で壊れる (Refs ippoan/alc-app-s3#134)
+describe('normalizeCardId', () => {
+  it('端末が送る大文字 IDm を小文字にする', () => {
+    expect(normalizeCardId('0123456789ABCDEF')).toBe('0123456789abcdef')
+  })
+
+  it('区切りと前後の空白を落とす', () => {
+    expect(normalizeCardId('  AA:BB:CC:DD  ')).toBe('aabbccdd')
+  })
+
+  it('既に正規化済みの値はそのまま', () => {
+    expect(normalizeCardId('0123456789abcdef')).toBe('0123456789abcdef')
+  })
+
+  it('免許証の nfc_id (16 桁の数字) には no-op', () => {
+    expect(normalizeCardId('2023040120280331')).toBe('2023040120280331')
+  })
+
+  it('空白だけなら空文字', () => {
+    expect(normalizeCardId('   ')).toBe('')
+  })
+})


### PR DESCRIPTION
ippoan/rust-alc-api#614 (MERGED) の対。**セットで入れる必要がある。**

## なぜ必要か

`TimecardManager.vue` の `employeeByCardId` は **API 由来の `card_id` (= サーバで正規化済み = 小文字)** をキーに Map を作り、**ハブ測定値の payload = 端末の生値 (大文字 IDm)** で引いている。サーバ側だけ正規化すると、**登録済みのカードが「未登録カード ○○」と表示される**。

現状は `timecard_cards` が本番 0 件で `employees.nfc_id` (免許証の数字 16 桁、大文字小文字と無関係) 側が拾っているため表面化していない。**FeliCa カードを 1 枚登録した瞬間に出る。**

## 変更

- `web/app/utils/card-id.ts` (新規) — `normalizeCardId`。**サーバの `normalize_card_id` と同じ規則** (trim + 小文字 + `':'` 除去)
- `web/app/components/TimecardManager.vue` — Map のキーと引き側の両方に適用
- `web/tests/utils/card-id.test.ts` (新規) — 5 ケース

## 検証

**この repo は `on: push: branches: [main]` + `pull_request` のみで、feature branch の push では CI が回らない。この PR が初検証。** vitest は手元で node_modules が無く実行できていない (`npm ci` が permission 分類器に拒否されるため)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)