### PR TITLE
feat(recorder): 打刻の購読 WS (/watch-timecard) を足す (Refs ippoan/alc-app-s3#134)

### DIFF
--- a/cf-alc-recorder/src/auth.ts
+++ b/cf-alc-recorder/src/auth.ts
@@ -59,6 +59,60 @@ export const RECORDER_DEVICE_ROLES: ReadonlySet<string> = new Set([
   DEVICE_ROLE_TIMECARD,
 ]);
 
+/**
+ * キオスク端末 role。管理画面から self-pair して端末に保存する device credential
+ * (`web/app/composables/useDeviceToken.ts`、Refs ippoan/alc-app#434)。
+ *
+ * **`RECORDER_DEVICE_ROLES` には入れない。** あれは「下り command を受け取って
+ * よいデバイス」の allowlist なので、足すとキオスクが遠隔コマンドの対象になる。
+ * キオスクに要るのは読み取り専用の購読だけ。
+ */
+export const DEVICE_ROLE_KIOSK = "device-kiosk";
+
+/**
+ * 打刻の更新通知を購読してよい **user** role。打刻履歴を出す画面と同じ範囲
+ * (`AdminDashboard` / `ManagerDashboard` の「タイムカード」タブ)。
+ */
+export const WATCHER_USER_ROLES: ReadonlySet<string> = new Set(["admin", "manager"]);
+
+/** 同 **device** role。いまはキオスクだけ。 */
+export const WATCHER_DEVICE_ROLES: ReadonlySet<string> = new Set([DEVICE_ROLE_KIOSK]);
+
+/** watcher ハンドシェイクの判定結果。device と違い `deviceId` を持たない。 */
+export interface WatcherAuthDecision {
+  /** 101 = accept / 401 = token invalid / 403 = role 不許可 */
+  status: 101 | 401 | 403;
+  /** accept 時のみ非空。DO id (テナント単位) に使う。 */
+  tenantId: string;
+}
+
+/**
+ * 打刻更新の購読 (`GET /watch-timecard`) の可否を決める (純粋関数)。
+ *
+ * `decideRecorderAuth` と**別関数にしてある**のは、あちらが「下り command を
+ * 受け取ってよい device」の判定だから。混ぜると読み取り専用の購読者を増やす
+ * たびに command の宛先が増える。
+ *
+ * **user role と device role を明示的に受ける。** 「role が何であれ tenant_id が
+ * あれば通す」にすると、意図しない role (uploader 等) が入る。
+ *
+ * **`sub` は要求しない** — watcher に device 識別子は要らず、むしろ載せると
+ * DO の「接続中デバイス一覧」(`currentDeviceIds`) に現れてしまう。
+ */
+export function decideWatcherAuth(
+  result: IntrospectResult | null | undefined,
+): WatcherAuthDecision {
+  if (!result || result.active !== true || !result.tenant_id) {
+    return { status: 401, tenantId: "" };
+  }
+  const role = result.role;
+  if (typeof role !== "string") return { status: 403, tenantId: "" };
+  if (!WATCHER_USER_ROLES.has(role) && !WATCHER_DEVICE_ROLES.has(role)) {
+    return { status: 403, tenantId: "" };
+  }
+  return { status: 101, tenantId: result.tenant_id };
+}
+
 /** Secrets Store binding (`.get()`) / 文字列 のいずれでも値を取り出す。 */
 export async function resolveSecret(binding: unknown): Promise<string | null> {
   if (typeof binding === "string") return binding;

--- a/cf-alc-recorder/src/index.ts
+++ b/cf-alc-recorder/src/index.ts
@@ -28,6 +28,7 @@ import {
   bearerToken,
   constantTimeEquals,
   decideRecorderAuth,
+  decideWatcherAuth,
   introspectToken,
   resolveSecret,
 } from "./auth";
@@ -43,6 +44,7 @@ import {
 import { runBatterySnapshotCron } from "./battery-snapshot";
 
 export { RecorderHub } from "./recorder-hub";
+import { WATCH_SUBPROTOCOL } from "./recorder-hub";
 
 export interface Env {
   RECORDER_HUB: DurableObjectNamespace;
@@ -140,6 +142,53 @@ async function handleWebSocket(request: Request, env: Env, url: URL): Promise<Re
   return hubStub(env, auth.tenantId).fetch(fwd);
 }
 
+/**
+ * 打刻更新の購読 WS (`GET /watch-timecard`)。**読み取り専用**。
+ *
+ * ブラウザは WS にヘッダーを付けられないので、トークンは
+ * `Sec-WebSocket-Protocol` で運ぶ: `["alc.timecard.v1", "<jwt>"]`。
+ *
+ * **サーバは `alc.timecard.v1` だけを echo し返す。** サブプロトコルを 1 つも
+ * 返さないとブラウザが即座に接続を閉じる。**トークンの方を echo してはいけない**
+ * (応答ヘッダーに秘密が乗る)。`?token=` にしないのは、常時表示のキオスクが
+ * 1 時間ごとに mint する device 資格情報が Worker のログと分析に残り続けるため。
+ */
+async function handleWatchTimecard(request: Request, env: Env, url: URL): Promise<Response> {
+  if (request.headers.get("Upgrade")?.toLowerCase() !== "websocket") {
+    return new Response("Expected WebSocket. Use GET /watch-timecard with Upgrade header", {
+      status: 426,
+    });
+  }
+  const protocols = (request.headers.get("Sec-WebSocket-Protocol") ?? "")
+    .split(",")
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0);
+  if (protocols[0] !== WATCH_SUBPROTOCOL || !protocols[1]) {
+    return json({ error: "missing_token" }, 401);
+  }
+  const sharedSecret = await resolveSecret(env.INTERNAL_SHARED_SECRET);
+  if (!sharedSecret) {
+    return json({ error: "server_error" }, 503);
+  }
+  const result = await introspectToken(env.AUTH_WORKER, sharedSecret, protocols[1], url.origin);
+  if (result === null) {
+    return json({ error: "server_error" }, 503);
+  }
+  const decision = decideWatcherAuth(result);
+  if (decision.status !== 101) {
+    return json(
+      { error: decision.status === 403 ? "forbidden_role" : "invalid_token" },
+      decision.status,
+    );
+  }
+  // tenant は introspect 結果からのみ。**クライアントに名乗らせない** (既存の不変条件)
+  const fwd = new Request("https://recorder-hub.internal/watch", request);
+  fwd.headers.set("X-Recorder-Tenant-Id", decision.tenantId);
+  // device 経路のヘッダーが混ざらないよう明示的に落とす
+  fwd.headers.delete("X-Recorder-Device-Id");
+  return hubStub(env, decision.tenantId).fetch(fwd);
+}
+
 /** POST /measurements 1 リクエストの item 数上限 (WS の 64KB message 上限に相当する暴走ガード)。 */
 const MAX_BATCH_ITEMS = 100;
 
@@ -227,6 +276,9 @@ export default {
 
     if (url.pathname === "/ws") {
       return handleWebSocket(request, env, url);
+    }
+    if (url.pathname === "/watch-timecard") {
+      return handleWatchTimecard(request, env, url);
     }
 
     if (url.pathname === "/measurements" && request.method === "POST") {

--- a/cf-alc-recorder/src/recorder-hub.ts
+++ b/cf-alc-recorder/src/recorder-hub.ts
@@ -43,7 +43,12 @@ import {
 /** WS attachment。hibernation を跨いで identity を保持する。 */
 interface WsAttachment {
   tenantId: string;
-  deviceId: string;
+  /**
+   * device 接続のみ。**購読 (watcher) 接続では未設定にする** —
+   * `currentDeviceIds()` が全ソケットから拾うので、載せるとブラウザが
+   * 「接続中デバイス」一覧に現れる (Refs ippoan/alc-app-s3#134)。
+   */
+  deviceId?: string;
 }
 
 /** 上りメッセージ (JSON parse 後、field は全て untrusted)。 */
@@ -59,6 +64,24 @@ interface InboundMessage {
 
 /** getWebSockets の device 絞り込み用 tag。 */
 const DEVICE_TAG_PREFIX = "device:";
+
+/**
+ * 打刻更新の購読者 (ブラウザ) の tag。**device とは別の tag にする** —
+ * 下り command は `getWebSockets(DEVICE_TAG_PREFIX + ...)` で配るので、
+ * 別 tag にしておけば watcher には構造的に届かない (Refs ippoan/alc-app-s3#134)。
+ */
+const WATCH_TAG = "watch:timecard";
+
+/**
+ * 購読 WS のサブプロトコル名。ブラウザは `["alc.timecard.v1", "<jwt>"]` を送り、
+ * サーバはこちらだけを echo し返す (トークンを応答ヘッダーに乗せない)。
+ */
+export const WATCH_SUBPROTOCOL = "alc.timecard.v1";
+
+/** 打刻更新の合図。**行の中身は送らない** — ブラウザが API を引き直す。
+ * 行の形 (区分 / card_id / 社員解決の凍結 / JST 境界) は rust-alc-api 側に
+ * 作り込んであり、Worker に 2 実装目を作ると必ずズレるため。 */
+const TIMECARD_KIND = "timecard";
 
 /** command_result の storage key prefix。 */
 const CMD_RESULT_PREFIX = "cmdres:";
@@ -102,6 +125,9 @@ export class RecorderHub extends DurableObject<Env> {
     if (url.pathname === "/connect") {
       return this.handleConnect(request);
     }
+    if (url.pathname === "/watch") {
+      return this.handleWatch(request);
+    }
     if (url.pathname === "/command" && request.method === "POST") {
       return this.handleCommand(request);
     }
@@ -119,6 +145,61 @@ export class RecorderHub extends DurableObject<Env> {
   }
 
   // ── WS 受口 ────────────────────────────────────────────────────────────────
+
+  /**
+   * 打刻更新の購読 WS (読み取り専用)。
+   *
+   * **attachment に `deviceId` を載せない。** `currentDeviceIds()` は全ソケットを
+   * 走査して `attachment.deviceId` を拾うので、載せると**キオスクが「接続中
+   * デバイス」一覧に現れ、SSE で管理画面に配信される**。
+   *
+   * その結果 `webSocketMessage` は (deviceId が無いので) この接続からの上りを
+   * 1011 で切る。**それが意図した挙動** — watcher は購読専用で、上りを受けると
+   * 「ブラウザから DO を叩く口」になる。keep-alive の ping は constructor の
+   * `setWebSocketAutoResponse` が `webSocketMessage` を通さずに返すので成立する。
+   */
+  private handleWatch(request: Request): Response {
+    if (request.headers.get("Upgrade")?.toLowerCase() !== "websocket") {
+      return new Response("Expected WebSocket", { status: 426 });
+    }
+    const tenantId = request.headers.get("X-Recorder-Tenant-Id") ?? "";
+    if (!tenantId) {
+      return json({ error: "missing_identity" }, 400);
+    }
+    const pair = new WebSocketPair();
+    this.ctx.acceptWebSocket(pair[1], [WATCH_TAG]);
+    pair[1].serializeAttachment({ tenantId } satisfies WsAttachment);
+    // サブプロトコルを 1 つも返さないとブラウザが即座に閉じる。
+    // **トークン側を返してはいけない** (応答ヘッダーに秘密が乗る)
+    return new Response(null, {
+      status: 101,
+      webSocket: pair[0],
+      headers: { "Sec-WebSocket-Protocol": WATCH_SUBPROTOCOL },
+    });
+  }
+
+  /**
+   * 打刻が入ったことを購読者へ知らせる (**合図のみ**)。
+   *
+   * # 何が通知され、何が通知されないか
+   *
+   * 通知するのは **WS 経由の打刻 (NFC タイムカード端末)** だけ。次の 2 つは
+   * この DO を通らないので通知されない:
+   *
+   * - **ブラウザ版の打刻** (`POST /api/timecard/punch`) — rust-alc-api へ直行する。
+   *   ただし打った本人の画面は応答でその場更新するので、体感上の問題は
+   *   「他の画面に即時反映されない」だけ
+   * - `POST /measurements` (Wi-Fi 客の上り) — Worker 側で処理し DO を経由しない
+   *
+   * 常設の打刻端末が主用途なので、まずここだけを覆う。広げるなら
+   * **通知の発生源を増やすのではなく**、rust-alc-api 側から 1 か所で出す形を
+   * 検討すること (発生源が増えるほど「鳴らない経路」が生まれる)。
+   */
+  private notifyTimecardPunch(): void {
+    for (const ws of this.ctx.getWebSockets(WATCH_TAG)) {
+      this.send(ws, { type: "timecard_punch" });
+    }
+  }
 
   private handleConnect(request: Request): Response {
     if (request.headers.get("Upgrade")?.toLowerCase() !== "websocket") {
@@ -265,6 +346,10 @@ export class RecorderHub extends DurableObject<Env> {
       return;
     }
     this.send(ws, { type: "ack", seq });
+    // 打刻だけ購読者へ合図を出す (ack の後 = backend が受理した後)
+    if (parsed.item.kind === TIMECARD_KIND) {
+      this.notifyTimecardPunch();
+    }
   }
 
   // ── 上り: command_result → storage 保存 ───────────────────────────────────

--- a/cf-alc-recorder/src/recorder-hub.ts
+++ b/cf-alc-recorder/src/recorder-hub.ts
@@ -51,6 +51,15 @@ interface WsAttachment {
   deviceId?: string;
 }
 
+/**
+ * device 接続の attachment (`deviceId` が必ずある)。
+ *
+ * `WsAttachment.deviceId` は watcher のために optional なので、device 経路の
+ * ハンドラはこちらを受け取る。**`webSocketMessage` の guard を通った後だけ**
+ * 作れる — guard を消すと型でも落ちる。
+ */
+type DeviceAttachment = WsAttachment & { deviceId: string };
+
 /** 上りメッセージ (JSON parse 後、field は全て untrusted)。 */
 interface InboundMessage {
   type?: unknown;
@@ -249,12 +258,15 @@ export class RecorderHub extends DurableObject<Env> {
       return;
     }
 
-    const attachment = ws.deserializeAttachment() as WsAttachment | null;
-    if (!attachment?.tenantId || !attachment?.deviceId) {
-      // 想定外 (accept 時に必ず載せている)。identity 不明のまま ingest しない。
+    const raw = ws.deserializeAttachment() as WsAttachment | null;
+    if (!raw?.tenantId || !raw.deviceId) {
+      // device 接続なら想定外 (accept 時に必ず載せている)。
+      // **購読 (watcher) 接続はここに落ちるのが正しい** — deviceId を持たず、
+      // 上りを一切受け付けないため (Refs ippoan/alc-app-s3#134)。
       ws.close(1011, "missing attachment");
       return;
     }
+    const attachment: DeviceAttachment = { tenantId: raw.tenantId, deviceId: raw.deviceId };
 
     switch (msg.type) {
       case "measurement":
@@ -285,7 +297,7 @@ export class RecorderHub extends DurableObject<Env> {
 
   private async handleMeasurement(
     ws: WebSocket,
-    attachment: WsAttachment,
+    attachment: DeviceAttachment,
     msg: InboundMessage,
   ): Promise<void> {
     // 検証 + 転送は POST /measurements (Wi-Fi 客の上り) と共有 (measurements.ts)。
@@ -356,7 +368,7 @@ export class RecorderHub extends DurableObject<Env> {
 
   private async handleCommandResult(
     ws: WebSocket,
-    attachment: WsAttachment,
+    attachment: DeviceAttachment,
     msg: InboundMessage,
   ): Promise<void> {
     const id = typeof msg.id === "string" ? msg.id : "";

--- a/cf-alc-recorder/test/recorder.test.ts
+++ b/cf-alc-recorder/test/recorder.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { SELF, env, runInDurableObject } from "cloudflare:test";
 import type { Env } from "../src/index";
-import { decideRecorderAuth } from "../src/auth";
+import {
+  decideRecorderAuth,
+  decideWatcherAuth,
+  RECORDER_DEVICE_ROLES,
+  DEVICE_ROLE_KIOSK,
+} from "../src/auth";
 
 const BASE = "https://alc-recorder.test";
 const SHARED_SECRET = "test-shared-secret";
@@ -642,5 +647,71 @@ describe("hibernation 復帰 / テナント分離", () => {
     });
     const body = (await res.json()) as { devices: string[] };
     expect(body.devices).not.toContain("device-1");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 打刻更新の購読 (GET /watch-timecard、Refs ippoan/alc-app-s3#134)
+//
+// **読み取り専用の口**。device 経路 (`/ws`) の allowlist とは別判定にしてある —
+// あちらは「下り command を受け取ってよいデバイス」なので、混ぜると購読者を
+// 増やすたびに command の宛先が増える。
+// ---------------------------------------------------------------------------
+
+describe("decideWatcherAuth", () => {
+  it("キオスクの device JWT と 管理者/運行管理者の user JWT を受ける", () => {
+    expect(decideWatcherAuth({ active: true, role: DEVICE_ROLE_KIOSK, tenant_id: "t" })).toEqual({
+      status: 101,
+      tenantId: "t",
+    });
+    expect(decideWatcherAuth({ active: true, role: "admin", tenant_id: "t" }).status).toBe(101);
+    expect(decideWatcherAuth({ active: true, role: "manager", tenant_id: "t" }).status).toBe(101);
+  });
+
+  it("それ以外の role は 403 — 「tenant_id があれば通す」にしない", () => {
+    for (const role of ["viewer", "uploader", "device-uploader", ""]) {
+      expect(decideWatcherAuth({ active: true, role, tenant_id: "t" }).status).toBe(403);
+    }
+    // role 欠落も 403 (fail-closed)
+    expect(decideWatcherAuth({ active: true, tenant_id: "t" }).status).toBe(403);
+  });
+
+  it("active でない / tenant_id 欠落は 401 (fail-closed)", () => {
+    expect(decideWatcherAuth({ active: false, role: "admin", tenant_id: "t" }).status).toBe(401);
+    expect(decideWatcherAuth({ active: true, role: "admin" }).status).toBe(401);
+    expect(decideWatcherAuth(null).status).toBe(401);
+    expect(decideWatcherAuth(undefined).status).toBe(401);
+  });
+
+  it("★ device-kiosk を RECORDER_DEVICE_ROLES に足していない", () => {
+    // 足すと**キオスクが下り command の宛先になる** (blast radius 分離が崩れる)。
+    // 購読は読み取り専用なので、こちらの allowlist だけに入れる
+    expect(RECORDER_DEVICE_ROLES.has(DEVICE_ROLE_KIOSK)).toBe(false);
+    expect(decideRecorderAuth({ active: true, role: DEVICE_ROLE_KIOSK, tenant_id: "t", sub: "d" }).status).toBe(403);
+  });
+
+  it("watcher に deviceId は要らない (sub 無しでも通る)", () => {
+    // sub を要求すると、DO の attachment に deviceId を載せたくなる。
+    // 載せると currentDeviceIds() が拾い、キオスクが「接続中デバイス」に現れる
+    expect(decideWatcherAuth({ active: true, role: DEVICE_ROLE_KIOSK, tenant_id: "t" }).status).toBe(101);
+  });
+});
+
+describe("GET /watch-timecard のハンドシェイク", () => {
+  it("Upgrade が無ければ 426", async () => {
+    const res = await SELF.fetch(`${BASE}/watch-timecard`);
+    expect(res.status).toBe(426);
+  });
+
+  it("サブプロトコルが無い / トークンだけは 401", async () => {
+    const noProto = await SELF.fetch(`${BASE}/watch-timecard`, {
+      headers: { Upgrade: "websocket" },
+    });
+    expect(noProto.status).toBe(401);
+
+    const onlyName = await SELF.fetch(`${BASE}/watch-timecard`, {
+      headers: { Upgrade: "websocket", "Sec-WebSocket-Protocol": "alc.timecard.v1" },
+    });
+    expect(onlyName.status).toBe(401);
   });
 });

--- a/cf-alc-recorder/test/recorder.test.ts
+++ b/cf-alc-recorder/test/recorder.test.ts
@@ -35,6 +35,16 @@ function messageQueue(ws: WebSocket) {
   });
   ws.accept();
   return {
+    /**
+     * まだ取り出していない受信数。
+     *
+     * **「何も来ない」の確認に `next()` を使ってはいけない** — タイムアウトで
+     * reject しても waiter が配列に残り、**次に届いたメッセージがその死んだ
+     * waiter に吸われて消える**。`await sleep(...)` してからこれを見ること。
+     */
+    pending(): number {
+      return queue.length;
+    },
     next(timeoutMs = 3000): Promise<unknown> {
       const head = queue.shift();
       if (head !== undefined) return Promise.resolve(head);
@@ -767,7 +777,8 @@ describe("/watch-timecard の振る舞い", () => {
     // device には届く
     expect(((await deviceMessages.next()) as { type: string }).type).toBe("command");
     // watcher には届かない
-    await expect(watcher.next(300)).rejects.toThrow(/timeout/);
+    await new Promise((r) => setTimeout(r, 300));
+    expect(watcher.pending()).toBe(0);
   });
 
   it("★ 打刻の合図は同じテナントの watcher にだけ届く", async () => {
@@ -789,7 +800,8 @@ describe("/watch-timecard の振る舞い", () => {
       }),
     );
     expect(((await other.messages.next()) as { type: string }).type).toBe("ack");
-    await expect(watcher.next(300)).rejects.toThrow(/timeout/);
+    await new Promise((r) => setTimeout(r, 300));
+    expect(watcher.pending()).toBe(0);
 
     // 同じテナントの端末なら届く。**合図だけで行の中身は含まない**
     const same = await connectAccepted("hub-token-1"); // tenant-1
@@ -824,7 +836,8 @@ describe("/watch-timecard の振る舞い", () => {
       }),
     );
     expect(((await device.messages.next()) as { type: string }).type).toBe("ack");
-    await expect(watcher.next(300)).rejects.toThrow(/timeout/);
+    await new Promise((r) => setTimeout(r, 300));
+    expect(watcher.pending()).toBe(0);
   });
 
   it("★ watcher は「接続中デバイス」一覧に現れない", async () => {

--- a/cf-alc-recorder/test/recorder.test.ts
+++ b/cf-alc-recorder/test/recorder.test.ts
@@ -52,6 +52,20 @@ function messageQueue(ws: WebSocket) {
   };
 }
 
+/**
+ * 打刻更新の購読 WS を張る。トークンは `Sec-WebSocket-Protocol` の 2 つ目。
+ * **`connected` は送られない** (watcher は購読専用で、上りも下り command も無い)。
+ */
+async function connectWatcher(token: string) {
+  const res = await SELF.fetch(`${BASE}/watch-timecard`, {
+    headers: {
+      Upgrade: "websocket",
+      "Sec-WebSocket-Protocol": `alc.timecard.v1, ${token}`,
+    },
+  });
+  return { res, ws: res.webSocket ?? null };
+}
+
 /** 接続 + `connected` 受信までを行うヘルパー。 */
 async function connectAccepted(token: string) {
   const { res, ws } = await connect(token);
@@ -713,5 +727,118 @@ describe("GET /watch-timecard のハンドシェイク", () => {
       headers: { Upgrade: "websocket", "Sec-WebSocket-Protocol": "alc.timecard.v1" },
     });
     expect(onlyName.status).toBe(401);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 購読 WS の振る舞い (Refs ippoan/alc-app-s3#134)
+// ---------------------------------------------------------------------------
+
+describe("/watch-timecard の振る舞い", () => {
+  it("キオスクの device JWT で 101、サブプロトコルは名前だけ echo される", async () => {
+    const { res, ws } = await connectWatcher("kiosk-token");
+    expect(res.status).toBe(101);
+    expect(ws).not.toBeNull();
+    openSockets.push(ws!);
+    // **トークンを echo し返してはいけない** (応答ヘッダーに秘密が乗る)
+    expect(res.headers.get("Sec-WebSocket-Protocol")).toBe("alc.timecard.v1");
+  });
+
+  it("★ watcher は下り command を受け取らない", async () => {
+    // 購読者を増やすことが command の宛先を増やすことにならない、を固定する。
+    // 崩れると「読み取り専用のつもりが遠隔操作の対象になっていた」になる
+    const { ws: watcherWs } = await connectWatcher("kiosk-token");
+    expect(watcherWs).not.toBeNull();
+    openSockets.push(watcherWs!);
+    const watcher = messageQueue(watcherWs!);
+
+    // 同じテナントの device に command を送る
+    const { ws: deviceWs, messages: deviceMessages } = await connectAccepted("hub-token-1");
+    openSockets.push(deviceWs);
+
+    const cmdRes = await SELF.fetch(`${BASE}/tenants/tenant-1/devices/device-1/command`, {
+      method: "POST",
+      headers: { Authorization: SHARED_SECRET, "Content-Type": "application/json" },
+      body: JSON.stringify({ payload: { action: "MEASURE" } }),
+    });
+    expect(cmdRes.status).toBe(202);
+    expect(((await cmdRes.json()) as { delivered: number }).delivered).toBe(1);
+
+    // device には届く
+    expect(((await deviceMessages.next()) as { type: string }).type).toBe("command");
+    // watcher には届かない
+    await expect(watcher.next(300)).rejects.toThrow(/timeout/);
+  });
+
+  it("★ 打刻の合図は同じテナントの watcher にだけ届く", async () => {
+    const { ws: watcherWs } = await connectWatcher("kiosk-token"); // tenant-1
+    expect(watcherWs).not.toBeNull();
+    openSockets.push(watcherWs!);
+    const watcher = messageQueue(watcherWs!);
+
+    // **別テナント**の端末が打刻を送っても、tenant-1 の watcher には届かない
+    const other = await connectAccepted("hub-token-tenant-cmd"); // tenant-cmd
+    openSockets.push(other.ws);
+    other.ws.send(
+      JSON.stringify({
+        type: "measurement",
+        seq: 1,
+        recorded_at_ms: 1752300000000,
+        kind: "timecard",
+        payload: { card_id: "AAAA", card_kind: "felica_idm" },
+      }),
+    );
+    expect(((await other.messages.next()) as { type: string }).type).toBe("ack");
+    await expect(watcher.next(300)).rejects.toThrow(/timeout/);
+
+    // 同じテナントの端末なら届く。**合図だけで行の中身は含まない**
+    const same = await connectAccepted("hub-token-1"); // tenant-1
+    openSockets.push(same.ws);
+    same.ws.send(
+      JSON.stringify({
+        type: "measurement",
+        seq: 101,
+        recorded_at_ms: 1752300000000,
+        kind: "timecard",
+        payload: { card_id: "BBBB", card_kind: "felica_idm" },
+      }),
+    );
+    expect(((await same.messages.next()) as { type: string }).type).toBe("ack");
+    expect(await watcher.next()).toEqual({ type: "timecard_punch" });
+  });
+
+  it("打刻以外の kind では合図を出さない", async () => {
+    const { ws: watcherWs } = await connectWatcher("kiosk-token");
+    expect(watcherWs).not.toBeNull();
+    openSockets.push(watcherWs!);
+    const watcher = messageQueue(watcherWs!);
+
+    const device = await connectAccepted("hub-token-1");
+    openSockets.push(device.ws);
+    device.ws.send(
+      JSON.stringify({
+        type: "measurement",
+        seq: 201,
+        recorded_at_ms: 1752300000000,
+        payload: { type: "temperature", value: 36.5, unit: "celsius" },
+      }),
+    );
+    expect(((await device.messages.next()) as { type: string }).type).toBe("ack");
+    await expect(watcher.next(300)).rejects.toThrow(/timeout/);
+  });
+
+  it("★ watcher は「接続中デバイス」一覧に現れない", async () => {
+    // attachment に deviceId を載せると currentDeviceIds() が拾い、
+    // キオスクが管理画面のデバイス一覧に出てしまう
+    const { ws } = await connectWatcher("kiosk-token");
+    expect(ws).not.toBeNull();
+    openSockets.push(ws!);
+
+    const res = await SELF.fetch(`${BASE}/tenants/tenant-1/devices`, {
+      headers: { Authorization: SHARED_SECRET },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { devices: string[] };
+    expect(body.devices).not.toContain("device-kiosk-1");
   });
 });


### PR DESCRIPTION
打刻履歴を検索ボタンなしで更新するための、**読み取り専用の購読 WebSocket**。管理画面と運行者キオスクの両方が使う。

## 送るのは合図だけ

```json
{"type":"timecard_punch"}
```

**行の中身は送らない。** ブラウザは合図を受けて `GET /timecard/punches` を引き直す。

- 行の形 (区分 / `card_id` / 社員解決の凍結 / JST 境界) は ippoan/rust-alc-api#615〜#618 で作り込んだもので、**Worker に 2 実装目を作れば必ずズレる**
- DO は `timecard_cards` / `employees` を引けない

`cf-alc-signaling` の `/watch-rooms` は `rooms_updated` で中身も送るが、**transport の型だけ真似て payload の型は真似ない** (意図的な相違)。

## 認証 — `RECORDER_DEVICE_ROLES` は据え置き

**`decideWatcherAuth` を新設。** あの allowlist は「**下り command を受け取ってよいデバイス**」の意味なので、`device-kiosk` を足すと**読み取りが欲しいだけなのにキオスクが遠隔コマンドの対象になる**。

- **user role (admin / manager) と device role (`device-kiosk`) を明示的に受ける。** 「tenant_id があれば通す」にはしない
- tenant は **introspect 結果のみ**。パスにも入れない (クライアントに名乗らせない既存の不変条件を維持)
- `manager` も含めた — `ManagerDashboard.vue:96` も `<TimecardManager />` を出しており、admin だけだと運行管理者の画面が更新されない

**`cf-alc-signaling` の `/watch-rooms` は認証が無い**ので、そこは真似ていない。真似たのは `/cam-room?role=admin` の `introspectToken` + 専用判定関数の形。

## トークンの運び方

`Sec-WebSocket-Protocol: ["alc.timecard.v1", "<jwt>"]`。**サーバは `alc.timecard.v1` だけを echo** (トークン側を返すと応答ヘッダーに秘密が乗る)。

`?token=` にしなかったのは、**常時表示のキオスクが 1 時間ごとに mint し続ける device 資格情報**が Worker のログと CF の分析に残り続けるため。

## 守った 3 制約

1. **watcher の attachment に `deviceId` を載せない** — 載せると `currentDeviceIds()` (タグ無しの `getWebSockets()`) が拾い、**キオスクが「接続中デバイス」一覧に現れて SSE で管理画面へ配信される**
2. その結果 `webSocketMessage` が watcher の上りを 1011 で切る = **読み取り専用がそのまま成立**。keep-alive は既存の `setWebSocketAutoResponse` が `webSocketMessage` を通さずに返す
3. 下り command は device tag で配るので、**別 tag にしただけで watcher には構造的に届かない**

3 はテストで固定 (`RECORDER_DEVICE_ROLES.has("device-kiosk") === false` と `decideRecorderAuth({role:"device-kiosk"}).status === 403` を明示 assert)。

## ★ 通知されない経路がある (仕様)

**ブラウザ版の打刻 (`POST /api/timecard/punch`) は DO を通らないので通知されない** (rust-alc-api へ直行するため)。`POST /measurements` (Wi-Fi 客) も同様。

打った本人の画面は応答でその場更新するので、体感上は「**他の画面に即時反映されない**」だけ。広げるなら**発生源を増やすのではなく rust-alc-api 側から 1 か所で出す**形にすること — 発生源が増えるほど「鳴らない経路」が生まれる。

## 検証

**vitest / typecheck は手元で実行できていない** (node_modules 無し、`npm ci` が permission 分類器に拒否)。テストは足してあるので **CI が初検証**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)