### PR TITLE
fix(admin): 管理画面のタブを URL (?tab=) から開けるようにする (Refs ippoan/alc-app-s3#134)

### DIFF
--- a/web/app/components/AdminDashboard.vue
+++ b/web/app/components/AdminDashboard.vue
@@ -25,8 +25,40 @@ function disconnectRtc() {
   isRtcActive.value = false
 }
 
-type TabKey = 'employees' | 'license' | 'queue' | 'webhooks' | 'tenko_call' | 'camera' | 'site_camera' | 'timecard' | 'devices' | 'tenko' | 'hub_measurements'
-const activeTab = ref<TabKey>('employees')
+/**
+ * タブの定義。**テンプレートの描画と `?tab=` の検証で同じ配列を使う** —
+ * 2 か所に並べると、タブを足したときに URL から開けないものが混ざる。
+ */
+const TABS = [
+  { key: 'employees', label: '乗務員' },
+  { key: 'license', label: '免許証' },
+  { key: 'queue', label: '送信キュー' },
+  { key: 'webhooks', label: 'Webhook' },
+  { key: 'tenko_call', label: '中間点呼' },
+  { key: 'camera', label: 'リモートカメラ' },
+  { key: 'site_camera', label: '拠点カメラ' },
+  { key: 'timecard', label: 'タイムカード' },
+  { key: 'devices', label: 'デバイス管理' },
+  { key: 'tenko', label: '点呼' },
+  { key: 'hub_measurements', label: 'ハブ測定値' },
+] as const
+
+type TabKey = typeof TABS[number]['key']
+
+const props = defineProps<{
+  /** `?tab=` の値。未指定・不正値は 'employees' に倒す (ManagerDashboard と同じ形) */
+  initialTab?: string
+}>()
+
+/** タブが変わったことを親へ知らせる。URL への反映は index.vue が一括で持つ */
+const emit = defineEmits<{ 'update:tab': [TabKey] }>()
+
+function toTabKey(v: string | undefined): TabKey {
+  return TABS.some(t => t.key === v) ? (v as TabKey) : 'employees'
+}
+
+const activeTab = ref<TabKey>(toTabKey(props.initialTab))
+watch(activeTab, tab => emit('update:tab', tab))
 const cameraActive = computed(() => activeTab.value === 'camera')
 </script>
 
@@ -35,23 +67,11 @@ const cameraActive = computed(() => activeTab.value === 'camera')
     <div class="px-4 pt-4 flex items-center gap-3">
       <div class="flex flex-wrap gap-1 bg-gray-200 rounded-lg p-1 w-fit">
         <button
-          v-for="tab in [
-            { key: 'employees', label: '乗務員' },
-            { key: 'license', label: '免許証' },
-            { key: 'queue', label: '送信キュー' },
-            { key: 'webhooks', label: 'Webhook' },
-            { key: 'tenko_call', label: '中間点呼' },
-            { key: 'camera', label: 'リモートカメラ' },
-            { key: 'site_camera', label: '拠点カメラ' },
-            { key: 'timecard', label: 'タイムカード' },
-            { key: 'devices', label: 'デバイス管理' },
-            { key: 'tenko', label: '点呼' },
-            { key: 'hub_measurements', label: 'ハブ測定値' },
-          ]"
+          v-for="tab in TABS"
           :key="tab.key"
           class="px-4 py-2 rounded-md text-sm font-medium transition-colors"
           :class="activeTab === tab.key ? 'bg-white text-gray-800 shadow-sm' : 'text-gray-600 hover:text-gray-800'"
-          @click="activeTab = tab.key as TabKey"
+          @click="activeTab = tab.key"
         >
           {{ tab.label }}
         </button>

--- a/web/app/pages/index.vue
+++ b/web/app/pages/index.vue
@@ -84,6 +84,28 @@ watch(driverSubTab, (tab) => {
   window.history.replaceState({}, '', qs ? `/?${qs}` : '/')
 })
 
+/** `?tab=` の生値。vue-router は同名クエリが複数あると配列で返すので先頭だけ見る */
+const queryTab = computed(() => {
+  const t = route.query.tab
+  return (Array.isArray(t) ? t[0] : t) ?? undefined
+})
+
+/**
+ * システム管理者タブの URL 同期。
+ *
+ * **`?tab=` は `role` で意味が変わる** — `role=admin` なら管理タブ、
+ * 省略時 (= 運行者) なら運行者サブタブ。書き込みはどちらも「いま表示している
+ * ロールのぶんだけ」なので、role を切り替えたときは各 watcher が URL を
+ * 組み直して相手のぶんを落とす (= そのロールの既定タブに戻る)。
+ */
+function onAdminTabChange(tab: string) {
+  if (activeRole.value !== 'admin') return
+  const params = new URLSearchParams()
+  params.set('role', 'admin')
+  if (tab !== 'employees') params.set('tab', tab)
+  window.history.replaceState({}, '', `/?${params.toString()}`)
+}
+
 const roleLabels: Record<RoleTab, string> = {
   driver: '運行者',
   manager: '運行管理者',
@@ -456,7 +478,7 @@ function onRoleTabClick(role: RoleTab) {
 
     <!-- システム管理者タブ -->
     <RoleAuthGate v-if="activeRole === 'admin'" :key="adminAuthKey" required-role="admin" class="flex-1 min-h-0">
-      <AdminDashboard />
+      <AdminDashboard :initial-tab="queryTab" @update:tab="onAdminTabChange" />
     </RoleAuthGate>
 
     <!-- 汎用管理タブ (PCのみ, Google/LINE WORKS認証) -->


### PR DESCRIPTION
`https://alc.ippoan.org/?role=admin&tab=timecard` を開いても「乗務員」タブが出る、という報告への対応。

## 原因

`AdminDashboard.vue` は **URL を一切見ていなかった**:

```ts
const activeTab = ref<TabKey>('employees')   // ← query を読む処理が無い
```

`?tab=` を消費しているのは `index.vue` の運行者側タブだけで、管理画面には効いていなかった。

## 変更

- `AdminDashboard` が `initialTab` prop で受け、`update:tab` で親へ返す (`ManagerDashboard` と同じ形)
- **URL への反映は `index.vue` が持つ** — role / 運行者サブタブと同じ場所。組み立てが 3 か所に散ると、role を切り替えたときに相手のクエリが残る事故が出る
- `?tab=` は role で意味が変わるので、**書き込みはいま表示しているロールのぶんだけ**。doc に明記

## ついでに 1 つ

タブの配列がテンプレートに直書きだったので `TABS as const` として script へ出し、**描画と `?tab=` の検証で同じ配列**を使うようにした。`TabKey` もそこから導出する。2 か所に並べると、タブを足したときに URL から開けないものが混ざる。

## 副次的な効果

管理画面をスクリーンショットで確認する手段が戻る。これまではタブのクリックに in-page 評価が必要で、それが使えない環境では管理画面の各タブを外から確認できなかった。

## 範囲

`ManagerDashboard` も同じ `initialTab` prop を持っているが `index.vue` が渡していない。**報告のあった admin だけに絞った。**

## 検証

**この repo は `on: push: branches: [main]` + `pull_request` のみで、feature branch の push では CI が回らない。この PR が初検証。** vitest は手元で node_modules が無く未実行 (`npm ci` が permission 分類器に拒否されるため)。型は目視確認のみ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)