### PR TITLE
fix(security): 打刻中継で dev token を弾く — 検証セッションが本番を変更できていた (Refs #162)

### DIFF
--- a/web/server/api/timecard/punch.post.ts
+++ b/web/server/api/timecard/punch.post.ts
@@ -19,7 +19,7 @@
  * 純粋ロジック (認可判定・forward 構築) は server/utils/timecard-relay.ts。
  */
 import type { H3Event } from 'h3'
-import { buildIntrospectForward } from '../../utils/print-relay'
+import { buildIntrospectForward, isDevLoginToken } from '../../utils/print-relay'
 import { buildRecorderTimecardPunchForward, decideTimecardPunchAccess } from '../../utils/timecard-relay'
 
 function cfEnv(event: H3Event): Record<string, unknown> {
@@ -73,6 +73,15 @@ export default defineEventHandler(async (event) => {
   const access = decideTimecardPunchAccess(await introRes.json())
   if (!access.ok) {
     throw createError({ statusCode: access.status, statusMessage: access.message })
+  }
+
+  // dev-login (`token_kind: "dev"`) は本番に書かせない (Refs ippoan/alc-app#162)。
+  // **auth-worker の read-only enforcement (#433) は `/alc-proxy` の中にあり、
+  // 自前 introspect のこの route には効かない。** 「post-merge の検証セッションは
+  // 本番を変更しない」は検証を気軽に回すための土台なので、副作用のある route 側で
+  // 明示的に塞ぐ。判定するのは introspect が active を返した後 = 署名検証済み。
+  if (isDevLoginToken(token)) {
+    throw createError({ statusCode: 403, statusMessage: 'dev_token_write_forbidden' })
   }
 
   // 2. recorder へ渡す (kind / seq は recorder 側が立てる)。応答は素通し —

--- a/web/server/utils/print-relay.ts
+++ b/web/server/utils/print-relay.ts
@@ -104,6 +104,47 @@ export interface IntrospectClaims {
 }
 
 /**
+ * JWT の payload から `token_kind` を読む (**署名は検証しない**)。
+ *
+ * dev-login (ippoan/auth-worker#423) が発行する JWT は `token_kind: "dev"` を持ち、
+ * 本番の `logi_auth_token` と同じ鍵で署名されている。auth-worker の
+ * read-only enforcement (#433) は **`/alc-proxy` の中**にあるので、
+ * **自前で introspect する server route には効かない** (Refs ippoan/alc-app#162)。
+ *
+ * **署名を検証しなくてよい理由**: この値を見るのは `/auth/introspect` が
+ * `active: true` を返した**後**だけ。auth-worker が同じ token の署名・exp・ACL を
+ * 検証済みなので、その payload の claim は本物である。JWT_SECRET は要らない
+ * (consumer に鍵を配らない #290 の方針は保たれる)。
+ *
+ * **introspect の応答に `token_kind` が無いのでここで読んでいる。** auth-worker が
+ * 応答に足してくれたら、そちらへ寄せてこの関数は消すこと (判定材料は 1 か所が良い)。
+ *
+ * 読めない token (segment 不足 / base64 不正 / JSON 不正) は null を返す。
+ * **その場合 dev 扱いにはしない** — introspect を通った token しかここに来ないため。
+ */
+export function tokenKindOf(token: string): string | null {
+  const seg = token.split('.')[1]
+  if (!seg) return null
+  try {
+    const b64 = seg.replace(/-/g, '+').replace(/_/g, '/')
+    const padded = b64 + '='.repeat((4 - (b64.length % 4)) % 4)
+    const bin = atob(padded)
+    // claim に非 ASCII (氏名など) が入りうるので TextDecoder で UTF-8 として読む
+    const bytes = Uint8Array.from(bin, c => c.charCodeAt(0))
+    const payload = JSON.parse(new TextDecoder().decode(bytes)) as { token_kind?: unknown }
+    return typeof payload.token_kind === 'string' ? payload.token_kind : null
+  }
+  catch {
+    return null
+  }
+}
+
+/** dev-login (`token_kind: "dev"`) の token か。副作用のある route はこれで弾く。 */
+export function isDevLoginToken(token: string): boolean {
+  return tokenKindOf(token) === 'dev'
+}
+
+/**
  * auth-worker `/auth/introspect` への forward request を組む。operator の
  * browser JWT を検証して tenant_id / role を得るのに使う (recorder の auth.ts と
  * 同じ shared secret 認証)。

--- a/web/tests/server/timecard-relay.test.ts
+++ b/web/tests/server/timecard-relay.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { resolve } from 'node:path'
+import { isDevLoginToken, tokenKindOf } from '../../server/utils/print-relay'
 import {
   BROWSER_DEVICE_ID,
   PUNCH_DEVICE_ROLES,
@@ -97,6 +98,41 @@ describe('buildRecorderTimecardPunchForward', () => {
   })
 })
 
+/** テスト用の JWT を組む (署名は使わないので固定文字列)。 */
+function jwt(payload: Record<string, unknown>): string {
+  const b64url = (o: unknown) =>
+    Buffer.from(JSON.stringify(o)).toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+  return `${b64url({ alg: 'HS256', typ: 'JWT' })}.${b64url(payload)}.sig`
+}
+
+describe('tokenKindOf / isDevLoginToken (検証セッションの書き込みを弾く、Refs ippoan/alc-app#162)', () => {
+  it('dev-login の JWT を見分ける', () => {
+    expect(tokenKindOf(jwt({ sub: 'u1', token_kind: 'dev' }))).toBe('dev')
+    expect(isDevLoginToken(jwt({ sub: 'u1', token_kind: 'dev' }))).toBe(true)
+  })
+
+  it('通常の browser JWT は dev ではない (token_kind が無い)', () => {
+    expect(tokenKindOf(jwt({ sub: 'u1', role: 'admin' }))).toBeNull()
+    expect(isDevLoginToken(jwt({ sub: 'u1', role: 'admin' }))).toBe(false)
+  })
+
+  it('非 ASCII の claim があっても payload を読める (UTF-8)', () => {
+    // atob をそのまま JSON.parse すると氏名などで壊れる
+    expect(tokenKindOf(jwt({ name: '本多 優鷹', token_kind: 'dev' }))).toBe('dev')
+  })
+
+  it('token_kind が文字列でなければ null', () => {
+    expect(tokenKindOf(jwt({ token_kind: 1 }))).toBeNull()
+  })
+
+  it('読めない token は null (dev 扱いにしない = introspect を通ったものしか来ない)', () => {
+    for (const bad of ['', 'not-a-jwt', 'a.b', 'a.@@@.c', `a.${Buffer.from('not json').toString('base64url')}.c`]) {
+      expect(tokenKindOf(bad)).toBeNull()
+      expect(isDevLoginToken(bad)).toBe(false)
+    }
+  })
+})
+
 describe('server/api/timecard/punch.post.ts (route 本体の不変条件)', () => {
   const src = readFileSync(resolve(__dirname, '../../server/api/timecard/punch.post.ts'), 'utf-8')
 
@@ -106,6 +142,17 @@ describe('server/api/timecard/punch.post.ts (route 本体の不変条件)', () =
     expect(src).toContain('deviceId: access.deviceId')
     expect(src).not.toMatch(/body\?\.(tenant_id|device_id)/)
     expect(src).not.toMatch(/getQuery|getRouterParam/)
+  })
+
+  it('★ dev-login の token では打刻を書かせない (検証セッションが本番を変えない)', () => {
+    // auth-worker の read-only enforcement (#433) は /alc-proxy の中にあり、
+    // 自前 introspect のこの route には効かない (Refs ippoan/alc-app#162)
+    expect(src).toContain('isDevLoginToken(token)')
+    expect(src).toContain('dev_token_write_forbidden')
+    // 弾くのは introspect (= 署名検証) を通った後であること
+    expect(src.indexOf('decideTimecardPunchAccess')).toBeLessThan(src.indexOf('isDevLoginToken(token)'))
+    // recorder へ転送する前であること
+    expect(src.indexOf('isDevLoginToken(token)')).toBeLessThan(src.indexOf('buildRecorderTimecardPunchForward({'))
   })
 
   it('RECORDER / AUTH_WORKER / INTERNAL_SHARED_SECRET の binding を使い、secret を応答に載せない', () => {


### PR DESCRIPTION
**検証用の dev JWT で本番に打刻が書ける状態だった。** 塞ぐ。

## 何が破れていたか

**壊れていたのは権限ではなく「検証セッションは本番を変更しない」という前提**の方。admin は元々 UI から打刻できるので権限昇格ではないが、**この前提があるから post-merge の検証を気軽に回している**ので、静かに破れているのが一番まずい。

dev JWT の read-only enforcement (`token_kind:"dev"` → 非 GET を拒否、auth-worker#433) は **`/alc-proxy` の中**にある。`POST /api/timecard/punch` は **`/alc-proxy` を通らず自前で introspect して recorder へ渡す**ので、この防波堤の外側にいた。

実際に `verify_eval` から本物の打刻が書ける状態だったことを確認している (**書かない形に限定して検証した**)。

## ★ `token_kind` は introspect の応答に無い

`auth-worker/src/handlers/auth-introspect.ts` が返すのは `{ active, tenant_id, role, email, sub, exp, org_wide }` **だけ**。alc-proxy が判定できるのは**その中で JWT payload を直接読めるから** (`alc-proxy.ts:211`)。**consumer 側の server route は introspect の応答からは dev token を見分けられない。**

⇒ **introspect が `active: true` を返した後に、同じ token の payload を base64 デコードして `token_kind` を読む**形にした。

**署名を検証せずに読んでよい理由**: 見るのは **auth-worker が同じ token の署名・exp・ACL を検証し終えた後**だけなので、その payload の claim は本物。JWT_SECRET を consumer に配らない方針 (#290) も保たれる。読めない token は null = **dev 扱いにしない** (introspect を通ったものしか来ないので fail-open で問題ない)。

**auth-worker が introspect に `token_kind` を返すようになったら、そちらへ寄せてこの関数は消す** (判定材料は 1 か所が良い)。コードと #162 に明記。

## テスト

**「introspect の後・recorder へ転送する前」に弾いていること**をソースの出現順で固定した (順番が入れ替わると意味が変わる)。web vitest **1153 green** (新規 6)、coverage gate 31 ファイル 100%。

## 残りの route は**この PR では塞いでいない**

`buildIntrospectForward` を使う server route は 4 本。副作用があるのは 3 本:

| route | 副作用 | 本 PR |
|---|---|---|
| `driver-master/run.post.ts` | theearth → **employees の作成・更新** | **未** |
| `print/[deviceId].post.ts` | **実物のプリンターに印字** | **未** |
| `timecard/punch.post.ts` | `hub_measurements` に 1 行 INSERT | **塞いだ** |
| `print/devices.get.ts` | 一覧取得のみ | 対象外 |

**危険度は `driver-master/run` の方が打刻より重い** (employees の行を作る)。ただし塞ぐと「検証セッションから印刷テストができない」「乗務員マスタ同期を検証で起動できない」という**既存の運用を止める**ので、**どこまで塞ぐかは #162 で判断する**。

Refs #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)