### PR TITLE
refactor(manager): signaling の room 一覧購読を useActiveRooms へ畳む (Refs ippoan/alc-app-s3#135)

### DIFF
--- a/web/app/components/ScreenShareAdminView.vue
+++ b/web/app/components/ScreenShareAdminView.vue
@@ -3,7 +3,7 @@ const config = useRuntimeConfig()
 
 const webRtc = useWebRtc('admin')
 
-const allRooms = ref<string[]>([])
+const { activeRooms, start: startWatchingRooms, stop: stopWatchingRooms, reload: reloadActiveRooms } = useActiveRooms()
 const selectedRoomId = ref<string | null>(null)
 const isViewActive = ref(false)
 const isLoading = ref(false)
@@ -26,24 +26,17 @@ function toggleFullscreen() {
 }
 
 // screen- プレフィックスのみフィルタリング
-const screenRooms = computed(() => allRooms.value.filter(r => r.startsWith('screen-')))
+const screenRooms = computed(() => activeRooms.value.filter(r => r.startsWith('screen-')))
 
-const signalingHttpUrl = (config.public.signalingUrl as string).replace(/^wss/, 'https').replace(/^ws:/, 'http:')
 const signalingWsUrl = (config.public.signalingUrl as string).replace(/^https/, 'wss').replace(/^http:/, 'ws:')
 
 async function loadActiveRooms() {
   isLoading.value = true
   loadError.value = null
-  try {
-    const res = await fetch(`${signalingHttpUrl}/active-rooms`)
-    if (!res.ok) throw new Error(`HTTP ${res.status}`)
-    const data = await res.json() as { rooms: string[] }
-    allRooms.value = data.rooms
-  } catch {
+  if (!await reloadActiveRooms()) {
     loadError.value = '画面共有一覧の取得に失敗しました'
-  } finally {
-    isLoading.value = false
   }
+  isLoading.value = false
 }
 
 async function startViewing(roomId: string) {
@@ -99,40 +92,12 @@ function toggleMute() {
   }
 }
 
-// WebSocket でリアルタイム更新
-let watchWs: WebSocket | null = null
-let watchPingTimer: ReturnType<typeof setInterval> | null = null
-
-function connectWatchSocket() {
-  const wsUrl = `${signalingWsUrl}/watch-rooms`
-  watchWs = new WebSocket(wsUrl)
-
-  watchWs.onmessage = (event) => {
-    try {
-      const data = JSON.parse(event.data)
-      if (data.type === 'rooms_updated') {
-        allRooms.value = data.rooms
-        // 視聴中のルームが消えたら停止
-        if (isViewActive.value && selectedRoomId.value && !data.rooms.includes(selectedRoomId.value)) {
-          stopViewing()
-        }
-      }
-    } catch { /* ignore */ }
+// 視聴中のルームが一覧から消えたら停止
+watch(activeRooms, (rooms) => {
+  if (isViewActive.value && selectedRoomId.value && !rooms.includes(selectedRoomId.value)) {
+    stopViewing()
   }
-
-  watchWs.onopen = () => {
-    watchPingTimer = setInterval(() => watchWs?.send('ping'), 30000)
-  }
-
-  watchWs.onclose = () => {
-    if (watchPingTimer) { clearInterval(watchPingTimer); watchPingTimer = null }
-    setTimeout(connectWatchSocket, 3000)
-  }
-
-  watchWs.onerror = () => {
-    watchWs?.close()
-  }
-}
+})
 
 watch(() => webRtc.remoteStream.value, (stream) => {
   if (videoRef.value) videoRef.value.srcObject = stream
@@ -140,16 +105,14 @@ watch(() => webRtc.remoteStream.value, (stream) => {
 
 onMounted(() => {
   loadActiveRooms()
-  connectWatchSocket()
+  startWatchingRooms()
   document.addEventListener('fullscreenchange', () => {
     isFullscreen.value = !!document.fullscreenElement
   })
 })
 
 onUnmounted(() => {
-  watchWs?.close()
-  watchWs = null
-  if (watchPingTimer) clearInterval(watchPingTimer)
+  stopWatchingRooms()
   webRtc.disconnect()
   adminMicStream?.getTracks().forEach(t => t.stop())
   adminMicStream = null

--- a/web/app/components/TenkoRemoteAdminView.vue
+++ b/web/app/components/TenkoRemoteAdminView.vue
@@ -15,8 +15,14 @@ const adminCamera = useCamera()
 let adminAudioStream: MediaStream | null = null  // マイク音声 (WebRTC用)
 const adminCombinedStream = ref<MediaStream | null>(null)  // 映像+音声 (TenkoVideoCall用)
 
-// シグナリングサーバーからアクティブなルーム(device接続中)一覧を取得
-const activeRooms = ref<string[]>([])
+// シグナリングサーバーからアクティブなルーム(device接続中)一覧を購読 (アプリ全体で 1 本)
+const {
+  activeRooms,
+  start: startWatchingRooms,
+  stop: stopWatchingRooms,
+  setJoined,
+  reload: reloadActiveRooms,
+} = useActiveRooms()
 const selectedRoomId = ref<string | null>(null)
 const isCallActive = ref(false)
 const isLoading = ref(false)
@@ -134,8 +140,6 @@ function selfDeclLabel(key: string) {
   return map[key] || key
 }
 
-// HTTP用: wss://→https:// または ws://→http://
-const signalingHttpUrl = (config.public.signalingUrl as string).replace(/^wss/, 'https').replace(/^ws:/, 'http:')
 // WebSocket用: https://→wss:// または http://→ws://
 const signalingWsUrl = (config.public.signalingUrl as string).replace(/^https/, 'wss').replace(/^http:/, 'ws:')
 
@@ -197,16 +201,10 @@ function cancelFaceAuth() {
 async function loadActiveRooms() {
   isLoading.value = true
   loadError.value = null
-  try {
-    const res = await fetch(`${signalingHttpUrl}/active-rooms`)
-    if (!res.ok) throw new Error(`HTTP ${res.status}`)
-    const data = await res.json() as { rooms: string[] }
-    activeRooms.value = data.rooms
-  } catch {
+  if (!await reloadActiveRooms()) {
     loadError.value = '接続中デバイスの取得に失敗しました'
-  } finally {
-    isLoading.value = false
   }
+  isLoading.value = false
 }
 
 async function startCall(roomId: string) {
@@ -216,6 +214,7 @@ async function startCall(roomId: string) {
     adminAudioStream?.getTracks().forEach(t => t.stop())
     adminAudioStream = null
     isCallActive.value = false
+    setJoined(null)
   }
 
   selectedRoomId.value = roomId
@@ -241,6 +240,7 @@ async function startCall(roomId: string) {
       await webRtc.startStreaming(streamToSend)
     }
     isCallActive.value = true
+    setJoined(roomId)
     startSessionPolling(roomId)
   }
   catch {
@@ -257,38 +257,7 @@ function endCall() {
   adminCombinedStream.value = null
   isCallActive.value = false
   selectedRoomId.value = null
-}
-
-// WebSocket で room 一覧をリアルタイム受信
-let watchWs: WebSocket | null = null
-let watchPingTimer: ReturnType<typeof setInterval> | null = null
-
-function connectWatchSocket() {
-  const wsUrl = `${signalingWsUrl}/watch-rooms`
-  watchWs = new WebSocket(wsUrl)
-
-  watchWs.onmessage = (event) => {
-    try {
-      const data = JSON.parse(event.data)
-      if (data.type === 'rooms_updated') {
-        activeRooms.value = data.rooms
-      }
-    } catch { /* ignore */ }
-  }
-
-  watchWs.onopen = () => {
-    watchPingTimer = setInterval(() => watchWs?.send('ping'), 30000)
-  }
-
-  watchWs.onclose = () => {
-    if (watchPingTimer) { clearInterval(watchPingTimer); watchPingTimer = null }
-    // 切断時は3秒後に再接続
-    setTimeout(connectWatchSocket, 3000)
-  }
-
-  watchWs.onerror = () => {
-    watchWs?.close()
-  }
+  setJoined(null)
 }
 
 const { deviceId, deviceSettingsToken } = useAuth()
@@ -305,7 +274,7 @@ onMounted(async () => {
   }
 
   loadActiveRooms()
-  connectWatchSocket()
+  startWatchingRooms()
 })
 
 // initialRoomId 指定時、ルームが現れたら自動で requestCall
@@ -319,9 +288,7 @@ watch(activeRooms, (rooms) => {
 
 onUnmounted(() => {
   stopSessionPolling()
-  watchWs?.close()
-  watchWs = null
-  if (watchPingTimer) clearInterval(watchPingTimer)
+  stopWatchingRooms()
   webRtc.disconnect()
   adminCamera.stop()
   adminAudioStream?.getTracks().forEach(t => t.stop())

--- a/web/app/composables/useActiveRooms.ts
+++ b/web/app/composables/useActiveRooms.ts
@@ -1,0 +1,114 @@
+/**
+ * signaling の room 一覧 (= 端末が繋いでいる部屋) を、アプリ全体で 1 本だけ購読する singleton。
+ *
+ * 初期取得は `GET /active-rooms`、以後の更新は `/watch-rooms` の WebSocket で受ける。
+ * 遠隔点呼モニターと画面共有モニターが同じ一覧を見るため、画面ごとに WebSocket を
+ * 張ると signaling 側の接続が画面数だけ増える。ここに畳んで 1 本にする。
+ *
+ * start/stop は参照カウント: 運行管理者ダッシュボード (親) と子画面が同時に持つので、
+ * 子が unmount しても親が持っているあいだは WebSocket を落とさない。落とすと
+ * 「signaling 切断」を見張っている側が誤検知する。
+ */
+
+/** 生存確認。signaling 側のアイドルタイムアウトより短く */
+const PING_INTERVAL = 30000
+/** 切断されたら待ってから張り直す */
+const RECONNECT_DELAY = 3000
+
+/** 購読は 1 本なので module スコープで持つ (start/stop は client でしか呼ばれない) */
+let ws: WebSocket | null = null
+let pingTimer: ReturnType<typeof setInterval> | null = null
+let reconnectTimer: ReturnType<typeof setTimeout> | null = null
+let refCount = 0
+
+export function useActiveRooms() {
+  const config = useRuntimeConfig()
+
+  const activeRooms = useState<string[]>('active-rooms', () => [])
+  /** WebSocket が open かどうか */
+  const isWatching = useState<boolean>('active-rooms-watching', () => false)
+  /** 運行管理者が今どの room に入っているか (未参加は null) */
+  const joinedRoomId = useState<string | null>('active-rooms-joined', () => null)
+
+  const signalingHttpUrl = (config.public.signalingUrl as string).replace(/^wss/, 'https').replace(/^ws:/, 'http:')
+  const signalingWsUrl = (config.public.signalingUrl as string).replace(/^https/, 'wss').replace(/^http:/, 'ws:')
+
+  /** `GET /active-rooms` を 1 回。成功したら true (エラー文言は画面ごとに違うので投げない) */
+  async function reload(): Promise<boolean> {
+    try {
+      const res = await fetch(`${signalingHttpUrl}/active-rooms`)
+      if (!res.ok) throw new Error(`HTTP ${res.status}`)
+      const data = await res.json() as { rooms: string[] }
+      activeRooms.value = data.rooms
+      return true
+    }
+    catch {
+      return false
+    }
+  }
+
+  function connect() {
+    reconnectTimer = null
+    const socket = new WebSocket(`${signalingWsUrl}/watch-rooms`)
+    ws = socket
+
+    socket.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data)
+        if (data.type === 'rooms_updated') {
+          activeRooms.value = data.rooms
+        }
+      }
+      catch { /* 壊れた frame は捨てる */ }
+    }
+
+    socket.onopen = () => {
+      isWatching.value = true
+      pingTimer = setInterval(() => socket.send('ping'), PING_INTERVAL)
+    }
+
+    socket.onclose = () => {
+      isWatching.value = false
+      ws = null
+      if (pingTimer) { clearInterval(pingTimer); pingTimer = null }
+      // 使っている画面が残っているあいだだけ張り直す
+      if (refCount > 0) reconnectTimer = setTimeout(connect, RECONNECT_DELAY)
+    }
+
+    socket.onerror = () => {
+      socket.close()
+    }
+  }
+
+  /** 購読を 1 つ増やす。最初の 1 つ目で WebSocket を張る */
+  function start() {
+    refCount += 1
+    if (refCount === 1) connect()
+  }
+
+  /** 購読を 1 つ減らす。最後の 1 つが外れたら WebSocket を閉じる */
+  function stop() {
+    if (refCount === 0) return
+    refCount -= 1
+    if (refCount > 0) return
+
+    if (pingTimer) { clearInterval(pingTimer); pingTimer = null }
+    if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null }
+    if (ws) { ws.close(); ws = null }
+    isWatching.value = false
+  }
+
+  function setJoined(roomId: string | null) {
+    joinedRoomId.value = roomId
+  }
+
+  return {
+    activeRooms: readonly(activeRooms),
+    isWatching: readonly(isWatching),
+    joinedRoomId: readonly(joinedRoomId),
+    start,
+    stop,
+    setJoined,
+    reload,
+  }
+}

--- a/web/coverage_100.toml
+++ b/web/coverage_100.toml
@@ -15,6 +15,10 @@ path = "app/composables/useAndroidLandscape.ts"
 branches = true
 
 [[files]]
+path = "app/composables/useActiveRooms.ts"
+branches = true
+
+[[files]]
 path = "app/composables/useAuth.ts"
 branches = true
 

--- a/web/tests/composables/useActiveRooms.test.ts
+++ b/web/tests/composables/useActiveRooms.test.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// 生成された MockWebSocket をすべて記録する
+let wsInstances: MockWebSocket[] = []
+
+class MockWebSocket {
+  static CONNECTING = 0
+  static OPEN = 1
+  static CLOSING = 2
+  static CLOSED = 3
+
+  readyState = MockWebSocket.CONNECTING
+  url: string
+  sent: string[] = []
+  onopen: ((event: Event) => void) | null = null
+  onclose: ((event: CloseEvent) => void) | null = null
+  onmessage: ((event: MessageEvent) => void) | null = null
+  onerror: ((event: Event) => void) | null = null
+
+  constructor(url: string) {
+    this.url = url
+    wsInstances.push(this)
+  }
+
+  send(data: string) {
+    this.sent.push(data)
+  }
+
+  close() {
+    if (this.readyState === MockWebSocket.CLOSED) return
+    this.readyState = MockWebSocket.CLOSED
+    this.onclose?.(new CloseEvent('close'))
+  }
+
+  simulateOpen() {
+    this.readyState = MockWebSocket.OPEN
+    this.onopen?.(new Event('open'))
+  }
+
+  simulateMessage(data: string) {
+    this.onmessage?.(new MessageEvent('message', { data }))
+  }
+
+  simulateError() {
+    this.onerror?.(new Event('error'))
+  }
+}
+
+function lastWs(): MockWebSocket {
+  return wsInstances[wsInstances.length - 1]!
+}
+
+/** open まで済んだ購読を 1 本張る */
+function startOpened(useActiveRooms: () => any) {
+  const rooms = useActiveRooms()
+  rooms.start()
+  lastWs().simulateOpen()
+  return rooms
+}
+
+describe('useActiveRooms', () => {
+  let originalWebSocket: typeof WebSocket
+  let useActiveRooms: typeof import('~/composables/useActiveRooms').useActiveRooms
+
+  beforeEach(async () => {
+    wsInstances = []
+    originalWebSocket = globalThis.WebSocket
+    vi.stubGlobal('WebSocket', MockWebSocket)
+    vi.useFakeTimers()
+
+    // module スコープの参照カウント / socket を test ごとにリセットする
+    vi.resetModules()
+    const mod = await import('~/composables/useActiveRooms')
+    useActiveRooms = mod.useActiveRooms
+
+    // useState は Nuxt の payload に載るので module のリセットでは消えない
+    useState<string[]>('active-rooms').value = []
+    useState<boolean>('active-rooms-watching').value = false
+    useState<string | null>('active-rooms-joined').value = null
+  })
+
+  afterEach(() => {
+    vi.stubGlobal('WebSocket', originalWebSocket)
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('初期状態は未購読で room 一覧は空', () => {
+    const { activeRooms, isWatching, joinedRoomId } = useActiveRooms()
+    expect(activeRooms.value).toEqual([])
+    expect(isWatching.value).toBe(false)
+    expect(joinedRoomId.value).toBeNull()
+  })
+
+  it('start で signaling の /watch-rooms へ繋ぐ', () => {
+    const { start } = useActiveRooms()
+    start()
+    expect(wsInstances).toHaveLength(1)
+    expect(lastWs().url).toBe('ws://localhost:8787/watch-rooms')
+  })
+
+  it('open で isWatching が true になる', () => {
+    const { isWatching } = startOpened(useActiveRooms)
+    expect(isWatching.value).toBe(true)
+  })
+
+  it('rooms_updated で room 一覧を更新する', () => {
+    const { activeRooms } = startOpened(useActiveRooms)
+    lastWs().simulateMessage(JSON.stringify({ type: 'rooms_updated', rooms: ['dev-1', 'screen-dev-1'] }))
+    expect(activeRooms.value).toEqual(['dev-1', 'screen-dev-1'])
+  })
+
+  it('rooms_updated 以外の frame は無視する', () => {
+    const { activeRooms } = startOpened(useActiveRooms)
+    lastWs().simulateMessage(JSON.stringify({ type: 'pong' }))
+    expect(activeRooms.value).toEqual([])
+  })
+
+  it('壊れた frame は捨てる', () => {
+    const { activeRooms } = startOpened(useActiveRooms)
+    expect(() => lastWs().simulateMessage('not json')).not.toThrow()
+    expect(activeRooms.value).toEqual([])
+  })
+
+  it('30 秒ごとに ping を送る', () => {
+    startOpened(useActiveRooms)
+    const ws = lastWs()
+    vi.advanceTimersByTime(30000)
+    expect(ws.sent).toEqual(['ping'])
+    vi.advanceTimersByTime(30000)
+    expect(ws.sent).toEqual(['ping', 'ping'])
+  })
+
+  it('close で isWatching が false になり 3 秒後に再接続する', () => {
+    const { isWatching } = startOpened(useActiveRooms)
+    lastWs().close()
+    expect(isWatching.value).toBe(false)
+    expect(wsInstances).toHaveLength(1)
+
+    vi.advanceTimersByTime(3000)
+    expect(wsInstances).toHaveLength(2)
+    lastWs().simulateOpen()
+    expect(isWatching.value).toBe(true)
+  })
+
+  it('再接続後も ping は 1 本だけ (前の socket の timer は止まっている)', () => {
+    startOpened(useActiveRooms)
+    const first = lastWs()
+    first.close()
+    vi.advanceTimersByTime(3000)
+    const second = lastWs()
+    second.simulateOpen()
+
+    vi.advanceTimersByTime(30000)
+    expect(first.sent).toEqual([])
+    expect(second.sent).toEqual(['ping'])
+  })
+
+  it('error で socket を閉じる (open 前なので ping timer は無い)', () => {
+    const { start, isWatching } = useActiveRooms()
+    start()
+    lastWs().simulateError()
+    expect(lastWs().readyState).toBe(MockWebSocket.CLOSED)
+    expect(isWatching.value).toBe(false)
+  })
+
+  it('start 2 回 → stop 1 回では閉じず、2 回目で閉じる', () => {
+    const { start, stop, isWatching } = useActiveRooms()
+    start()
+    start()
+    expect(wsInstances).toHaveLength(1)
+    lastWs().simulateOpen()
+
+    stop()
+    expect(lastWs().readyState).toBe(MockWebSocket.OPEN)
+    expect(isWatching.value).toBe(true)
+
+    stop()
+    expect(lastWs().readyState).toBe(MockWebSocket.CLOSED)
+    expect(isWatching.value).toBe(false)
+  })
+
+  it('stop 後は ping も再接続もしない', () => {
+    const { start, stop } = startOpened(useActiveRooms) as any
+    void start
+    const ws = lastWs()
+    stop()
+    vi.advanceTimersByTime(60000)
+    expect(ws.sent).toEqual([])
+    expect(wsInstances).toHaveLength(1)
+  })
+
+  it('再接続待ちのあいだに stop すると再接続タイマーを止める', () => {
+    const { stop } = startOpened(useActiveRooms)
+    lastWs().close()
+    stop()
+    vi.advanceTimersByTime(10000)
+    expect(wsInstances).toHaveLength(1)
+  })
+
+  it('参照カウントは負にならない (余分な stop は無視)', () => {
+    const { start, stop } = useActiveRooms()
+    stop()
+    stop()
+    start()
+    expect(wsInstances).toHaveLength(1)
+    stop()
+    expect(lastWs().readyState).toBe(MockWebSocket.CLOSED)
+  })
+
+  it('別の呼び出しでも同じ購読を共有する (singleton)', () => {
+    const a = useActiveRooms()
+    const b = useActiveRooms()
+    a.start()
+    b.start()
+    expect(wsInstances).toHaveLength(1)
+    lastWs().simulateMessage(JSON.stringify({ type: 'rooms_updated', rooms: ['dev-1'] }))
+    expect(b.activeRooms.value).toEqual(['dev-1'])
+  })
+
+  it('setJoined で joinedRoomId を出し入れできる', () => {
+    const { setJoined, joinedRoomId } = useActiveRooms()
+    setJoined('dev-1')
+    expect(joinedRoomId.value).toBe('dev-1')
+    setJoined(null)
+    expect(joinedRoomId.value).toBeNull()
+  })
+
+  it('reload 成功で room 一覧を差し替え true を返す', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ rooms: ['dev-1'] }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { reload, activeRooms } = useActiveRooms()
+    await expect(reload()).resolves.toBe(true)
+    expect(fetchMock).toHaveBeenCalledWith('http://localhost:8787/active-rooms')
+    expect(activeRooms.value).toEqual(['dev-1'])
+  })
+
+  it('reload が HTTP エラーなら false を返し一覧は変えない', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false, status: 500 }))
+
+    const { reload, activeRooms } = useActiveRooms()
+    await expect(reload()).resolves.toBe(false)
+    expect(activeRooms.value).toEqual([])
+  })
+
+  it('reload が通信エラーなら false を返す', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')))
+
+    const { reload } = useActiveRooms()
+    await expect(reload()).resolves.toBe(false)
+  })
+})


### PR DESCRIPTION
signaling の room 一覧購読 (`/watch-rooms` WebSocket + `GET /active-rooms`) が遠隔点呼 (`TenkoRemoteAdminView`) と画面共有 (`ScreenShareAdminView`) に同型で複製されていたのを、`useActiveRooms` 1 本に畳む。**画面の挙動は変えない** (純粋なリファクタ)。

Refs ippoan/alc-app-s3#135

## なぜ今

警告デバイス (Atom VoiceS3R) を運行管理者の PC に置き、**着信 (乗務員がキオスクで点呼を始めて room が立った) で鳴らす**ことになった。後続 PR (c135-5b) が `ManagerDashboard` から「room がある & 管理者が未 join」を読んで USB へ `call=1` を送るので、**画面が mount されていなくても購読を保てる singleton** が要る。

## 変更

- `useActiveRooms.ts` (新規) — `useState` の singleton。`activeRooms` / `isWatching` / `joinedRoomId` / `start()` / `stop()` / `setJoined()` / `reload()`。**start/stop は参照カウント** (0→1 で WS を張り、1→0 で閉じる。子画面が先に unmount しても親が持つ間は落ちない)。30 秒 ping・close 3 秒後の再接続は旧コードのまま。URL は `config.public.signalingUrl` から
- 2 画面 — 購読コードを除去して composable を呼ぶだけ (−95 行)。遠隔点呼は通話の開始 / 掛け直し / 終了で `setJoined` を更新
- `useActiveRooms.test.ts` (19 ケース) + `coverage_100.toml` 登録 (lines / branches 100%)

## 挙動が変わりうる唯一の点

画面共有の「視聴中の room が一覧から消えたら停止」を WS frame のハンドラから `watch(activeRooms)` へ移した (条件式は同一)。WS が切れている間に「更新」を押して GET の結果から room が消えていた場合だけ、旧は停止せず新は停止する。WS が生きていれば同じ frame で先に停止するので実運用では到達しない。

## 検証

- `npm run test:coverage` → 43 files / 1214 passed。`check_coverage_100.mjs` → 33 files OK
- `nuxi typecheck` → 0 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
