### PR TITLE
fix(timecard): 打刻履歴の基準日を JST で決める — JST 早朝に「昨日」が開く (Refs ippoan/alc-app-s3#134)

### DIFF
--- a/web/app/components/TimecardManager.vue
+++ b/web/app/components/TimecardManager.vue
@@ -4,6 +4,7 @@ import {
   getEmployees, listTimecardCards, createTimecardCard, deleteTimecardCard,
   listTimePunches, downloadTimePunchesCsv,
 } from '~/utils/api'
+import { jstTodayDate } from '~/utils/jst'
 
 type SubTab = 'cards' | 'punches'
 
@@ -100,7 +101,10 @@ const punchTotal = ref(0)
 const punchPage = ref(1)
 const punchPerPage = 50
 const isLoadingPunches = ref(false)
-const filterDate = ref(new Date().toISOString().slice(0, 10))
+// **既定は JST の今日。** `toISOString().slice(0, 10)` は UTC の日付なので、
+// JST 00:00〜09:00 のあいだ「昨日」を開いてしまう (範囲は `+09:00` で正しく
+// 作っているのに、その範囲を間違った日に当てることになる)
+const filterDate = ref(jstTodayDate())
 const filterEmployeeId = ref('')
 
 /** 打刻履歴の 1 行。打刻と点呼を同じ形に均して並べる。 */

--- a/web/app/utils/jst.ts
+++ b/web/app/utils/jst.ts
@@ -25,3 +25,14 @@ export function jstTodayStartIso(now: Date = new Date()): string {
   // その暦日の JST 0 時 = UTC 0 時 − 9h
   return new Date(midnightUtc - JST_OFFSET_MS).toISOString()
 }
+
+/**
+ * JST の「今日」を `YYYY-MM-DD` で返す (`<input type="date">` の初期値用)。
+ *
+ * **`new Date().toISOString().slice(0, 10)` は UTC の日付**なので、JST の
+ * 00:00〜09:00 のあいだは「昨日」になる。日付を UTC で決めて範囲だけ `+09:00`
+ * で作ると、**正しい範囲を間違った日に対して**引くことになる。
+ */
+export function jstTodayDate(now: Date = new Date()): string {
+  return new Date(now.getTime() + JST_OFFSET_MS).toISOString().slice(0, 10)
+}

--- a/web/tests/utils/jst.test.ts
+++ b/web/tests/utils/jst.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 
-import { jstTodayStartIso } from '~/utils/jst'
+import { jstTodayDate, jstTodayStartIso } from '~/utils/jst'
 
 // サーバ側 (rust-alc-api の list_today_punches) と同じ境界であることを固定する。
 // ずれると「今日の打刻」がクライアントとサーバで食い違う
@@ -27,5 +27,24 @@ describe('jstTodayStartIso', () => {
     // 2026-09-05T03:00Z = JST 09-05 12:00
     expect(jstTodayStartIso(new Date('2026-09-05T03:00:00Z')))
       .toBe('2026-09-04T15:00:00.000Z')
+  })
+})
+
+describe('jstTodayDate', () => {
+  it('JST では翌日に入っている時間帯 (UTC 15:30 = JST 00:30)', () => {
+    // toISOString().slice(0, 10) だと 2026-09-04 になってしまう時刻
+    expect(jstTodayDate(new Date('2026-09-04T15:30:00Z'))).toBe('2026-09-05')
+  })
+
+  it('同じ UTC 日で JST も同じ日 (UTC 03:00 = JST 12:00)', () => {
+    expect(jstTodayDate(new Date('2026-09-05T03:00:00Z'))).toBe('2026-09-05')
+  })
+
+  it('ちょうど JST 0 時', () => {
+    expect(jstTodayDate(new Date('2026-09-04T15:00:00Z'))).toBe('2026-09-05')
+  })
+
+  it('JST 23:59', () => {
+    expect(jstTodayDate(new Date('2026-09-05T14:59:00Z'))).toBe('2026-09-05')
   })
 })


### PR DESCRIPTION
管理画面の打刻履歴が **JST 00:00〜09:00 のあいだ毎日「昨日」を開く**。実際に本番で `09/04/2026` と表示されていた (JST は 9/5)。

## 原因

```js
const filterDate = ref(new Date().toISOString().slice(0, 10))   // ← UTC の日付
```

範囲は `${filterDate}T00:00:00+09:00` 〜 `T23:59:59+09:00` と **JST で正しく**作っている。**正しい範囲を、間違った日に当てている。**

ippoan/alc-app#157 で `TimePunchKiosk` の日付境界を JST に揃えたとき、`TimecardManager` は「元から `+09:00` 固定なので変更なし」と判断した。それは**範囲**の話で、**基準日そのもの**を見落としていた。

## 変更

`jst.ts` に `jstTodayDate` を足し、`filterDate` の初期値に使う。テスト 4 ケース。node で「旧 = 2026-09-04 / 新 = 2026-09-05」を実測。

## 関連

サーバ側の同種の不具合 (`list_today_punches` の `CURRENT_DATE` がサーバ TZ 基準) は ippoan/rust-alc-api#616 で修正済み。**クライアントとサーバの「今日」の定義がこれで揃う。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)