### PR TITLE
refactor(webserial): isWebSerialSupported を utils に 1 本化する (Refs #182)

### DIFF
--- a/web/app/components/BleStatus.vue
+++ b/web/app/components/BleStatus.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { isWebSerialSupported } from '~/utils/webserial'
+
 const emit = defineEmits<{
   skip: []
   next: []
@@ -13,7 +15,6 @@ const {
   latestBloodPressure,
   hasMedicalData,
   transport,
-  isWebSerialSupported,
   connect,
   startAutoConnect,
   clearReadings,

--- a/web/app/composables/useAlarmDevice.ts
+++ b/web/app/composables/useAlarmDevice.ts
@@ -25,6 +25,8 @@
  * VID 0x303A / PID 0x1001 で同一。`STATUS` への応答の先頭 2 トークンで見分ける。
  */
 
+import { isWebSerialSupported } from '~/utils/webserial'
+
 /** デバイスが報告する鳴動状態 */
 export interface AlarmDeviceState {
   state: 'idle' | 'alarming' | 'muted'
@@ -84,7 +86,7 @@ export function useAlarmDevice() {
   // 送る中身の素。購読の開始/停止はダッシュボード側の責務 (ここでは読むだけ)
   const rooms = useActiveRooms()
 
-  const isSupported = typeof navigator !== 'undefined' && 'serial' in navigator
+  const isSupported = isWebSerialSupported()
 
   // --- 行の解釈 ---
 

--- a/web/app/composables/useBleGateway.ts
+++ b/web/app/composables/useBleGateway.ts
@@ -3,6 +3,7 @@ import type {
   TemperatureReading,
   BloodPressureReading,
 } from '~/types'
+import { isWebSerialSupported } from '~/utils/webserial'
 
 const SERIAL_OPTIONS: SerialOptions = {
   baudRate: 115200,
@@ -66,10 +67,6 @@ let heartbeatCheckTimer: ReturnType<typeof setInterval> | null = null
 const HEARTBEAT_TIMEOUT = 30000
 
 export function useBleGateway() {
-
-  function isWebSerialSupported(): boolean {
-    return typeof navigator !== 'undefined' && 'serial' in navigator
-  }
 
   // --- WebSocket transport (Android BLE Bridge) ---
 
@@ -521,7 +518,6 @@ export function useBleGateway() {
     gatewayVersion: readonly(gatewayVersion),
     transport: readonly(transport),
     hasMedicalData,
-    isWebSerialSupported,
     connect,
     autoConnect,
     startAutoConnect,

--- a/web/app/composables/useFc1200Serial.ts
+++ b/web/app/composables/useFc1200Serial.ts
@@ -2,6 +2,7 @@ import type { Fc1200State, Fc1200Event, MeasurementResult, SensorLifetime, Memor
 import { isClient } from '~/utils/env'
 import type { Fc1200WasmSession } from 'fc1200-wasm'
 import { initFc1200Wasm, createFc1200Session } from '~/utils/fc1200'
+import { isWebSerialSupported } from '~/utils/webserial'
 
 const SERIAL_OPTIONS: SerialOptions = {
   baudRate: 9600,
@@ -57,10 +58,6 @@ export function useFc1200Serial() {
   let wsReconnectTimer: ReturnType<typeof setTimeout> | null = null
   let wsReconnectAttempts = 0
   let wsIntentionalClose = false
-
-  function isWebSerialSupported(): boolean {
-    return typeof navigator !== 'undefined' && 'serial' in navigator
-  }
 
   /** WebSerial または WebSocket (Android ブリッジ) で接続可能か */
   function isSupported(): boolean {
@@ -569,7 +566,6 @@ export function useFc1200Serial() {
     memoryRecords: readonly(memoryRecords),
     dateUpdateSuccess: readonly(dateUpdateSuccess),
     transport: readonly(transport),
-    isWebSerialSupported,
     isSupported,
     autoConnect,
     connect,

--- a/web/app/composables/useSerialDeviceManager.ts
+++ b/web/app/composables/useSerialDeviceManager.ts
@@ -1,3 +1,5 @@
+import { isWebSerialSupported } from '~/utils/webserial'
+
 export interface PortEntry {
   port: SerialPort
   info: SerialPortInfo
@@ -5,7 +7,7 @@ export interface PortEntry {
 
 export function useSerialDeviceManager() {
   const ports = ref<PortEntry[]>([])
-  const isSupported = typeof navigator !== 'undefined' && 'serial' in navigator
+  const isSupported = isWebSerialSupported()
 
   async function refreshPorts() {
     if (!isSupported) return

--- a/web/app/utils/webserial.ts
+++ b/web/app/utils/webserial.ts
@@ -1,0 +1,12 @@
+/**
+ * WebSerial (`navigator.serial`) が使えるかの判定。
+ *
+ * 同じ式が composable ごとに複製されていたため 1 本にまとめた
+ * (Refs ippoan/alc-app#182)。判定はここだけに置き、WebSerial の
+ * 調停を 1 か所へ寄せる後続の変更もこの関数を起点にする。
+ *
+ * SSR では `navigator` 自体が無いので false を返す。
+ */
+export function isWebSerialSupported(): boolean {
+  return typeof navigator !== 'undefined' && 'serial' in navigator
+}

--- a/web/coverage_100.toml
+++ b/web/coverage_100.toml
@@ -149,3 +149,7 @@ branches = true
 [[files]]
 path = "app/utils/video-store.ts"
 branches = true
+
+[[files]]
+path = "app/utils/webserial.ts"
+branches = true

--- a/web/tests/composables/useBleGateway.test.ts
+++ b/web/tests/composables/useBleGateway.test.ts
@@ -117,16 +117,6 @@ function installSerialMock(serialMock: {
   })
 }
 
-function removeSerialMock() {
-  if ('serial' in navigator) {
-    Object.defineProperty(navigator, 'serial', {
-      value: undefined,
-      configurable: true,
-      writable: true,
-    })
-  }
-}
-
 // --- Tests ---
 
 describe('useBleGateway', () => {
@@ -163,16 +153,6 @@ describe('useBleGateway', () => {
     expect(gw.gatewayVersion.value).toBeNull()
     expect(gw.transport.value).toBeNull()
     expect(gw.hasMedicalData.value).toBe(false)
-  })
-
-  it('isWebSerialSupported: navigator.serial なし → false', () => {
-    expect(gw.isWebSerialSupported()).toBe(false)
-  })
-
-  it('isWebSerialSupported: navigator.serial あり → true', () => {
-    installSerialMock({})
-    expect(gw.isWebSerialSupported()).toBe(true)
-    removeSerialMock()
   })
 
   // =============================================

--- a/web/tests/composables/useFc1200Serial.test.ts
+++ b/web/tests/composables/useFc1200Serial.test.ts
@@ -205,18 +205,6 @@ describe('useFc1200Serial', () => {
     expect(fc.transport.value).toBeNull()
   })
 
-  // ---------- isWebSerialSupported ----------
-
-  it('isWebSerialSupported returns false when no navigator.serial', () => {
-    expect(fc.isWebSerialSupported()).toBe(false)
-  })
-
-  it('isWebSerialSupported returns true when navigator.serial exists', () => {
-    installSerialMock({})
-    expect(fc.isWebSerialSupported()).toBe(true)
-    removeSerialMock()
-  })
-
   // ---------- isSupported ----------
 
   it('isSupported returns true when WebSerial is available', () => {

--- a/web/tests/utils/webserial.test.ts
+++ b/web/tests/utils/webserial.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, afterEach } from 'vitest'
+
+import { isWebSerialSupported } from '~/utils/webserial'
+
+// 判定が複数の composable に複製されていたものを 1 本にまとめた関数
+// (Refs ippoan/alc-app#182)。SSR (navigator 無し) を含めて挙動を固定する。
+describe('isWebSerialSupported', () => {
+  const savedNavigator = Object.getOwnPropertyDescriptor(globalThis, 'navigator')
+
+  afterEach(() => {
+    if (savedNavigator) Object.defineProperty(globalThis, 'navigator', savedNavigator)
+    delete (navigator as any).serial
+  })
+
+  it('navigator が無い (SSR) → false', () => {
+    Object.defineProperty(globalThis, 'navigator', {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    })
+    expect(isWebSerialSupported()).toBe(false)
+  })
+
+  it('navigator はあるが serial が無い → false', () => {
+    delete (navigator as any).serial
+    expect(isWebSerialSupported()).toBe(false)
+  })
+
+  it('navigator.serial がある → true', () => {
+    Object.defineProperty(navigator, 'serial', {
+      value: { requestPort: () => {}, getPorts: async () => [] },
+      configurable: true,
+      writable: true,
+    })
+    expect(isWebSerialSupported()).toBe(true)
+  })
+})


### PR DESCRIPTION
4 か所に複製されていた WebSerial の対応判定を `web/app/utils/webserial.ts` の `isWebSerialSupported()` 1 本にまとめます。挙動は変えていません。

CoreS3 を WebSerial で直結する一連の変更 (Refs #182) の 1 本目です。後続で調停ロジックを 1 つにまとめるにあたり、同じ判定式が 4 か所に散っていると触る面が増えるため先に潰します。

## 変更

- 新規 `web/app/utils/webserial.ts` と `web/tests/utils/webserial.test.ts`
- `useBleGateway` / `useFc1200Serial` は関数定義を削除して utils を import。**戻り値からも外した**ので、利用側は utils を直接 import します
- `useSerialDeviceManager` / `useAlarmDevice` はインライン式を呼び出しに置換。どちらも「composable 生成時に 1 度評価する const boolean」のままで、評価タイミングは変えていません
- `BleStatus.vue` は destructure から import に変更 (template は無変更)
- composable 経由で判定していた test 4 件を utils の test へ移設
- `web/coverage_100.toml` に `app/utils/webserial.ts` を branches = true で登録

行数は +63 / −45 で、削減ではなく複製の解消です。

## 確認

- `npm run test:coverage` → 1261 passed / 3 skipped、新規 utils は Stmts・Branch・Funcs・Lines とも 100%
- `node scripts/check_coverage_100.mjs` → All 36 files at 100% lines (35 also checked branches)
- `npx nuxi typecheck` → exit 0
- `grep -rn "'serial' in navigator" web/app` → utils/webserial.ts の 1 件のみ
- 戻り値から destructure していた箇所は BleStatus.vue のみであることを web/app 全体の grep で確認

Refs #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)
