### PR TITLE
style(manager): 警告デバイスのバーをロールタブ・認証カードと同じ設計言語に揃える (Refs ippoan/alc-app-s3#135)

### DIFF
--- a/web/app/components/ManagerAlarmBar.vue
+++ b/web/app/components/ManagerAlarmBar.vue
@@ -45,32 +45,86 @@ const alarmStatusText = computed(() => {
   return '接続'
 })
 
-const alarmDotClass = computed(() => {
-  if (!alarm.isConnected.value) return 'bg-gray-300'
-  const state = alarm.deviceState.value?.state
-  if (state === 'alarming') return 'bg-red-500'
-  if (state === 'muted') return 'bg-amber-400'
-  return 'bg-green-500'
+type AlarmVisual = 'disconnected' | 'idle' | 'alarming' | 'muted'
+
+/** 見た目 (アイコン円・状態ピル・カードの枠) を 1 つの状態語に畳む */
+const alarmVisual = computed<AlarmVisual>(() => {
+  if (!alarm.isConnected.value) return 'disconnected'
+  const s = alarm.deviceState.value?.state
+  if (s === 'alarming') return 'alarming'
+  if (s === 'muted') return 'muted'
+  return 'idle'
 })
+
+// Tailwind の purge に残るよう、クラスは完全な文字列で持つ (`bg-${色}-100` のような連結は禁止)
+const iconClasses: Record<AlarmVisual, string> = {
+  disconnected: 'bg-gray-100 text-gray-400',
+  idle: 'bg-green-100 text-green-600',
+  alarming: 'bg-red-100 text-red-600',
+  muted: 'bg-amber-100 text-amber-600',
+}
+const pillClasses: Record<AlarmVisual, string> = {
+  disconnected: 'bg-gray-100 text-gray-500',
+  idle: 'bg-green-50 text-green-700',
+  alarming: 'bg-red-50 text-red-700',
+  muted: 'bg-amber-50 text-amber-700',
+}
+const cardClasses: Record<AlarmVisual, string> = {
+  disconnected: '',
+  idle: '',
+  alarming: 'border border-red-300 bg-red-50',
+  muted: 'border border-amber-200',
+}
+
+const alarmIconClass = computed(() => iconClasses[alarmVisual.value])
+const alarmPillClass = computed(() => pillClasses[alarmVisual.value])
+const alarmCardClass = computed(() => cardClasses[alarmVisual.value])
 </script>
 
 <template>
   <ClientOnly>
-    <div
-      v-if="isSupported"
-      class="shrink-0 px-4 py-1.5 bg-white border-b flex items-center gap-3 text-xs"
-      data-testid="manager-alarm-bar"
-    >
-      <span class="w-2.5 h-2.5 rounded-full shrink-0" :class="alarmDotClass" />
-      <span class="text-gray-700">警告デバイス: {{ alarmStatusText }}</span>
-      <span v-if="!isWatching" class="text-red-600">着信を受けられません (signaling 未接続)</span>
-      <span v-else-if="isCalling" class="text-amber-600 font-medium">着信あり</span>
-      <button
-        class="ml-auto px-3 py-1 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors"
-        @click="alarm.requestPort()"
+    <div v-if="isSupported" class="w-full max-w-lg mx-auto px-4 mt-2">
+      <div
+        class="bg-white rounded-2xl shadow-sm px-4 py-3 flex items-center gap-3"
+        :class="alarmCardClass"
+        data-testid="manager-alarm-bar"
       >
-        警告デバイスを接続
-      </button>
+        <span
+          class="w-9 h-9 rounded-full flex items-center justify-center shrink-0"
+          :class="alarmIconClass"
+        >
+          <svg
+            class="w-5 h-5"
+            :class="{ 'animate-pulse': alarmVisual === 'alarming' }"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+          >
+            <path stroke-linecap="round" stroke-linejoin="round" d="M15 17h5l-1.4-1.4a2 2 0 01-.6-1.4V11a6 6 0 10-12 0v3.2a2 2 0 01-.6 1.4L4 17h5m6 0H9m6 0v1a3 3 0 11-6 0v-1" />
+          </svg>
+        </span>
+
+        <div class="flex-1 min-w-0">
+          <div class="flex items-center gap-2">
+            <span class="text-sm font-medium text-gray-800">警告デバイス</span>
+            <span class="text-xs px-2 py-0.5 rounded-full" :class="alarmPillClass">{{ alarmStatusText }}</span>
+          </div>
+          <p v-if="!isWatching" class="text-xs text-red-600">着信を受けられません (signaling 未接続)</p>
+          <p v-else-if="isCalling" class="text-xs text-amber-700 font-medium">着信あり — 遠隔点呼に入ると止まります</p>
+          <p v-else class="text-xs text-gray-500">運行管理者のブラウザを見張っています (閉じると鳴ります)</p>
+        </div>
+
+        <button
+          class="shrink-0 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors"
+          :class="alarmVisual === 'disconnected'
+            ? 'bg-blue-600 text-white hover:bg-blue-700'
+            : 'border border-gray-300 text-gray-600 hover:bg-gray-50'"
+          @click="alarm.requestPort()"
+        >
+          {{ alarmVisual === 'disconnected' ? '接続' : '接続し直す' }}
+        </button>
+      </div>
     </div>
   </ClientOnly>
 </template>

--- a/web/tests/components/ManagerAlarmBar.test.ts
+++ b/web/tests/components/ManagerAlarmBar.test.ts
@@ -75,28 +75,36 @@ describe('ManagerAlarmBar', () => {
     expect(calls).toEqual([])
   })
 
-  it('未接続のあいだは灰の丸と「未接続」', async () => {
+  it('未接続のあいだは灰のアイコンと「未接続」、ボタンは「接続」', async () => {
     const wrapper = await mountSuspended(ManagerAlarmBar)
-    expect(wrapper.text()).toContain('警告デバイス: 未接続')
-    expect(wrapper.find('.bg-gray-300').exists()).toBe(true)
+    expect(wrapper.text()).toContain('警告デバイス')
+    expect(wrapper.text()).toContain('未接続')
+    expect(wrapper.find('.bg-gray-100').exists()).toBe(true)
+    expect(wrapper.find('button').text()).toBe('接続')
     wrapper.unmount()
   })
 
-  it('接続後は緑、鳴動中は赤 + 理由、停止済みは黄 + 理由', async () => {
+  it('接続後は緑、鳴動中は赤 + 理由 + 赤枠、停止済みは黄 + 理由', async () => {
     alarmState.isConnected.value = true
     const wrapper = await mountSuspended(ManagerAlarmBar)
-    expect(wrapper.text()).toContain('警告デバイス: 接続')
-    expect(wrapper.find('.bg-green-500').exists()).toBe(true)
+    expect(wrapper.text()).toContain('接続')
+    expect(wrapper.find('.bg-green-100').exists()).toBe(true)
+    // 接続済みならボタンは繋ぎ直し
+    expect(wrapper.find('button').text()).toBe('接続し直す')
 
     alarmState.deviceState.value = { state: 'alarming', cause: 'silence' }
     await wrapper.vm.$nextTick()
     expect(wrapper.text()).toContain('鳴動中 (無音)')
-    expect(wrapper.find('.bg-red-500').exists()).toBe(true)
+    expect(wrapper.find('.bg-red-100').exists()).toBe(true)
+    expect(wrapper.find('.animate-pulse').exists()).toBe(true)
+    // 鳴動中はカードごと赤く縁取る
+    expect(wrapper.find('[data-testid="manager-alarm-bar"]').classes()).toContain('border-red-300')
 
     alarmState.deviceState.value = { state: 'muted', cause: 'call' }
     await wrapper.vm.$nextTick()
     expect(wrapper.text()).toContain('停止済み (人が止めた・呼び出し)')
-    expect(wrapper.find('.bg-amber-400').exists()).toBe(true)
+    expect(wrapper.find('.bg-amber-100').exists()).toBe(true)
+    expect(wrapper.find('[data-testid="manager-alarm-bar"]').classes()).toContain('border-amber-200')
 
     // firmware が知らない cause を返しても、そのまま表示する
     alarmState.deviceState.value = { state: 'alarming', cause: 'ng:unknown' }
@@ -111,10 +119,11 @@ describe('ManagerAlarmBar', () => {
     expect(wrapper.text()).toContain('着信あり')
     expect(wrapper.text()).not.toContain('2')
 
-    // どれかに入れば着信ではない
+    // どれかに入れば着信ではなく、平常の見張り文言に戻る
     roomsState.joinedRoomId.value = 'room-a'
     await wrapper.vm.$nextTick()
     expect(wrapper.text()).not.toContain('着信あり')
+    expect(wrapper.text()).toContain('運行管理者のブラウザを見張っています')
     wrapper.unmount()
   })
 
@@ -127,7 +136,7 @@ describe('ManagerAlarmBar', () => {
     wrapper.unmount()
   })
 
-  it('「警告デバイスを接続」でポート許可を求める', async () => {
+  it('接続ボタンでポート許可を求める', async () => {
     const wrapper = await mountSuspended(ManagerAlarmBar)
     await wrapper.find('button').trigger('click')
     expect(alarmMock.requestPort).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
運行管理者タブ上部の警告デバイスのバー (#177) の見た目を、同じ画面のロールタブ・認証カードと揃える。**機能・状態判定・文言の意味・mount/unmount は変えない** (script の骨格は #177 のまま)。

Refs ippoan/alc-app-s3#135

## 変更

- 画面幅いっぱいの `border-b` の帯 → ロールタブと同じ幅 (`max-w-lg`、中央寄せ) の白いカード (`rounded-2xl shadow-sm`)
- 左: 状態色の円 + ベルのアイコン (未接続=灰 / 接続=緑 / 鳴動中=赤で `animate-pulse` / 停止済み=黄)
- 中央: 「警告デバイス」+ 状態ピル、2 行目に短い説明 (「運行管理者のブラウザを見張っています (閉じると鳴ります)」 / 「着信あり — 遠隔点呼に入ると止まります」 / 「着信を受けられません (signaling 未接続)」)
- 右: 未接続なら primary「接続」、接続済みなら outline「接続し直す」
- 鳴動中はカードに赤枠 + 薄赤の背景、停止済みは黄の枠
- 状態別クラスは Tailwind の purge に残るよう完全な文字列で持つ

## 検証

- `npm run test:coverage` → 全 pass (ManagerAlarmBar.test.ts 7 件)。`check_coverage_100.mjs` → OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)
