### PR TITLE
fix(timecard): 打刻の失敗理由を出し分ける — 未ペアリングと通信障害が同じ顔をしていた (Refs ippoan/alc-app-s3#134)

### DIFF
--- a/web/app/components/TimePunchKiosk.vue
+++ b/web/app/components/TimePunchKiosk.vue
@@ -118,10 +118,10 @@ onMounted(async () => {
     }
     catch (e: any) {
       // 未登録カードでも打刻自体は記録される (履歴に「未登録カード …」で出る)
-      // ので、ここに来るのは通信・認証の失敗だけ
-      errorMsg.value = e?.message?.includes('401')
-        ? 'この端末は登録されていません (ペアリングが必要です)'
-        : '打刻に失敗しました'
+      // ので、ここに来るのは通信・認証の失敗だけ。
+      // **理由ごとに文言を変える** — 実機の前に立った人が次の一手を選べるように
+      // (「打刻に失敗しました」だけだと、ペアリング漏れも通信障害も同じ顔になる)
+      errorMsg.value = punchFailureMessage(e)
       if (errorTimer) clearTimeout(errorTimer)
       errorTimer = setTimeout(() => { errorMsg.value = '' }, 5000)
     }
@@ -136,6 +136,17 @@ onUnmounted(() => {
   if (errorTimer) clearTimeout(errorTimer)
   if (highlightTimer) clearTimeout(highlightTimer)
 })
+
+/**
+ * 失敗の文言。**status を握りつぶさない** — 未ペアリング (資格情報が無い) と
+ * 通信障害を同じ文言にすると、現地で「ペアリングすれば直る」と分からない。
+ */
+function punchFailureMessage(e: unknown): string {
+  const err = e as { punchFailure?: string, status?: number } | undefined
+  if (err?.punchFailure === 'unpaired') return 'この端末は登録されていません (ペアリングが必要です)'
+  if (err?.punchFailure === 'forbidden') return 'この端末では打刻できません (ペアリングの種別を確認してください)'
+  return err?.status ? `打刻に失敗しました (${err.status})` : '打刻に失敗しました'
+}
 
 function formatTime(iso: string): string {
   return new Date(iso).toLocaleTimeString('ja-JP', { hour: '2-digit', minute: '2-digit', second: '2-digit' })

--- a/web/app/utils/api.ts
+++ b/web/app/utils/api.ts
@@ -127,7 +127,11 @@ async function bearerRequest<T>(url: string, jwt: string, options: RequestInit):
   const res = await fetch(url, { ...options, headers })
   if (!res.ok) {
     const body = await res.text()
-    throw new Error(`API エラー (${res.status}): ${body || res.statusText}`)
+    // **status を Error に載せる。** 呼び出し側 (TimecardManager 等) は既に
+    // `e?.status === 409` の形で見ているのに、ここが文字列しか投げていなかった
+    throw Object.assign(new Error(`API エラー (${res.status}): ${body || res.statusText}`), {
+      status: res.status,
+    })
   }
   if (res.status === 204) return undefined as T
   return (await res.json()) as T
@@ -691,6 +695,25 @@ export async function getTimecardCardByCardId(cardId: string): Promise<TimecardC
 }
 
 /**
+ * 打刻の失敗理由。**画面の文言を決めるためだけでなく、現地での切り分けのため**に
+ * 分けてある — 「打刻に失敗しました」だけだと、未ペアリング・権限不足・通信障害が
+ * 区別できず、実機の前に立った人が次に何をすればよいか分からない
+ * (Refs ippoan/alc-app-s3#134 の実機確認で実際に詰まった)。
+ */
+export type PunchFailure =
+  /** 端末に資格情報が無い / token が無効。ペアリングが要る */
+  | 'unpaired'
+  /** 認証は通ったが、この端末では打刻できない role */
+  | 'forbidden'
+  /** それ以外 (通信・上流エラー) */
+  | 'failed'
+
+/** `punchFailure` を載せた Error を作る。 */
+function punchError(failure: PunchFailure, message: string, status?: number): Error {
+  return Object.assign(new Error(message), { punchFailure: failure, status })
+}
+
+/**
  * 打刻する (Refs ippoan/alc-app-s3#134)。
  *
  * **rust-alc-api ではなく alc-app 自身の server route** (`/api/timecard/punch`) を
@@ -703,15 +726,28 @@ export async function getTimecardCardByCardId(cardId: string): Promise<TimecardC
  * 呼び出し側は打刻後に `listTimePunches` を引き直すこと。
  *
  * tenant_id / device_id は route が JWT から決めるので**ここからは送らない**。
+ *
+ * 失敗は `punchFailure` を載せて投げる (上の型を参照)。
  */
 export async function punchTimecard(cardId: string): Promise<void> {
   const jwt = getAccessToken?.() ?? (getKioskDeviceJwt ? await getKioskDeviceJwt() : null)
-  if (!jwt) throw new Error('認証が必要です')
-  await bearerRequest<unknown>('/api/timecard/punch', jwt, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ card_id: cardId }),
-  })
+  // **ここを 'failed' に落とさない。** 未ペアリング端末はこの分岐にだけ来るので、
+  // 一緒くたにすると「ペアリングすれば直る」と分からなくなる
+  if (!jwt) throw punchError('unpaired', '端末がペアリングされていません')
+  try {
+    await bearerRequest<unknown>('/api/timecard/punch', jwt, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ card_id: cardId }),
+    })
+  }
+  catch (e) {
+    const status = (e as { status?: number })?.status
+    const message = (e as Error)?.message || '打刻に失敗しました'
+    if (status === 401) throw punchError('unpaired', message, status)
+    if (status === 403) throw punchError('forbidden', message, status)
+    throw punchError('failed', message, status)
+  }
 }
 
 export async function listTimePunches(filter: TimePunchFilter = {}): Promise<TimePunchesResponse> {

--- a/web/tests/utils/api.test.ts
+++ b/web/tests/utils/api.test.ts
@@ -2015,7 +2015,7 @@ describe.skipIf(isLive)('punchTimecard (#134 worker 経由)', () => {
 
   it('どちらの JWT も無ければ fetch せずに失敗する (未ペアリング端末)', async () => {
     initApi(API_BASE, () => null, () => 'tid')
-    await expect(punchTimecard('CARD-3')).rejects.toThrow('認証が必要です')
+    await expect(punchTimecard('CARD-3')).rejects.toThrow('端末がペアリングされていません')
     expect(mockFetch).not.toHaveBeenCalled()
   })
 
@@ -2023,6 +2023,46 @@ describe.skipIf(isLive)('punchTimecard (#134 worker 経由)', () => {
     initApi(API_BASE, () => 'admin-jwt', () => 'tid')
     mockFetch.mockResolvedValueOnce(errResponse(401, 'unauthorized'))
     await expect(punchTimecard('CARD-4')).rejects.toThrow('API エラー (401)')
+  })
+
+  // ★ 失敗理由を潰さない (Refs ippoan/alc-app-s3#134 の実機確認)。
+  // 「打刻に失敗しました」だけだと、未ペアリング・権限不足・通信障害が
+  // 現地で区別できず、次の一手 (ペアリングし直す/待つ) を選べない
+  it.each([
+    [401, 'unpaired'],
+    [403, 'forbidden'],
+    [500, 'failed'],
+    [502, 'failed'],
+  ] as [number, string][])('HTTP %i の失敗理由は %s', async (status, failure) => {
+    initApi(API_BASE, () => 'admin-jwt', () => 'tid')
+    mockFetch.mockResolvedValueOnce(errResponse(status, 'ng'))
+    await expect(punchTimecard('CARD-5')).rejects.toMatchObject({ punchFailure: failure, status })
+  })
+
+  it('★ JWT が無い場合の失敗理由は unpaired (通信障害と混ぜない)', async () => {
+    // ここを failed に落としていたせいで、未ペアリングの端末が
+    // 「打刻に失敗しました」としか出さず、原因の切り分けができなかった
+    initApi(API_BASE, () => null, () => 'tid')
+    await expect(punchTimecard('CARD-6')).rejects.toMatchObject({ punchFailure: 'unpaired' })
+    expect(mockFetch).not.toHaveBeenCalled()
+  })
+
+  it('fetch 自体が失敗した場合も failed (status なし) で投げる', async () => {
+    initApi(API_BASE, () => 'admin-jwt', () => 'tid')
+    mockFetch.mockRejectedValueOnce(new Error('Failed to fetch'))
+    await expect(punchTimecard('CARD-7')).rejects.toMatchObject({
+      punchFailure: 'failed',
+      message: 'Failed to fetch',
+    })
+  })
+
+  it('message を持たない失敗でも文言が空にならない', async () => {
+    initApi(API_BASE, () => 'admin-jwt', () => 'tid')
+    mockFetch.mockRejectedValueOnce({})
+    await expect(punchTimecard('CARD-8')).rejects.toMatchObject({
+      punchFailure: 'failed',
+      message: '打刻に失敗しました',
+    })
   })
 })
 


### PR DESCRIPTION
実機 (staging の Android タブレット) でタップ → **「打刻に失敗しました」しか出ず、原因が分からなかった**。

## ① 文言が原因を隠していた

```js
e?.message?.includes('401') ? 'この端末は登録されていません…' : '打刻に失敗しました'
```

`punchTimecard` は JWT が無いとき `Error('認証が必要です')` を投げる。**文字列に `401` を含まないので、未ペアリングでも汎用文言に落ちる。**

⇒ **「ペアリングすれば直る」ケースと通信障害が同じ顔になっていた。現地の人が次の一手を選べない**のが実害。

## ② `bearerRequest` が `status` を載せていなかった (既存バグ)

呼び出し側は既に `e?.status === 409` の形で見ている (`TimecardManager` のカード重複判定など) のに、**`bearerRequest` は文字列しか投げていなかった**。つまりその分岐は**一度も効いていない**。

## 変更

- `punchTimecard` が失敗理由 `punchFailure` (`unpaired` / `forbidden` / `failed`) を載せて投げる
- `bearerRequest` の Error に `status` を載せる (①②の共通の土台)
- キオスクは理由ごとに文言を出す (`打刻に失敗しました (502)` のように status も出す)

## ★ 背景 — #161 で撤去した fallback は staging では生きていた

```
prod    rust /api/employees + X-Tenant-ID → 403   (Cloud Run IAM ロックダウン済み)
staging rust /api/employees + X-Tenant-ID → 200   ← 生きている
```

#161 で「旧 `X-Tenant-ID` 直叩きはロックダウンでどのみち 403 だから残す意味がない」と判断したが、**確認したのは prod だけで staging に一般化していた**。staging では未ペアリング端末が fallback で打刻できており、それを塞いだ形。

**fallback は戻していない。** 戻すと staging だけ「合図の出ない書き込み経路」が生き残り、**staging が prod と違う挙動をテストする**ことになる。未ペアリング端末はペアリングして使う (文言でそう案内する) 方が筋が通る。

## この修正はどちらに転んでも要る

staging のタブレットが未ペアリングかは未確認 (端末設定の「認証情報: 取得済み / 未取得」で確定する)。**「未取得」でも「取得済み」でも、次の切り分けが即座にできるようになるので本 PR は必要。**

## 検証

`vitest run` **1160 passed / 3 skipped** (新規 7) / `check_coverage_100.mjs` **31 ファイル 100%** (`app/utils/api.ts` は branches も 100% 維持) / `vue-tsc --build` は fc1200-wasm 不在の既知エラーのみ。**CI が初検証。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)