### PR TITLE
refactor(serial): CoreS3 の利用側を新設し BLE ゲートウェイを調停役に載せ替える (Refs #182)

### DIFF
--- a/web/app/composables/useBleGateway.ts
+++ b/web/app/composables/useBleGateway.ts
@@ -3,16 +3,6 @@ import type {
   TemperatureReading,
   BloodPressureReading,
 } from '~/types'
-import { isWebSerialSupported } from '~/utils/webserial'
-import { BLE_GW_DEVICES } from '~/composables/useSerialArbiter'
-
-const SERIAL_OPTIONS: SerialOptions = {
-  baudRate: 115200,
-  dataBits: 8,
-  parity: 'none' as ParityType,
-  stopBits: 1,
-  flowControl: 'none' as FlowControlType,
-}
 
 // Android BLE Bridge WebSocket
 const BLE_WS_URL = 'ws://127.0.0.1:9877'
@@ -21,10 +11,6 @@ const BLE_WS_MAX_RECONNECT = 10
 
 // serial 探索がこの回数連続で失敗したら WS ブリッジも試す (#123)
 const SERIAL_WS_FALLBACK_AFTER = 2
-
-// 警告デバイス (Atom VoiceS3R) を掴んでしまったポート。VID/PID が CoreS3 と同一
-// (0x303A:0x1001) で USB 記述子では見分けられないため、応答行で判別して以後外す (#135)
-const excludedPorts = new Set<SerialPort>()
 
 // シングルトン: 全コンポーネントで共有
 const isConnected = ref(false)
@@ -36,11 +22,8 @@ const latestBloodPressure = ref<BloodPressureReading | null>(null)
 const gatewayVersion = ref<string | null>(null)
 const transport = ref<'serial' | 'websocket' | null>(null)
 
-let port: SerialPort | null = null
-let writer: WritableStreamDefaultWriter<Uint8Array> | null = null
-let reader: ReadableStreamDefaultReader<Uint8Array> | null = null
-let readLoopActive = false
-let lineBuffer = ''
+/** useCoreS3Serial の受け口を繋いだか (useBleGateway は複数の component から呼ばれる) */
+let wired = false
 
 // WebSocket state
 let ws: WebSocket | null = null
@@ -60,6 +43,9 @@ let heartbeatCheckTimer: ReturnType<typeof setInterval> | null = null
 const HEARTBEAT_TIMEOUT = 30000
 
 export function useBleGateway() {
+  // serial 側のポートは自前で探さない。探索・open・機種判定は useSerialArbiter に
+  // 集約され、その利用側 useCoreS3Serial から JSON を受け取る (Refs #182)
+  const coreS3 = useCoreS3Serial()
 
   // --- WebSocket transport (Android BLE Bridge) ---
 
@@ -86,6 +72,9 @@ export function useBleGateway() {
       transport.value = 'websocket'
       error.value = null
       wsReconnectAttempts = 0
+      // WS に決まったので serial の探索は降りる (後から CoreS3 を挿されて
+      // transport が横取りされないように)
+      void coreS3.disconnect()
     }
 
     ws.onmessage = (event: MessageEvent) => {
@@ -147,168 +136,58 @@ export function useBleGateway() {
     console.log('[BLE-GW WS TX]', cmd)
   }
 
-  // --- WebSerial transport (PC / ATOM Lite USB) ---
+  // --- WebSerial transport (CoreS3 / ATOM Lite USB) ---
+
+  /** CoreS3 の受け口を 1 度だけ繋ぐ */
+  function wire(): void {
+    if (wired) return
+    wired = true
+
+    coreS3.onOpen(() => {
+      isConnected.value = true
+      transport.value = 'serial'
+    })
+
+    coreS3.onJson((msg) => {
+      console.log('[BLE-GW RX]', msg)
+      processMessage(msg as BleGatewayMessage)
+    })
+
+    // 抜線・クラッシュでポートを失った → serial の state を畳む
+    // (掴み直しは arbiter が 10 秒ごとの再スキャンで行う)
+    coreS3.onClose(() => { void cleanup() })
+  }
 
   /** ブラウザのポートピッカーで手動接続 */
   async function connect(): Promise<void> {
     error.value = null
 
-    if (!isWebSerialSupported()) {
+    if (!coreS3.isSupported) {
       // WebSerial 非対応 → WebSocket フォールバック
       connectWebSocket()
       return
     }
 
-    try {
-      port = await navigator.serial.requestPort()
-      await port.open(SERIAL_OPTIONS)
-
-      if (port.readable) {
-        reader = port.readable.getReader()
-        if (port.writable) writer = port.writable.getWriter()
-        isConnected.value = true
-        transport.value = 'serial'
-        startReadLoop()
-      }
-      else {
-        throw new Error('シリアルポートの読み取りストリームが取得できません')
-      }
-    }
-    catch (e) {
-      // ユーザーがポートピッカーをキャンセル
-      if (e instanceof DOMException && e.name === 'NotFoundError') {
-        return
-      }
-      error.value = e instanceof Error ? e.message : 'BLE ゲートウェイへの接続に失敗しました'
-      await cleanup()
-    }
+    wire()
+    // 許可 (ユーザー操作) のあとは arbiter に任せる。ここで open すると
+    // 調停役と二重に掴んで InvalidStateError になる (#182)
+    await coreS3.requestPort()
   }
 
-  /** 許可済みポートに自動接続（リトライ付き） */
+  /** 許可済みポートに自動接続 (arbiter の claim を待つ) */
   async function autoConnect(): Promise<boolean> {
     if (isConnected.value) return true
 
     // WebSerial 非対応 → WebSocket で接続
-    if (!isWebSerialSupported()) {
+    if (!coreS3.isSupported) {
       connectWebSocket()
       // WebSocket の接続完了を少し待つ
       await new Promise(r => setTimeout(r, 500))
       return isConnected.value
     }
 
-    const MAX_RETRIES = 3
-    const RETRY_DELAY = 500
-
-    for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
-      try {
-        const ports = await navigator.serial.getPorts()
-        console.log('[BLE-GW] getPorts:', ports.map(p => {
-          const info = p.getInfo()
-          return { vid: info.usbVendorId?.toString(16), pid: info.usbProductId?.toString(16) }
-        }))
-
-        // VID+PID マッチを優先、なければ許可済みポートの先頭を使う
-        // (警告デバイスと確定したポートは候補から外す)
-        const selectable = ports.filter(p => !excludedPorts.has(p))
-        const candidate = selectable.find((p) => {
-          const info = p.getInfo()
-          if (info.usbVendorId === undefined) return false
-          return BLE_GW_DEVICES.some(d =>
-            d.vid === info.usbVendorId && (d.pid === undefined || d.pid === info.usbProductId),
-          )
-        }) ?? (selectable.length === 1 ? selectable[0] : null)
-        if (!candidate) return false
-
-        port = candidate
-        await port.open(SERIAL_OPTIONS)
-
-        if (port.readable) {
-          reader = port.readable.getReader()
-          if (port.writable) writer = port.writable.getWriter()
-          isConnected.value = true
-          transport.value = 'serial'
-          startReadLoop()
-          return true
-        }
-        return false
-      }
-      catch (e) {
-        console.warn('[BLE-GW] autoConnect attempt', attempt + 1, 'failed:', e)
-        // InvalidStateError = ポートがまだ開いている (前回の close 完了待ち) → リトライ
-        if (e instanceof DOMException && e.name === 'InvalidStateError') {
-          if (attempt < MAX_RETRIES - 1) await new Promise(r => setTimeout(r, RETRY_DELAY))
-          continue
-        }
-        await cleanup()
-        return false
-      }
-    }
-    await cleanup()
-    return false
-  }
-
-  async function startReadLoop(): Promise<void> {
-    readLoopActive = true
-    const decoder = new TextDecoder()
-
-    try {
-      while (readLoopActive) {
-        const { value, done } = await reader!.read()
-        if (done) break
-        if (!value) continue
-
-        lineBuffer += decoder.decode(value, { stream: true })
-
-        // 改行区切りで JSON を処理
-        let newlineIdx: number
-        while ((newlineIdx = lineBuffer.indexOf('\n')) !== -1) {
-          const line = lineBuffer.substring(0, newlineIdx).trim()
-          lineBuffer = lineBuffer.substring(newlineIdx + 1)
-          if (line) {
-            processLine(line)
-          }
-        }
-      }
-    }
-    catch {
-      // readLoopActive は finally で false にするため、ここでは常に true
-      error.value = 'BLE ゲートウェイからの受信中にエラーが発生しました'
-    }
-    finally {
-      readLoopActive = false
-      // If we were connected and the loop ended unexpectedly, attempt reconnect
-      if (isConnected.value) {
-        console.warn('[BLE-GW] Read loop ended, attempting reconnect...')
-        await cleanup()
-        scheduleReconnect()
-      }
-    }
-  }
-
-  function processLine(line: string): void {
-    // 掴んでいたのは警告デバイスだった (バナーが 5 秒ごとに来るので 5 秒以内に気づく) →
-    // 手放して以後スキャンから外し、本来の BLE GW を探し直す (#135)
-    if (line.startsWith('STATUS alarm') || line.startsWith('EVT ALARM')) {
-      console.warn('[BLE-GW] Alarm device detected on this port, releasing:', line)
-      // read loop の finally が二重に reconnect しないよう先に落とす
-      const grabbed = port
-      isConnected.value = false
-      void cleanup().then(() => {
-        // read loop が回っている間 port は必ず非 null
-        excludedPorts.add(grabbed as SerialPort)
-        scheduleReconnect()
-      })
-      return
-    }
-
-    try {
-      const msg = JSON.parse(line) as BleGatewayMessage
-      console.log('[BLE-GW RX]', msg)
-      processMessage(msg)
-    }
-    catch {
-      console.warn('[BLE-GW] Invalid JSON:', line)
-    }
+    wire()
+    return await coreS3.connect(0)
   }
 
   // --- 共通: メッセージ処理 (Serial / WebSocket 共用) ---
@@ -371,15 +250,9 @@ export function useBleGateway() {
       sendWsCommand(cmd)
       return
     }
-    if (!writer) return
-    const encoder = new TextEncoder()
-    try {
-      await writer.write(encoder.encode(JSON.stringify(cmd) + '\n'))
-      console.log('[BLE-GW TX]', cmd)
-    }
-    catch (e) {
-      console.warn('[BLE-GW] sendCommand failed:', e)
-    }
+    const ok = await coreS3.write(JSON.stringify(cmd))
+    if (ok) console.log('[BLE-GW TX]', cmd)
+    else console.warn('[BLE-GW] sendCommand failed:', cmd)
   }
 
   /** BLE 接続をリセットして再スキャン開始 */
@@ -456,7 +329,7 @@ export function useBleGateway() {
       if (success) return true
       // WebSerial があるのにポートが見つからない (GW の WebView で Serial 無効化フラグが
       // 効いていない等) → alc-gw / Android の WS ブリッジを試す
-      if (isWebSerialSupported() && i + 1 >= SERIAL_WS_FALLBACK_AFTER) {
+      if (coreS3.isSupported && i + 1 >= SERIAL_WS_FALLBACK_AFTER) {
         if (await tryWsFallback()) return true
       }
       if (i < maxAttempts - 1) {
@@ -468,29 +341,17 @@ export function useBleGateway() {
 
   async function disconnect(): Promise<void> {
     disconnectWebSocket()
+    // 明示的な切断なので探索ごと降りる
+    await coreS3.disconnect()
     await cleanup()
   }
 
   async function cleanup(): Promise<void> {
-    readLoopActive = false
     stopHeartbeatCheck()
     if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null }
 
-    if (writer) {
-      try { writer.releaseLock() } catch {}
-      writer = null
-    }
-
-    if (reader) {
-      try { await reader.cancel() } catch {}
-      try { reader.releaseLock() } catch {}
-      reader = null
-    }
-
-    if (port) {
-      try { await port.close() } catch {}
-      port = null
-    }
+    // 預かっているポートは arbiter に返す (登録は残るので掴み直しに行く)
+    await coreS3.release()
 
     if (transport.value === 'serial') {
       isConnected.value = false
@@ -498,7 +359,6 @@ export function useBleGateway() {
       thermometerConnected.value = false
       bloodPressureConnected.value = false
     }
-    lineBuffer = ''
   }
 
   return {

--- a/web/app/composables/useCoreS3Serial.ts
+++ b/web/app/composables/useCoreS3Serial.ts
@@ -1,0 +1,222 @@
+/**
+ * CoreS3 (統合ハブ) との USB シリアル接続。useSerialArbiter の利用側。
+ *
+ * CoreS3 は BLE 医療機器ゲートウェイ (JSON 行) と NFC リーダー (`EVT` 行) を 1 本の
+ * USB CDC に相乗りさせる。どちらの機能を使う側も自分でポートを探しに行かず、ここが
+ * 受け取った行を接頭辞で振り分けて配る。
+ *
+ * プロトコル (行指向 \n / ASCII / 115200 8N1):
+ *   host → dev  `STATUS`                     … 機種判定のためのプローブ (arbiter が撃つ)
+ *   dev  → host `{"type":"ready",...}`       … BLE ゲートウェイの JSON メッセージ
+ *   dev  → host `STATUS BOARD=cores3 ...`    … プローブへの応答 (名乗り)
+ *   dev  → host `EVT <NAME> <args...>`       … NFC など状態遷移の通知
+ * 既知の接頭辞に当てはまらない行は捨てる。
+ *
+ * 機種識別を USB 記述子では行えない: CoreS3 も警告デバイス (Atom VoiceS3R) も
+ * VID 0x303A / PID 0x1001 で同一。ポートの探索・open・`STATUS` プローブは
+ * useSerialArbiter が 1 本で行い、ここは「これは CoreS3 だ」と名乗り出る述語と、
+ * 預かったポートの使い方だけを持つ (Refs ippoan/alc-app#182)。
+ *
+ * ready まで無言のファームウェアが「無応答」で閉じられ続けないよう、JSON 行が
+ * 先着したら `STATUS` の応答を待たずに claim する。
+ */
+
+import type { SerialClaimant } from '~/composables/useSerialArbiter'
+import { writeLine } from '~/composables/useSerialArbiter'
+
+/** arbiter に登録する名前 */
+const CLAIMANT_NAME = 'cores3'
+
+/**
+ * connect() が claim を待つ上限。
+ *
+ * 過ぎても登録は残り、arbiter は 10 秒ごとに探し続ける — 呼び出し側は false を
+ * 受け取ったあとでも isConnected / onOpen で接続を知れる。
+ */
+const CLAIM_TIMEOUT = 3000
+
+/** 行の素性。CoreS3 のものか、警告デバイスのものか、どちらとも言えないか */
+type LineKind = 'json' | 'status' | 'event' | 'alarm' | 'unknown'
+
+// シングルトン: 1 台の PC につながる CoreS3 は 1 台
+const isConnected = ref(false)
+
+const jsonHandlers = new Set<(msg: unknown) => void>()
+const eventHandlers = new Set<(name: string, args: string[]) => void>()
+const openHandlers = new Set<() => void>()
+const closeHandlers = new Set<() => void>()
+/** claim を待っている connect() */
+const waiters = new Set<() => void>()
+
+/** 預かっているポートの writer (未接続なら null) */
+let held: WritableStreamDefaultWriter<Uint8Array> | null = null
+
+/**
+ * 行の接頭辞から素性を決める。
+ *
+ * 警告デバイスの行を先に見る: `EVT ALARM` は `EVT ` にも当てはまるため。
+ */
+function classify(line: string): LineKind {
+  if (line.startsWith('STATUS alarm') || line.startsWith('EVT ALARM')) return 'alarm'
+  if (line.startsWith('{')) return 'json'
+  if (line.startsWith('STATUS ') && line.includes('BOARD=cores3')) return 'status'
+  if (line.startsWith('EVT ')) return 'event'
+  return 'unknown'
+}
+
+export function useCoreS3Serial() {
+  // ポートの探索と調停は arbiter に任せる (navigator.serial を自前で叩かない)
+  const arbiter = useSerialArbiter()
+
+  const isSupported = arbiter.isSupported
+
+  // --- 行の振り分け ---
+
+  /** `EVT <NAME> <args...>` を名前と引数に割る */
+  function dispatchEvent(line: string): void {
+    // 'EVT ' の 4 文字を落とし、最初の空白までが名前
+    const sep = line.indexOf(' ', 4)
+    const name = sep === -1 ? line.slice(4) : line.slice(4, sep)
+    const args = sep === -1 ? [] : line.slice(sep + 1).split(' ')
+    for (const cb of [...eventHandlers]) cb(name, args)
+  }
+
+  function dispatchJson(line: string): void {
+    let msg: unknown
+    try {
+      msg = JSON.parse(line)
+    }
+    catch {
+      console.warn('[CoreS3] Invalid JSON:', line)
+      return
+    }
+    for (const cb of [...jsonHandlers]) cb(msg)
+  }
+
+  function handleLine(line: string): void {
+    const kind = classify(line)
+    if (kind === 'json') dispatchJson(line)
+    else if (kind === 'event') dispatchEvent(line)
+    // 'status' (名乗りそのもの) / 'alarm' / 'unknown' は捨てる
+  }
+
+  // --- claim を待つ ---
+
+  /** 呼ぶ前に connect() が接続済みを弾いているので、ここは必ず未接続から始まる */
+  function waitForClaim(): Promise<boolean> {
+    return new Promise<boolean>((resolve) => {
+      const onClaim = (): void => {
+        clearTimeout(timer)
+        waiters.delete(onClaim)
+        resolve(true)
+      }
+      const timer = setTimeout(() => {
+        waiters.delete(onClaim)
+        resolve(false)
+      }, CLAIM_TIMEOUT)
+      waiters.add(onClaim)
+    })
+  }
+
+  // --- arbiter に預ける述語とハンドラ ---
+
+  const claimant: SerialClaimant = {
+    // JSON か `BOARD=cores3` の名乗りが来たら自分のもの
+    claim: lines => lines.some((line) => {
+      const kind = classify(line)
+      return kind === 'json' || kind === 'status'
+    }),
+    // 警告デバイスの行が来たら自分のものではないと確定
+    reject: lines => lines.some(line => classify(line) === 'alarm'),
+
+    onOpen(_port, _reader, w, lines) {
+      held = w
+      isConnected.value = true
+      // 利用側の transport を先に立ててから、プローブ中に来ていた行を配る
+      for (const cb of [...openHandlers]) cb()
+      for (const line of lines) handleLine(line)
+      for (const notify of [...waiters]) notify()
+    },
+
+    onLine: handleLine,
+
+    onClose() {
+      held = null
+      isConnected.value = false
+      for (const cb of [...closeHandlers]) cb()
+    },
+  }
+
+  // --- 公開 API ---
+
+  /** JSON として読めた行を受け取る */
+  function onJson(cb: (msg: unknown) => void): void {
+    jsonHandlers.add(cb)
+  }
+
+  /** `EVT <NAME> <args...>` を受け取る */
+  function onEvent(cb: (name: string, args: string[]) => void): void {
+    eventHandlers.add(cb)
+  }
+
+  /** ポートを預かった (接続した) */
+  function onOpen(cb: () => void): void {
+    openHandlers.add(cb)
+  }
+
+  /** ポートを失った / 返した */
+  function onClose(cb: () => void): void {
+    closeHandlers.add(cb)
+  }
+
+  /** 行を 1 本書く。書けなくなったらポートを返して掴み直しへ */
+  async function write(line: string): Promise<boolean> {
+    if (!held) return false
+    const ok = await writeLine(held, line)
+    if (!ok) await arbiter.release(CLAIMANT_NAME)
+    return ok
+  }
+
+  /**
+   * arbiter に自分を登録して claim を待つ。`delay` ミリ秒後に最初のスキャン。
+   * 待ちが切れても登録は残るので、以後 10 秒ごとの再スキャンで拾われる。
+   */
+  async function connect(delay = 0): Promise<boolean> {
+    if (!isSupported) return false
+    if (isConnected.value) return true
+    arbiter.register(CLAIMANT_NAME, claimant)
+    arbiter.start(delay)
+    return await waitForClaim()
+  }
+
+  /** WebSerial の初回許可 (ユーザー操作が要る) → 許可されたら探索して claim を待つ */
+  async function requestPort(): Promise<boolean> {
+    const granted = await arbiter.requestPort()
+    if (!granted) return false
+    return await connect(0)
+  }
+
+  /** ポートだけ返す (登録は残すので arbiter は掴み直しに行く) */
+  async function release(): Promise<void> {
+    await arbiter.release(CLAIMANT_NAME)
+  }
+
+  /** 登録を解いてポートを返す (探索も止まる) */
+  async function disconnect(): Promise<void> {
+    await arbiter.unregister(CLAIMANT_NAME)
+  }
+
+  return {
+    isSupported,
+    isConnected: readonly(isConnected),
+    onJson,
+    onEvent,
+    onOpen,
+    onClose,
+    write,
+    connect,
+    requestPort,
+    release,
+    disconnect,
+  }
+}

--- a/web/app/composables/useSerialArbiter.ts
+++ b/web/app/composables/useSerialArbiter.ts
@@ -27,7 +27,8 @@ import { isWebSerialSupported } from '~/utils/webserial'
 /**
  * BLE ゲートウェイの既知 VID:PID (CH340, CP210x, Espressif, FTDI FT232R)。
  *
- * useBleGateway (候補の優先) と useFc1200Serial (候補からの除外) が同じ表を見る。
+ * 0x303A 以外の機種を見分けるための表。useFc1200Serial が候補からの除外に使う
+ * (0x303A の調停はこのファイルの ARBITRATED_VID 側で行う)。
  */
 export const BLE_GW_DEVICES = [
   { vid: 0x1A86 },            // CH340/CH552

--- a/web/coverage_100.toml
+++ b/web/coverage_100.toml
@@ -114,6 +114,10 @@ branches = true
 path = "app/composables/useSerialArbiter.ts"
 branches = true
 
+[[files]]
+path = "app/composables/useCoreS3Serial.ts"
+branches = true
+
 # --- middleware ---
 
 [[files]]

--- a/web/tests/composables/useBleGateway.test.ts
+++ b/web/tests/composables/useBleGateway.test.ts
@@ -56,50 +56,77 @@ class MockWebSocket {
 
 vi.stubGlobal('WebSocket', MockWebSocket)
 
-// --- Mock SerialPort ---
+// --- Mock SerialPort (useCoreS3Serial.test.ts と同型) ---
 
-function createMockPort(options?: {
-  readable?: boolean
-  writable?: boolean
-  readValues?: Array<{ value: Uint8Array | null; done: boolean }>
-  getInfoResult?: { usbVendorId?: number; usbProductId?: number }
-}) {
-  const readValues = options?.readValues ?? []
-  let readIdx = 0
+interface MockPortHandle {
+  port: any
+  writes: string[]
+  /** デバイスからの受信行を流す (未読なら queue に積まれる) */
+  emit: (text: string) => void
+  /** 抜線・クラッシュ (read が done で終わる) */
+  end: () => void
+  setWriteError: (v: boolean) => void
+}
 
-  const mockReader = {
-    read: vi.fn(async () => {
-      if (readIdx < readValues.length) {
-        return readValues[readIdx++]!
-      }
-      return { value: null, done: true }
+function createMockPort(options?: { vid?: number }): MockPortHandle {
+  const queue: Array<{ value?: Uint8Array; done: boolean }> = []
+  let pending: ((chunk: { value?: Uint8Array; done: boolean }) => void) | null = null
+  let cancelled = false
+  let writeError = false
+
+  const reader = {
+    read: vi.fn(() => {
+      const next = queue.shift()
+      if (next) return Promise.resolve(next)
+      if (cancelled) return Promise.resolve({ value: undefined, done: true })
+      return new Promise<{ value?: Uint8Array; done: boolean }>((resolve) => {
+        pending = resolve
+      })
     }),
-    cancel: vi.fn(async () => {}),
+    cancel: vi.fn(async () => {
+      cancelled = true
+      if (pending) {
+        pending({ value: undefined, done: true })
+        pending = null
+      }
+    }),
     releaseLock: vi.fn(),
   }
 
-  const mockWriter = {
-    write: vi.fn(async () => {}),
+  function push(chunk: { value?: Uint8Array; done: boolean }) {
+    if (pending) {
+      pending(chunk)
+      pending = null
+    }
+    else {
+      queue.push(chunk)
+    }
+  }
+
+  const writes: string[] = []
+  const writer = {
+    write: vi.fn(async (data: Uint8Array) => {
+      if (writeError) throw new Error('write failed')
+      writes.push(new TextDecoder().decode(data))
+    }),
     releaseLock: vi.fn(),
   }
 
-  const mockReadable = options?.readable !== false
-    ? { getReader: vi.fn(() => mockReader) }
-    : null
-  const mockWritable = options?.writable !== false
-    ? { getWriter: vi.fn(() => mockWriter) }
-    : null
+  const port = {
+    open: vi.fn(async () => {}),
+    close: vi.fn(async () => {}),
+    // 掴み直しでも同じ reader を使い回す (前回の cancel を持ち越さない)
+    readable: { getReader: vi.fn(() => { cancelled = false; return reader }) },
+    writable: { getWriter: vi.fn(() => writer) },
+    getInfo: vi.fn(() => ({ usbVendorId: options?.vid ?? 0x303A, usbProductId: 0x1001 })),
+  }
 
   return {
-    port: {
-      open: vi.fn(async () => {}),
-      close: vi.fn(async () => {}),
-      readable: mockReadable,
-      writable: mockWritable,
-      getInfo: vi.fn(() => options?.getInfoResult ?? { usbVendorId: 0x1A86 }),
-    },
-    reader: mockReader,
-    writer: mockWriter,
+    port,
+    writes,
+    emit: (text: string) => push({ value: new TextEncoder().encode(text), done: false }),
+    end: () => push({ value: undefined, done: true }),
+    setWriteError: (v: boolean) => { writeError = v },
   }
 }
 
@@ -123,16 +150,42 @@ describe('useBleGateway', () => {
   let useBleGateway: typeof import('~/composables/useBleGateway').useBleGateway
   let gw: ReturnType<typeof useBleGateway>
 
-  beforeEach(async () => {
-    vi.clearAllMocks()
-    vi.useFakeTimers({ toFake: ['setTimeout', 'setInterval', 'clearTimeout', 'clearInterval'] })
-    MockWebSocket.instances = []
-    delete (navigator as any).serial
-
+  /**
+   * composable を作り直す。serial の対応判定は setup 直下で 1 度だけ評価されるので、
+   * serial のテストは installSerialMock のあとに呼ぶこと (SSR で navigator を
+   * top-level で触らないための形。#182)
+   */
+  async function load() {
     vi.resetModules()
     const mod = await import('~/composables/useBleGateway')
     useBleGateway = mod.useBleGateway
     gw = useBleGateway()
+  }
+
+  /** JSON 行を先着させて arbiter に claim させる (実機の BLE ゲートウェイと同じ形) */
+  async function connectSerial(dev: MockPortHandle, ready = true) {
+    installSerialMock({ getPorts: vi.fn(async () => [dev.port]) })
+    await load()
+    if (ready) dev.emit('{"type":"ready","version":"1.0.0"}\n')
+    else dev.emit('{"type":"reset"}\n')
+    expect(await autoConnect()).toBe(true)
+  }
+
+  /** autoConnect は arbiter の setTimeout(0) 越しに走るのでタイマーを進めながら待つ */
+  async function autoConnect(): Promise<boolean> {
+    const p = gw.autoConnect()
+    await vi.advanceTimersByTimeAsync(0)
+    return await p
+  }
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    // 見送ったポートの再訪判定が Date.now() を見るので Date も止める
+    vi.useFakeTimers({ toFake: ['setTimeout', 'setInterval', 'clearTimeout', 'clearInterval', 'Date'] })
+    MockWebSocket.instances = []
+    delete (navigator as any).serial
+
+    await load()
   })
 
   afterEach(async () => {
@@ -456,24 +509,26 @@ describe('useBleGateway', () => {
     })
 
     it('serial 接続成功 → 即 true (WS フォールバックなし)', async () => {
-      const { port } = createMockPort({
-        readValues: [{ value: null, done: true }],
-      })
-      installSerialMock({ getPorts: vi.fn(async () => [port]) })
-      const result = await gw.startAutoConnect(2, 10)
-      expect(result).toBe(true)
+      const dev = createMockPort()
+      installSerialMock({ getPorts: vi.fn(async () => [dev.port]) })
+      await load()
+      dev.emit('{"type":"ready","version":"1.0.0"}\n')
+      const promise = gw.startAutoConnect(2, 10)
+      await vi.advanceTimersByTimeAsync(0)
+      expect(await promise).toBe(true)
       expect(gw.transport.value).toBe('serial')
       expect(MockWebSocket.instances).toHaveLength(0)
     })
 
     it('serial ポート 0 件が続く → 2 回目以降 WS ブリッジへフォールバック (#123)', async () => {
       installSerialMock({ getPorts: vi.fn(async () => []) })
+      await load()
       const promise = gw.startAutoConnect(3, 10)
-      // 1 回目の失敗ではまだ WS を試さない
-      await vi.advanceTimersByTimeAsync(0)
+      // 1 回目の失敗 (claim の待ち 3 秒) ではまだ WS を試さない
+      await vi.advanceTimersByTimeAsync(3000)
       expect(MockWebSocket.instances).toHaveLength(0)
       // interval → 2 回目の serial 失敗 → WS フォールバック開始
-      await vi.advanceTimersByTimeAsync(10)
+      await vi.advanceTimersByTimeAsync(10 + 3000)
       expect(MockWebSocket.instances).toHaveLength(1)
       expect(MockWebSocket.instances[0]!.url).toBe('ws://127.0.0.1:9877')
       MockWebSocket.instances[0]!.simulateOpen()
@@ -484,8 +539,9 @@ describe('useBleGateway', () => {
 
     it('serial 0 件 + WS ブリッジも不在 → WS を後始末して false (#123)', async () => {
       installSerialMock({ getPorts: vi.fn(async () => []) })
+      await load()
       const promise = gw.startAutoConnect(2, 10)
-      await vi.advanceTimersByTimeAsync(10)  // 1 回目失敗 + interval → 2 回目失敗 → WS フォールバック
+      await vi.advanceTimersByTimeAsync(3000 + 10 + 3000) // 1 回目失敗 + interval → 2 回目失敗 → WS フォールバック
       await vi.advanceTimersByTimeAsync(500) // WS 未接続 → disconnect
       expect(await promise).toBe(false)
       expect(gw.isConnected.value).toBe(false)
@@ -494,726 +550,292 @@ describe('useBleGateway', () => {
     })
   })
 
+
   // =============================================
   // Serial transport
+  //
+  // ポートの探索・open・機種判定は useSerialArbiter → useCoreS3Serial に移った (#182)。
+  // ここで見るのは「BLE ゲートウェイとして外から見える挙動」が不変であること。
   // =============================================
 
   describe('Serial transport', () => {
-    describe('connect (serial)', () => {
-      it('正常接続 → isConnected=true, transport=serial', async () => {
-        const { port } = createMockPort({
-          readValues: [{ value: null, done: true }],
-        })
-        installSerialMock({
-          requestPort: vi.fn(async () => port),
-        })
+    describe('connect (serial / 手動ポートピッカー)', () => {
+      it('許可 → arbiter が open する (自前で open しないので二重 open にならない)', async () => {
+        const dev = createMockPort()
+        const requestPort = vi.fn(async () => dev.port)
+        installSerialMock({ getPorts: vi.fn(async () => [dev.port]), requestPort })
+        await load()
+        dev.emit('{"type":"ready","version":"1.0.0"}\n')
 
-        await gw.connect()
+        const p = gw.connect()
+        await vi.advanceTimersByTimeAsync(0)
+        await p
+
+        expect(requestPort).toHaveBeenCalledTimes(1)
+        // 許可のあと開くのは arbiter の 1 回だけ
+        expect(dev.port.open).toHaveBeenCalledTimes(1)
         expect(gw.isConnected.value).toBe(true)
         expect(gw.transport.value).toBe('serial')
-      })
-
-      it('readable なし → エラー + cleanup', async () => {
-        const { port } = createMockPort({ readable: false })
-        installSerialMock({
-          requestPort: vi.fn(async () => port),
-        })
-
-        await gw.connect()
-        expect(gw.error.value).toBe('シリアルポートの読み取りストリームが取得できません')
-      })
-
-      it('writable なし → writer=null でも接続成功', async () => {
-        const { port } = createMockPort({
-          writable: false,
-          readValues: [{ value: null, done: true }],
-        })
-        installSerialMock({
-          requestPort: vi.fn(async () => port),
-        })
-
-        await gw.connect()
-        expect(gw.isConnected.value).toBe(true)
-      })
-
-      it('NotFoundError (キャンセル) → エラーなし', async () => {
-        installSerialMock({
-          requestPort: vi.fn(async () => {
-            const e = new DOMException('cancel', 'NotFoundError')
-            throw e
-          }),
-        })
-
-        await gw.connect()
         expect(gw.error.value).toBeNull()
       })
 
-      it('一般エラー → error 設定', async () => {
+      it('ポートピッカーをキャンセル → 未接続 / エラーなし', async () => {
+        const getPorts = vi.fn(async () => [])
         installSerialMock({
-          requestPort: vi.fn(async () => { throw new Error('port error') }),
+          getPorts,
+          requestPort: vi.fn(async () => { throw new DOMException('cancel', 'NotFoundError') }),
         })
+        await load()
 
         await gw.connect()
-        expect(gw.error.value).toBe('port error')
-      })
-
-      it('非 Error → 汎用メッセージ', async () => {
-        installSerialMock({
-          requestPort: vi.fn(async () => { throw 'unknown' }),
-        })
-
-        await gw.connect()
-        expect(gw.error.value).toBe('BLE ゲートウェイへの接続に失敗しました')
-      })
-    })
-
-    describe('startReadLoop (serial)', () => {
-      it('JSON 行の処理', async () => {
-        const encoder = new TextEncoder()
-        const jsonLine = JSON.stringify({ type: 'temperature', value: 36.5, unit: 'celsius' }) + '\n'
-        const { port } = createMockPort({
-          readValues: [
-            { value: encoder.encode(jsonLine), done: false },
-            { value: null, done: true },
-          ],
-        })
-        installSerialMock({
-          requestPort: vi.fn(async () => port),
-        })
-
-        await gw.connect()
-        // Wait for readLoop to process
-        await vi.advanceTimersByTimeAsync(0)
-        expect(gw.latestTemperature.value).not.toBeNull()
-        expect(gw.latestTemperature.value!.value).toBe(36.5)
-      })
-
-      it.skip('複数行まとめて受信', async () => {
-        const encoder = new TextEncoder()
-        const lines = JSON.stringify({ type: 'temperature', value: 36.5, unit: 'celsius' }) + '\n'
-          + JSON.stringify({ type: 'connected', device: 'thermometer' }) + '\n'
-        const { port, reader: mockReader } = createMockPort()
-        mockReader.read
-          .mockResolvedValueOnce({ value: encoder.encode(lines), done: false })
-          .mockImplementation(async () => new Promise(() => {})) // block to prevent cleanup
-        installSerialMock({
-          requestPort: vi.fn(async () => port),
-        })
-
-        await gw.connect()
-        await vi.advanceTimersByTimeAsync(0)
-        expect(gw.latestTemperature.value!.value).toBe(36.5)
-        expect(gw.thermometerConnected.value).toBe(true)
-      })
-
-      it('不正 JSON 行 → console.warn', async () => {
-        const encoder = new TextEncoder()
-        const { port } = createMockPort({
-          readValues: [
-            { value: encoder.encode('not json\n'), done: false },
-            { value: null, done: true },
-          ],
-        })
-        installSerialMock({
-          requestPort: vi.fn(async () => port),
-        })
-
-        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
-        await gw.connect()
-        await vi.advanceTimersByTimeAsync(0)
-        expect(warnSpy).toHaveBeenCalled()
-        warnSpy.mockRestore()
-      })
-
-      it('空行はスキップ', async () => {
-        const encoder = new TextEncoder()
-        const { port } = createMockPort({
-          readValues: [
-            { value: encoder.encode('\n\n'), done: false },
-            { value: null, done: true },
-          ],
-        })
-        installSerialMock({
-          requestPort: vi.fn(async () => port),
-        })
-
-        // Should not crash
-        await gw.connect()
-        await vi.advanceTimersByTimeAsync(0)
-      })
-
-      it('value=null (continue) → スキップ', async () => {
-        const { port } = createMockPort({
-          readValues: [
-            { value: null as any, done: false },
-            { value: null, done: true },
-          ],
-        })
-        installSerialMock({
-          requestPort: vi.fn(async () => port),
-        })
-
-        await gw.connect()
-        await vi.advanceTimersByTimeAsync(0)
-        // no crash
-      })
-
-      it('read エラー (readLoopActive=true) → error 設定', async () => {
-        const { port, reader: mockReader } = createMockPort()
-        mockReader.read.mockRejectedValueOnce(new Error('read error'))
-        installSerialMock({
-          requestPort: vi.fn(async () => port),
-        })
-
-        await gw.connect()
-        await vi.advanceTimersByTimeAsync(0)
-        expect(gw.error.value).toBe('BLE ゲートウェイからの受信中にエラーが発生しました')
-      })
-
-      it('readLoop 終了時 isConnected → cleanup + scheduleReconnect', async () => {
-        const { port } = createMockPort({
-          readValues: [{ value: null, done: true }],
-        })
-        installSerialMock({
-          requestPort: vi.fn(async () => port),
-          getPorts: vi.fn(async () => []),
-        })
-
-        await gw.connect()
-        await vi.advanceTimersByTimeAsync(0)
-        // readLoop ended with done=true, isConnected was true
-        // cleanup sets isConnected=false, scheduleReconnect sets timer
-        // After cleanup, isConnected becomes false
         expect(gw.isConnected.value).toBe(false)
-      })
-    })
-
-    describe('ready message → heartbeat check (serial)', () => {
-      it('serial + ready → startHeartbeatCheck', async () => {
-        const encoder = new TextEncoder()
-        const readyLine = JSON.stringify({ type: 'ready', device: 'gw', version: '2.0' }) + '\n'
-        let readCount = 0
-        const { port, reader: mockReader } = createMockPort()
-        mockReader.read
-          .mockResolvedValueOnce({ value: encoder.encode(readyLine), done: false })
-          .mockImplementation(async () => {
-            readCount++
-            // Keep blocking to prevent readLoop from ending
-            if (readCount > 100) return { value: null, done: true }
-            return new Promise(() => {}) // never resolves (blocks)
-          })
-        installSerialMock({
-          requestPort: vi.fn(async () => port),
-        })
-
-        await gw.connect()
-        await vi.advanceTimersByTimeAsync(0)
-        expect(gw.gatewayVersion.value).toBe('2.0')
-
-        // heartbeat timeout (30s), check interval is 10s
-        // Advance 31s without heartbeat → should trigger timeout
-        vi.advanceTimersByTime(31000)
-        // Heartbeat timeout triggers cleanup + scheduleReconnect
-        await vi.advanceTimersByTimeAsync(0)
-      })
-    })
-
-    describe('sendCommand (serial)', () => {
-      it('serial writer に書き込み', async () => {
-        const encoder = new TextEncoder()
-        const readyLine = JSON.stringify({ type: 'ready', device: 'gw', version: '1.0' }) + '\n'
-        let readCount = 0
-        const { port, writer: mockWriter, reader: mockReader } = createMockPort()
-        mockReader.read
-          .mockResolvedValueOnce({ value: encoder.encode(readyLine), done: false })
-          .mockImplementation(async () => {
-            readCount++
-            if (readCount > 100) return { value: null, done: true }
-            return new Promise(() => {})
-          })
-        installSerialMock({
-          requestPort: vi.fn(async () => port),
-        })
-
-        await gw.connect()
-        await vi.advanceTimersByTimeAsync(0)
-
-        await gw.sendCommand({ cmd: 'scan' })
-        expect(mockWriter.write).toHaveBeenCalled()
-      })
-
-      it('serial writer.write 失敗 → console.warn', async () => {
-        const encoder = new TextEncoder()
-        let readCount = 0
-        const { port, writer: mockWriter, reader: mockReader } = createMockPort()
-        mockReader.read.mockImplementation(async () => {
-          readCount++
-          if (readCount > 100) return { value: null, done: true }
-          return new Promise(() => {})
-        })
-        mockWriter.write.mockRejectedValueOnce(new Error('write fail'))
-        installSerialMock({
-          requestPort: vi.fn(async () => port),
-        })
-
-        await gw.connect()
-        await vi.advanceTimersByTimeAsync(0)
-
-        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
-        await gw.sendCommand({ cmd: 'test' })
-        expect(warnSpy).toHaveBeenCalled()
-        warnSpy.mockRestore()
-      })
-
-      it('writer なし → 何もしない', async () => {
-        // transport is not websocket, writer is null → just returns
-        await gw.sendCommand({ cmd: 'test' })
-      })
-    })
-
-    describe('resetGateway (serial)', () => {
-      it('serial → sendCommand({ cmd: "reset" })', async () => {
-        let readCount = 0
-        const { port, writer: mockWriter, reader: mockReader } = createMockPort()
-        mockReader.read.mockImplementation(async () => {
-          readCount++
-          if (readCount > 100) return { value: null, done: true }
-          return new Promise(() => {})
-        })
-        installSerialMock({
-          requestPort: vi.fn(async () => port),
-        })
-
-        await gw.connect()
-        await vi.advanceTimersByTimeAsync(0)
-
-        await gw.resetGateway()
-        expect(mockWriter.write).toHaveBeenCalled()
+        expect(gw.error.value).toBeNull()
+        expect(getPorts).not.toHaveBeenCalled()
       })
     })
 
     describe('autoConnect (serial)', () => {
-      it('VID マッチ → 接続成功', async () => {
-        const { port } = createMockPort({
-          readValues: [{ value: null, done: true }],
-          getInfoResult: { usbVendorId: 0x1A86 },
-        })
-        installSerialMock({
-          getPorts: vi.fn(async () => [port]),
-        })
+      it('JSON 行が先着 → 接続 (STATUS の応答を待たない)', async () => {
+        const dev = createMockPort()
+        await connectSerial(dev)
 
-        const result = await gw.autoConnect()
-        expect(result).toBe(true)
+        expect(gw.transport.value).toBe('serial')
+        expect(gw.gatewayVersion.value).toBe('1.0.0')
+        // 自前の列挙をしないので open は arbiter の 1 回だけ
+        expect(dev.port.open).toHaveBeenCalledTimes(1)
+      })
+
+      it('ポートが 1 つも無い → 3 秒待って false', async () => {
+        installSerialMock({ getPorts: vi.fn(async () => []) })
+        await load()
+
+        const p = gw.autoConnect()
+        await vi.advanceTimersByTimeAsync(3000)
+        expect(await p).toBe(false)
+        expect(gw.isConnected.value).toBe(false)
+      })
+
+      it('既に接続済み → 探索せず true', async () => {
+        const dev = createMockPort()
+        await connectSerial(dev)
+
+        expect(await gw.autoConnect()).toBe(true)
+      })
+
+      it('警告デバイス (VoiceS3R) のポートは掴まない (#135)', async () => {
+        const alarm = createMockPort()
+        alarm.emit('EVT ALARM state=alarming cause=silence\n')
+        installSerialMock({ getPorts: vi.fn(async () => [alarm.port]) })
+        await load()
+
+        const p = gw.autoConnect()
+        await vi.advanceTimersByTimeAsync(3000)
+        expect(await p).toBe(false)
+        expect(gw.isConnected.value).toBe(false)
+        // reject が確定した時点で手放している
+        expect(alarm.port.close).toHaveBeenCalledTimes(1)
+      })
+    })
+
+    describe('processMessage (serial)', () => {
+      it('ready → gatewayVersion + heartbeat 監視開始 (serial のみ)', async () => {
+        const dev = createMockPort()
+        await connectSerial(dev)
+
+        expect(gw.gatewayVersion.value).toBe('1.0.0')
+
+        // 30 秒 heartbeat が来なければ掴み直しへ (点検は 10 秒ごとなので 40 秒目に気づく)
+        await vi.advanceTimersByTimeAsync(40000)
+        expect(gw.isConnected.value).toBe(false)
+        expect(gw.transport.value).toBeNull()
+        expect(dev.port.close).toHaveBeenCalledTimes(1)
+      })
+
+      it('heartbeat が来ている間は掴み直さない', async () => {
+        const dev = createMockPort()
+        await connectSerial(dev)
+
+        for (let i = 0; i < 4; i++) {
+          await vi.advanceTimersByTimeAsync(10000)
+          dev.emit('{"type":"heartbeat","thermo":true,"bp":false}\n')
+          await vi.advanceTimersByTimeAsync(0)
+        }
+
+        expect(gw.isConnected.value).toBe(true)
+        expect(gw.thermometerConnected.value).toBe(true)
+        expect(gw.bloodPressureConnected.value).toBe(false)
+      })
+
+      it('ready 以外で始まる serial 接続では heartbeat 監視を始めない', async () => {
+        const dev = createMockPort()
+        await connectSerial(dev, false)
+
+        await vi.advanceTimersByTimeAsync(60000)
+        expect(gw.isConnected.value).toBe(true)
+      })
+
+      it('serial でも WebSocket と同じ分岐を通る (温度・血圧・機器・エラー)', async () => {
+        const dev = createMockPort()
+        await connectSerial(dev)
+
+        dev.emit('{"type":"connected","device":"thermometer"}\n')
+        dev.emit('{"type":"connected","device":"blood_pressure"}\n')
+        dev.emit('{"type":"temperature","value":36.7}\n')
+        dev.emit('{"type":"blood_pressure","systolic":120,"diastolic":80,"pulse":66}\n')
+        await vi.advanceTimersByTimeAsync(0)
+
+        expect(gw.thermometerConnected.value).toBe(true)
+        expect(gw.bloodPressureConnected.value).toBe(true)
+        expect(gw.latestTemperature.value?.value).toBe(36.7)
+        expect(gw.latestBloodPressure.value?.pulse).toBe(66)
+        expect(gw.hasMedicalData.value).toBe(true)
+
+        dev.emit('{"type":"disconnected","device":"thermometer"}\n')
+        dev.emit('{"type":"disconnected","device":"blood_pressure"}\n')
+        dev.emit('{"type":"error","message":"BLE スキャンに失敗しました"}\n')
+        await vi.advanceTimersByTimeAsync(0)
+
+        expect(gw.thermometerConnected.value).toBe(false)
+        expect(gw.bloodPressureConnected.value).toBe(false)
+        expect(gw.error.value).toBe('BLE スキャンに失敗しました')
+      })
+    })
+
+    describe('sendCommand / resetGateway (serial)', () => {
+      it('JSON 1 行として書く', async () => {
+        const dev = createMockPort()
+        await connectSerial(dev)
+
+        await gw.sendCommand({ cmd: 'scan' })
+        expect(dev.writes).toContain('{"cmd":"scan"}\n')
+      })
+
+      it('resetGateway → { cmd: "reset" } を送る (ポートは手放さない)', async () => {
+        const dev = createMockPort()
+        await connectSerial(dev)
+
+        await gw.resetGateway()
+        expect(dev.writes).toContain('{"cmd":"reset"}\n')
+        expect(gw.isConnected.value).toBe(true)
         expect(gw.transport.value).toBe('serial')
       })
 
-      it('VID+PID マッチ (FTDI)', async () => {
-        const { port } = createMockPort({
-          readValues: [{ value: null, done: true }],
-          getInfoResult: { usbVendorId: 0x0403, usbProductId: 0x6001 },
-        })
-        installSerialMock({
-          getPorts: vi.fn(async () => [port]),
-        })
+      it('書けなくなったら warn してポートを返す', async () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+        const dev = createMockPort()
+        await connectSerial(dev)
+        dev.setWriteError(true)
 
-        const result = await gw.autoConnect()
-        expect(result).toBe(true)
-      })
-
-      it('VID 不一致 + ポート1つ → フォールバック', async () => {
-        const { port } = createMockPort({
-          readValues: [{ value: null, done: true }],
-          getInfoResult: { usbVendorId: 0x9999 },
-        })
-        installSerialMock({
-          getPorts: vi.fn(async () => [port]),
-        })
-
-        const result = await gw.autoConnect()
-        // ports.length === 1 → falls back to ports[0]
-        expect(result).toBe(true)
-      })
-
-      it('VID undefined → find スキップ、ポート1つ → フォールバック', async () => {
-        const { port } = createMockPort({
-          readValues: [{ value: null, done: true }],
-          getInfoResult: {},
-        })
-        installSerialMock({
-          getPorts: vi.fn(async () => [port]),
-        })
-
-        const result = await gw.autoConnect()
-        expect(result).toBe(true)
-      })
-
-      it('ポート0 → false', async () => {
-        installSerialMock({
-          getPorts: vi.fn(async () => []),
-        })
-
-        const result = await gw.autoConnect()
-        expect(result).toBe(false)
-      })
-
-      it('ポート2つ + VID 不一致 → null candidate → false', async () => {
-        const { port: p1 } = createMockPort({ getInfoResult: { usbVendorId: 0x9999 } })
-        const { port: p2 } = createMockPort({ getInfoResult: { usbVendorId: 0x8888 } })
-        installSerialMock({
-          getPorts: vi.fn(async () => [p1, p2]),
-        })
-
-        const result = await gw.autoConnect()
-        expect(result).toBe(false)
-      })
-
-      it('readable なし → false', async () => {
-        const { port } = createMockPort({
-          readable: false,
-          getInfoResult: { usbVendorId: 0x1A86 },
-        })
-        installSerialMock({
-          getPorts: vi.fn(async () => [port]),
-        })
-
-        const result = await gw.autoConnect()
-        expect(result).toBe(false)
-      })
-
-      it('InvalidStateError → リトライ → 2回目で成功', async () => {
-        let attempt = 0
-        const { port } = createMockPort({
-          readValues: [{ value: null, done: true }],
-          getInfoResult: { usbVendorId: 0x1A86 },
-        })
-        const originalOpen = port.open
-        port.open = vi.fn(async () => {
-          attempt++
-          if (attempt === 1) {
-            throw new DOMException('busy', 'InvalidStateError')
-          }
-          return originalOpen()
-        })
-        installSerialMock({
-          getPorts: vi.fn(async () => [port]),
-        })
-
-        const promise = gw.autoConnect()
-        // 1st attempt: InvalidStateError → RETRY_DELAY (500ms) wait
-        await vi.advanceTimersByTimeAsync(500)
-        const result = await promise
-        expect(result).toBe(true)
-        expect(attempt).toBe(2)
-      })
-
-      it('InvalidStateError 全リトライ消費 → cleanup + false', async () => {
-        const { port } = createMockPort({
-          getInfoResult: { usbVendorId: 0x1A86 },
-        })
-        port.open = vi.fn(async () => {
-          throw new DOMException('busy', 'InvalidStateError')
-        })
-        installSerialMock({
-          getPorts: vi.fn(async () => [port]),
-        })
-
-        const promise = gw.autoConnect()
-        // 3 attempts: each InvalidStateError → continue (1st, 2nd get RETRY_DELAY wait)
-        await vi.advanceTimersByTimeAsync(500) // 1st retry delay
-        await vi.advanceTimersByTimeAsync(500) // 2nd retry delay
-        // 3rd attempt: InvalidStateError → continue → loop ends → cleanup + return false
-        const result = await promise
-        expect(result).toBe(false)
-      })
-
-      it('一般エラー → cleanup + false', async () => {
-        const { port } = createMockPort({
-          getInfoResult: { usbVendorId: 0x1A86 },
-        })
-        port.open = vi.fn(async () => { throw new Error('open fail') })
-        installSerialMock({
-          getPorts: vi.fn(async () => [port]),
-        })
-
-        const result = await gw.autoConnect()
-        expect(result).toBe(false)
-      })
-    })
-
-    describe('scheduleReconnect (serial)', () => {
-      it('MAX 超過 → エラー + リセット', async () => {
-        // Need to trigger scheduleReconnect via readLoop ending
-        // Connect serial, readLoop ends immediately → cleanup + scheduleReconnect
-        installSerialMock({
-          getPorts: vi.fn(async () => []),
-        })
-
-        const { port } = createMockPort({
-          readValues: [{ value: null, done: true }],
-        })
-        installSerialMock({
-          requestPort: vi.fn(async () => port),
-          getPorts: vi.fn(async () => []),
-        })
-
-        await gw.connect()
-        await vi.advanceTimersByTimeAsync(0)
-        // readLoop ended → cleanup → scheduleReconnect called
-        // Each reconnect attempt calls autoConnect which fails (getPorts returns [])
-        // then calls scheduleReconnect recursively
-        for (let i = 0; i < 10; i++) {
-          vi.advanceTimersByTime(30000) // max delay
-          await vi.advanceTimersByTimeAsync(0)
-        }
-        // After 10 attempts, should hit max
-        expect(gw.error.value).toBe('BLE ゲートウェイへの再接続に失敗しました')
-      })
-
-      it('reconnect 成功 → reconnectAttempt リセット', async () => {
-        // First connect serial, readLoop ends → cleanup → scheduleReconnect
-        const { port: port1 } = createMockPort({
-          readValues: [{ value: null, done: true }],
-        })
-        installSerialMock({
-          requestPort: vi.fn(async () => port1),
-          getPorts: vi.fn(async () => []),
-        })
-
-        await gw.connect()
-        await vi.advanceTimersByTimeAsync(0)
-        // readLoop ended, scheduleReconnect called
-
-        // Now install a port that autoConnect can find
-        const { port: port2, reader: mockReader2 } = createMockPort({
-          getInfoResult: { usbVendorId: 0x1A86 },
-        })
-        mockReader2.read.mockImplementation(async () => new Promise(() => {})) // block
-        installSerialMock({
-          getPorts: vi.fn(async () => [port2]),
-        })
-
-        // Advance timer to trigger reconnect (RECONNECT_BASE_DELAY=2000)
-        await vi.advanceTimersByTimeAsync(2000)
-        await vi.advanceTimersByTimeAsync(0)
-        // autoConnect succeeds → reconnectAttempt = 0
-        expect(gw.isConnected.value).toBe(true)
-      })
-    })
-
-    describe('heartbeat timeout', () => {
-      it('heartbeat タイムアウト → cleanup + scheduleReconnect', async () => {
-        const encoder = new TextEncoder()
-        const readyLine = JSON.stringify({ type: 'ready', device: 'gw', version: '1.0' }) + '\n'
-        let readCount = 0
-        const { port, reader: mockReader } = createMockPort()
-        mockReader.read
-          .mockResolvedValueOnce({ value: encoder.encode(readyLine), done: false })
-          .mockImplementation(async () => {
-            readCount++
-            if (readCount > 100) return { value: null, done: true }
-            return new Promise(() => {})
-          })
-        installSerialMock({
-          requestPort: vi.fn(async () => port),
-          getPorts: vi.fn(async () => []),
-        })
-
-        await gw.connect()
-        await vi.advanceTimersByTimeAsync(0)
-        expect(gw.isConnected.value).toBe(true)
-
-        // Mock Date.now to simulate time passing beyond HEARTBEAT_TIMEOUT (30s)
-        const originalNow = Date.now
-        let fakeNow = originalNow()
-        vi.spyOn(Date, 'now').mockImplementation(() => fakeNow)
-
-        // Advance past heartbeat timeout
-        fakeNow += 31000
-        // Trigger the heartbeat check interval (10s)
-        vi.advanceTimersByTime(10000)
-        await vi.advanceTimersByTimeAsync(0)
-
-        // Heartbeat timeout triggers cleanup → isConnected = false
+        await gw.sendCommand({ cmd: 'scan' })
+        expect(warn).toHaveBeenCalledWith('[BLE-GW] sendCommand failed:', { cmd: 'scan' })
         expect(gw.isConnected.value).toBe(false)
+        warn.mockRestore()
+      })
 
-        vi.spyOn(Date, 'now').mockRestore()
+      it('未接続なら何も書かない', async () => {
+        installSerialMock({ getPorts: vi.fn(async () => []) })
+        await load()
+
+        await gw.sendCommand({ cmd: 'scan' })
+        expect(gw.isConnected.value).toBe(false)
       })
     })
 
-    describe('cleanup (serial)', () => {
-      it('writer/reader/port の cleanup', async () => {
-        let readCount = 0
-        const { port, writer: mockWriter, reader: mockReader } = createMockPort()
-        mockReader.read.mockImplementation(async () => {
-          readCount++
-          if (readCount > 100) return { value: null, done: true }
-          return new Promise(() => {})
-        })
-        installSerialMock({
-          requestPort: vi.fn(async () => port),
-        })
-
-        await gw.connect()
+    describe('ポートを失ったとき', () => {
+      it('抜線 → serial の state を畳み、arbiter が掴み直す', async () => {
+        const dev = createMockPort()
+        await connectSerial(dev)
+        dev.emit('{"type":"heartbeat","thermo":true,"bp":true}\n')
         await vi.advanceTimersByTimeAsync(0)
-        expect(gw.isConnected.value).toBe(true)
+        expect(gw.thermometerConnected.value).toBe(true)
+
+        dev.end()
+        await vi.advanceTimersByTimeAsync(0)
+
+        expect(gw.isConnected.value).toBe(false)
+        expect(gw.transport.value).toBeNull()
+        expect(gw.thermometerConnected.value).toBe(false)
+        expect(gw.bloodPressureConnected.value).toBe(false)
+
+        // 登録は残っている → 10 秒後の再スキャンで開き直す
+        await vi.advanceTimersByTimeAsync(10000)
+        expect(dev.port.open).toHaveBeenCalledTimes(2)
+      })
+
+      it('disconnect → 登録ごと降りるので探索しない', async () => {
+        const dev = createMockPort()
+        await connectSerial(dev)
 
         await gw.disconnect()
         expect(gw.isConnected.value).toBe(false)
         expect(gw.transport.value).toBeNull()
-        expect(mockWriter.releaseLock).toHaveBeenCalled()
-        expect(mockReader.cancel).toHaveBeenCalled()
-        expect(mockReader.releaseLock).toHaveBeenCalled()
-        expect(port.close).toHaveBeenCalled()
-      })
 
-      it('releaseLock / cancel / close がエラーでもクラッシュしない', async () => {
-        const { port, writer: mockWriter, reader: mockReader } = createMockPort({
-          readValues: [{ value: null, done: true }],
-        })
-        mockWriter.releaseLock.mockImplementation(() => { throw new Error('lock err') })
-        mockReader.cancel.mockRejectedValue(new Error('cancel err'))
-        mockReader.releaseLock.mockImplementation(() => { throw new Error('lock err') })
-        port.close = vi.fn(async () => { throw new Error('close err') })
-        installSerialMock({
-          requestPort: vi.fn(async () => port),
-        })
-
-        await gw.connect()
-        await vi.advanceTimersByTimeAsync(0)
-
-        // Should not throw
-        await gw.disconnect()
-        expect(gw.isConnected.value).toBe(false)
+        await vi.advanceTimersByTimeAsync(30000)
+        expect(dev.port.open).toHaveBeenCalledTimes(1)
       })
     })
 
-    describe('readLoop finally: isConnected=false → no reconnect', () => {
-      it('readLoop 終了時に isConnected=false なら reconnect しない', async () => {
-        let resolveRead: (v: any) => void
-        const { port, reader: mockReader } = createMockPort({
-          getInfoResult: { usbVendorId: 0x1A86 },
-        })
-        // First read blocks, then returns done: true
-        mockReader.read
-          .mockImplementationOnce(() => new Promise((resolve) => {
-            resolveRead = resolve
-          }))
+    describe('scheduleReconnect (serial)', () => {
+      it('heartbeat タイムアウトのあと掴み直せれば元に戻る', async () => {
+        const dev = createMockPort()
+        await connectSerial(dev)
 
-        installSerialMock({ requestPort: vi.fn(async () => port) })
-        await gw.connect()
+        // heartbeat 断 → 掴み直しへ
+        await vi.advanceTimersByTimeAsync(40000)
+        expect(gw.isConnected.value).toBe(false)
+
+        // arbiter の再スキャン + backoff 越しに復帰する
+        dev.emit('{"type":"ready","version":"1.0.0"}\n')
+        await vi.advanceTimersByTimeAsync(20000)
         expect(gw.isConnected.value).toBe(true)
         expect(gw.transport.value).toBe('serial')
+      })
 
-        // Manually set isConnected to false (simulating external cleanup)
-        // Then resolve the read to end the loop
-        // We can't directly set isConnected since it's readonly
-        // Instead, call cleanup which sets isConnected=false
-        await gw.disconnect()
-        // Now resolve the blocked read (readLoop catches the cancelled error)
-        resolveRead!({ value: null, done: true })
-        await vi.advanceTimersByTimeAsync(0)
+      it('掴み直せないまま上限に達したらエラーを出して諦める', async () => {
+        const dev = createMockPort()
+        await connectSerial(dev)
+        installSerialMock({ getPorts: vi.fn(async () => []) })
 
-        // No reconnect should happen since isConnected was false
+        await vi.advanceTimersByTimeAsync(40000)
+        // 2s, 4s, 8s ... と 10 回分の backoff (各回 claim の待ち 3 秒つき)
+        await vi.advanceTimersByTimeAsync(300000)
+
+        expect(gw.error.value).toBe('BLE ゲートウェイへの再接続に失敗しました')
         expect(gw.isConnected.value).toBe(false)
       })
     })
 
-    describe('autoConnect writable=false', () => {
-      it('writable なし → writer=null でも接続成功', async () => {
-        const { port } = createMockPort({
-          writable: false,
-          readValues: [{ value: null, done: true }],
-          getInfoResult: { usbVendorId: 0x1A86 },
-        })
-        installSerialMock({
-          getPorts: vi.fn(async () => [port]),
-        })
-
-        const result = await gw.autoConnect()
-        expect(result).toBe(true)
-        expect(gw.isConnected.value).toBe(true)
-      })
-    })
-
-    describe('startAutoConnect 成功ケース', () => {
-      it('1回目で接続成功 → true', async () => {
-        const { port } = createMockPort({
-          readValues: [{ value: null, done: true }],
-        })
-        installSerialMock({
-          getPorts: vi.fn(async () => [port]),
-        })
-
-        const result = await gw.startAutoConnect(3, 100)
-        expect(result).toBe(true)
-      })
-    })
-
-    describe('警告デバイスを掴んでしまった場合 (#135)', () => {
-      it.each([
-        ['EVT ALARM state=alarming cause=silence\n'],
-        ['STATUS alarm state=idle cause=none hb_age_ms=1200 VER=0.1.0\n'],
-      ])('%s → 手放して除外し、再接続でも掴まない', async (line) => {
-        const encoder = new TextEncoder()
-        const { port } = createMockPort({
-          readValues: [{ value: encoder.encode(line), done: false }],
-        })
-        installSerialMock({
-          requestPort: vi.fn(async () => port),
-          getPorts: vi.fn(async () => [port]),
-        })
-
-        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
-        await gw.connect()
-        await vi.advanceTimersByTimeAsync(0)
-
-        expect(gw.isConnected.value).toBe(false)
-        expect(port.close).toHaveBeenCalled()
-
-        // 再接続が走っても除外済みなので開き直さない
-        await vi.advanceTimersByTimeAsync(2000)
-        expect(port.open).toHaveBeenCalledTimes(1)
-        warnSpy.mockRestore()
+    describe('公開 API', () => {
+      it('返すキーは #182 の前後で変わらない (呼び出し元は触らない)', () => {
+        expect(Object.keys(gw).sort()).toEqual([
+          'autoConnect',
+          'bloodPressureConnected',
+          'clearReadings',
+          'connect',
+          'disconnect',
+          'error',
+          'gatewayVersion',
+          'hasMedicalData',
+          'isConnected',
+          'latestBloodPressure',
+          'latestTemperature',
+          'resetGateway',
+          'sendCommand',
+          'startAutoConnect',
+          'thermometerConnected',
+          'transport',
+        ])
       })
 
-      it('除外済みポートしか無ければ候補ゼロ (単独ポートのフォールバックも効かない)', async () => {
-        const encoder = new TextEncoder()
-        const { port } = createMockPort({
-          getInfoResult: { usbVendorId: 0x303A, usbProductId: 0x1001 },
-          readValues: [{ value: encoder.encode('EVT ALARM state=idle cause=none\n'), done: false }],
-        })
-        installSerialMock({
-          requestPort: vi.fn(async () => port),
-          getPorts: vi.fn(async () => [port]),
-        })
+      it('navigator.serial は直接列挙しない (探索は arbiter 経由の 1 回)', async () => {
+        const dev = createMockPort()
+        const getPorts = vi.fn(async () => [dev.port])
+        installSerialMock({ getPorts })
+        await load()
+        dev.emit('{"type":"ready","version":"1.0.0"}\n')
+        await autoConnect()
 
-        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
-        await gw.connect()
-        await vi.advanceTimersByTimeAsync(0)
-
-        const result = await gw.autoConnect()
-        expect(result).toBe(false)
-        expect(port.open).toHaveBeenCalledTimes(1)
-        warnSpy.mockRestore()
-      })
-    })
-
-    describe('writable なし serial', () => {
-      it('writer なし → cleanup で writer スキップ', async () => {
-        const { port } = createMockPort({
-          writable: false,
-          readValues: [{ value: null, done: true }],
-        })
-        installSerialMock({
-          requestPort: vi.fn(async () => port),
-        })
-
-        await gw.connect()
-        await vi.advanceTimersByTimeAsync(0)
-
-        // disconnect when writer is null
-        await gw.disconnect()
-        expect(gw.isConnected.value).toBe(false)
+        expect(getPorts).toHaveBeenCalledTimes(1)
       })
     })
   })

--- a/web/tests/composables/useCoreS3Serial.test.ts
+++ b/web/tests/composables/useCoreS3Serial.test.ts
@@ -1,0 +1,443 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// --- Mock SerialPort (useAlarmDevice.test.ts と同型) ---
+
+interface MockPortHandle {
+  port: any
+  writes: string[]
+  /** デバイスからの受信行を流す (未読なら queue に積まれる) */
+  emit: (text: string) => void
+  setWriteError: (v: boolean) => void
+}
+
+function createMockPort(options?: {
+  vid?: number
+  writeError?: boolean
+}): MockPortHandle {
+  const queue: Array<{ value?: Uint8Array; done: boolean }> = []
+  let pending: ((chunk: { value?: Uint8Array; done: boolean }) => void) | null = null
+  let cancelled = false
+  let writeError = options?.writeError ?? false
+
+  const reader = {
+    read: vi.fn(() => {
+      const next = queue.shift()
+      if (next) return Promise.resolve(next)
+      if (cancelled) return Promise.resolve({ value: undefined, done: true })
+      return new Promise<{ value?: Uint8Array; done: boolean }>((resolve) => {
+        pending = resolve
+      })
+    }),
+    cancel: vi.fn(async () => {
+      cancelled = true
+      if (pending) {
+        pending({ value: undefined, done: true })
+        pending = null
+      }
+    }),
+    releaseLock: vi.fn(),
+  }
+
+  function push(chunk: { value?: Uint8Array; done: boolean }) {
+    if (pending) {
+      pending(chunk)
+      pending = null
+    }
+    else {
+      queue.push(chunk)
+    }
+  }
+
+  const writes: string[] = []
+  const writer = {
+    write: vi.fn(async (data: Uint8Array) => {
+      if (writeError) throw new Error('write failed')
+      writes.push(new TextDecoder().decode(data))
+    }),
+    releaseLock: vi.fn(),
+  }
+
+  const port = {
+    open: vi.fn(async () => {}),
+    close: vi.fn(async () => {}),
+    // 掴み直しでも同じ reader を使い回す (前回の cancel を持ち越さない)
+    readable: { getReader: vi.fn(() => { cancelled = false; return reader }) },
+    writable: { getWriter: vi.fn(() => writer) },
+    getInfo: vi.fn(() => ({ usbVendorId: options?.vid ?? 0x303A, usbProductId: 0x1001 })),
+  }
+
+  return {
+    port,
+    writes,
+    emit: (text: string) => push({ value: new TextEncoder().encode(text), done: false }),
+    setWriteError: (v: boolean) => { writeError = v },
+  }
+}
+
+function installSerialMock(serialMock: {
+  requestPort?: ReturnType<typeof vi.fn>
+  getPorts?: ReturnType<typeof vi.fn>
+}) {
+  Object.defineProperty(navigator, 'serial', {
+    value: {
+      requestPort: serialMock.requestPort ?? vi.fn(),
+      getPorts: serialMock.getPorts ?? vi.fn(async () => []),
+    },
+    configurable: true,
+    writable: true,
+  })
+}
+
+// --- Tests ---
+
+/**
+ * CoreS3 の利用側。ポートの探索・open・`STATUS` プローブは useSerialArbiter が行う (#182)。
+ * ここで見るのは「行の振り分け」と「claim / reject の述語」。
+ */
+describe('useCoreS3Serial', () => {
+  let mod: typeof import('~/composables/useCoreS3Serial')
+  let core: ReturnType<typeof mod.useCoreS3Serial>
+
+  async function load() {
+    vi.resetModules()
+    mod = await import('~/composables/useCoreS3Serial')
+    core = mod.useCoreS3Serial()
+  }
+
+  /** connect() は arbiter の setTimeout(0) 越しに走るのでタイマーを進めながら待つ */
+  async function connect(delay = 0): Promise<boolean> {
+    const p = core.connect(delay)
+    await vi.advanceTimersByTimeAsync(delay)
+    return await p
+  }
+
+  /** JSON 行を先着させて claim させる (実機の BLE ゲートウェイと同じ形) */
+  async function connectWithJson(dev: MockPortHandle) {
+    installSerialMock({ getPorts: vi.fn(async () => [dev.port]) })
+    await load()
+    dev.emit('{"type":"ready","version":"1.0.0"}\n')
+    expect(await connect()).toBe(true)
+  }
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    // 見送ったポートの再訪判定が Date.now() を見るので Date も止める
+    vi.useFakeTimers({ toFake: ['setTimeout', 'setInterval', 'clearTimeout', 'clearInterval', 'Date'] })
+    delete (navigator as any).serial
+  })
+
+  afterEach(async () => {
+    await core?.disconnect()
+    delete (navigator as any).serial
+    vi.useRealTimers()
+  })
+
+  // ---------- isSupported ----------
+
+  describe('WebSerial 非対応', () => {
+    it('isSupported=false / connect は false を返し探索しない', async () => {
+      await load()
+      expect(core.isSupported).toBe(false)
+      await expect(core.connect(0)).resolves.toBe(false)
+      await vi.advanceTimersByTimeAsync(20000)
+      expect(core.isConnected.value).toBe(false)
+    })
+  })
+
+  // ---------- claim / reject ----------
+
+  describe('claim', () => {
+    it('JSON 行が先着したら STATUS の応答を待たずに claim する', async () => {
+      const dev = createMockPort()
+      dev.emit('{"type":"ready","version":"1.0.0"}\n')
+      installSerialMock({ getPorts: vi.fn(async () => [dev.port]) })
+      await load()
+
+      expect(await connect()).toBe(true)
+      expect(core.isConnected.value).toBe(true)
+      // プローブの 8 秒窓を待っていない
+      expect(dev.writes).toEqual(['STATUS\n'])
+    })
+
+    it('STATUS に BOARD=cores3 が含まれれば claim する', async () => {
+      const dev = createMockPort()
+      dev.emit('STATUS BOARD=cores3 LAN=up VER=1.2.3\n')
+      installSerialMock({ getPorts: vi.fn(async () => [dev.port]) })
+      await load()
+
+      await expect(connect()).resolves.toBe(true)
+    })
+
+    it('BOARD= の無い STATUS では claim しない (8 秒で見送り)', async () => {
+      const dev = createMockPort()
+      dev.emit('STATUS LAN=up VER=1.2.3\n')
+      installSerialMock({ getPorts: vi.fn(async () => [dev.port]) })
+      await load()
+
+      const p = core.connect(0)
+      await vi.advanceTimersByTimeAsync(3000)
+      await expect(p).resolves.toBe(false)
+
+      // arbiter のプローブ窓 (8 秒) が切れて手放す
+      await vi.advanceTimersByTimeAsync(5000)
+      expect(core.isConnected.value).toBe(false)
+      expect(dev.port.close).toHaveBeenCalledTimes(1)
+    })
+
+    it.each([
+      ['EVT ALARM state=alarming cause=silence\n', 'EVT ALARM'],
+      ['STATUS alarm state=idle cause=none hb_age_ms=1200 VER=0.1.0\n', 'STATUS alarm'],
+    ])('警告デバイスの行 (%s) は reject して即手放す', async (line) => {
+      const dev = createMockPort()
+      dev.emit(line)
+      installSerialMock({ getPorts: vi.fn(async () => [dev.port]) })
+      await load()
+
+      void core.connect(0)
+      await vi.advanceTimersByTimeAsync(0)
+      expect(core.isConnected.value).toBe(false)
+      // 8 秒待たずに閉じている (reject が確定した時点で打ち切り)
+      expect(dev.port.close).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  // ---------- 行の振り分け ----------
+
+  describe('onJson', () => {
+    it('プローブ中に来ていた行も採用時に配る', async () => {
+      const dev = createMockPort()
+      installSerialMock({ getPorts: vi.fn(async () => [dev.port]) })
+      await load()
+      const seen: unknown[] = []
+      core.onJson(msg => seen.push(msg))
+
+      dev.emit('{"type":"ready","version":"1.0.0"}\n')
+      await connect()
+
+      expect(seen).toEqual([{ type: 'ready', version: '1.0.0' }])
+    })
+
+    it('採用後の JSON 行も配る', async () => {
+      const dev = createMockPort()
+      await connectWithJson(dev)
+      const seen: unknown[] = []
+      core.onJson(msg => seen.push(msg))
+
+      dev.emit('{"type":"heartbeat","thermo":true,"bp":false}\n')
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(seen).toEqual([{ type: 'heartbeat', thermo: true, bp: false }])
+    })
+
+    it('壊れた JSON は console.warn して捨てる', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const dev = createMockPort()
+      await connectWithJson(dev)
+      const seen: unknown[] = []
+      core.onJson(msg => seen.push(msg))
+
+      dev.emit('{not json\n')
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(seen).toEqual([])
+      expect(warn).toHaveBeenCalledWith('[CoreS3] Invalid JSON:', '{not json')
+      warn.mockRestore()
+    })
+  })
+
+  describe('onEvent', () => {
+    it('EVT <NAME> <args...> を名前と引数に割る', async () => {
+      const dev = createMockPort()
+      await connectWithJson(dev)
+      const seen: Array<[string, string[]]> = []
+      core.onEvent((name, args) => seen.push([name, args]))
+
+      dev.emit('EVT NFC_LICENSE issue=20230401 expiry=20280401\n')
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(seen).toEqual([['NFC_LICENSE', ['issue=20230401', 'expiry=20280401']]])
+    })
+
+    it('引数の無い EVT は args=[] で配る', async () => {
+      const dev = createMockPort()
+      await connectWithJson(dev)
+      const seen: Array<[string, string[]]> = []
+      core.onEvent((name, args) => seen.push([name, args]))
+
+      dev.emit('EVT NFC_REMOVED\n')
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(seen).toEqual([['NFC_REMOVED', []]])
+    })
+
+    it('EVT ALARM は CoreS3 の EVT ではないので配らない', async () => {
+      const dev = createMockPort()
+      await connectWithJson(dev)
+      const seen: string[] = []
+      core.onEvent(name => seen.push(name))
+
+      dev.emit('EVT ALARM state=idle cause=none\n')
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(seen).toEqual([])
+    })
+  })
+
+  it.each([
+    ['PONG\n', '既知の接頭辞に当てはまらない行'],
+    ['STATUS BOARD=cores3 LAN=up\n', '名乗りの STATUS'],
+  ])('%s は捨てる', async (line) => {
+    const dev = createMockPort()
+    await connectWithJson(dev)
+    const json: unknown[] = []
+    const events: string[] = []
+    core.onJson(msg => json.push(msg))
+    core.onEvent(name => events.push(name))
+
+    dev.emit(line)
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(json).toEqual([])
+    expect(events).toEqual([])
+  })
+
+  // ---------- write ----------
+
+  describe('write', () => {
+    it('預かった writer に 1 行書く', async () => {
+      const dev = createMockPort()
+      await connectWithJson(dev)
+
+      await expect(core.write('{"cmd":"reset"}')).resolves.toBe(true)
+      expect(dev.writes).toEqual(['STATUS\n', '{"cmd":"reset"}\n'])
+    })
+
+    it('未接続なら false (書きに行かない)', async () => {
+      installSerialMock({ getPorts: vi.fn(async () => []) })
+      await load()
+
+      await expect(core.write('{"cmd":"reset"}')).resolves.toBe(false)
+    })
+
+    it('書けなくなったらポートを返して掴み直しへ', async () => {
+      const dev = createMockPort()
+      await connectWithJson(dev)
+      dev.setWriteError(true)
+
+      await expect(core.write('{"cmd":"reset"}')).resolves.toBe(false)
+      expect(core.isConnected.value).toBe(false)
+      expect(dev.port.close).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  // ---------- connect / onOpen / onClose ----------
+
+  describe('connect', () => {
+    it('claim されるまで待ち、3 秒で諦めても登録は残る', async () => {
+      const dev = createMockPort()
+      installSerialMock({ getPorts: vi.fn(async () => [dev.port]) })
+      await load()
+
+      const first = core.connect(0)
+      await vi.advanceTimersByTimeAsync(3000)
+      await expect(first).resolves.toBe(false)
+      expect(core.isConnected.value).toBe(false)
+
+      // 諦めたあとでも、遅れて来た JSON で採用される
+      dev.emit('{"type":"ready","version":"1.0.0"}\n')
+      await vi.advanceTimersByTimeAsync(0)
+      expect(core.isConnected.value).toBe(true)
+    })
+
+    it('接続済みなら待たずに true', async () => {
+      const dev = createMockPort()
+      await connectWithJson(dev)
+
+      await expect(connect()).resolves.toBe(true)
+    })
+
+    it('onOpen は transport を立てる利用側のために claim 直後・行の配布前に呼ばれる', async () => {
+      const dev = createMockPort()
+      installSerialMock({ getPorts: vi.fn(async () => [dev.port]) })
+      await load()
+      const order: string[] = []
+      core.onOpen(() => order.push('open'))
+      core.onJson(() => order.push('json'))
+
+      dev.emit('{"type":"ready","version":"1.0.0"}\n')
+      await connect()
+
+      expect(order).toEqual(['open', 'json'])
+    })
+
+    it('release でポートを返すと onClose が呼ばれ、登録は残るので掴み直す', async () => {
+      const dev = createMockPort()
+      await connectWithJson(dev)
+      const closed: number[] = []
+      core.onClose(() => closed.push(1))
+
+      await core.release()
+      expect(closed).toEqual([1])
+      expect(core.isConnected.value).toBe(false)
+
+      // 登録は残っている → 10 秒後の再スキャンで開き直す
+      await vi.advanceTimersByTimeAsync(10000)
+      expect(dev.port.open).toHaveBeenCalledTimes(2)
+    })
+
+    it('disconnect は登録ごと降りるので探索しない', async () => {
+      const dev = createMockPort()
+      await connectWithJson(dev)
+
+      await core.disconnect()
+      expect(core.isConnected.value).toBe(false)
+
+      await vi.advanceTimersByTimeAsync(30000)
+      expect(dev.port.open).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  // ---------- requestPort ----------
+
+  describe('requestPort', () => {
+    it('許可されたら探索して claim を待つ', async () => {
+      const dev = createMockPort()
+      const requestPort = vi.fn(async () => dev.port)
+      installSerialMock({ getPorts: vi.fn(async () => [dev.port]), requestPort })
+      await load()
+      dev.emit('{"type":"ready","version":"1.0.0"}\n')
+
+      const p = core.requestPort()
+      await vi.advanceTimersByTimeAsync(0)
+      await expect(p).resolves.toBe(true)
+      expect(requestPort).toHaveBeenCalledTimes(1)
+      expect(core.isConnected.value).toBe(true)
+    })
+
+    it('キャンセルされたら false (探索を始めない)', async () => {
+      const getPorts = vi.fn(async () => [])
+      const requestPort = vi.fn(async () => { throw new DOMException('cancel', 'NotFoundError') })
+      installSerialMock({ getPorts, requestPort })
+      await load()
+
+      await expect(core.requestPort()).resolves.toBe(false)
+      await vi.advanceTimersByTimeAsync(10000)
+      expect(getPorts).not.toHaveBeenCalled()
+    })
+  })
+
+  // ---------- 公開 API の形 ----------
+
+  it('navigator.serial は直接触らない (列挙は arbiter 経由)', async () => {
+    const dev = createMockPort()
+    const getPorts = vi.fn(async () => [dev.port])
+    installSerialMock({ getPorts })
+    await load()
+    dev.emit('{"type":"ready","version":"1.0.0"}\n')
+    await connect()
+
+    // 探索 1 回。プローブは arbiter が撃つ
+    expect(getPorts).toHaveBeenCalledTimes(1)
+    expect(dev.writes).toEqual(['STATUS\n'])
+  })
+})


### PR DESCRIPTION
BLE ゲートウェイが自前で持っていたポート探索と読み取りループを、前の PR で入った調停役の利用側へ寄せます。新設した CoreS3 用の利用側がその受け口です。

## なぜ

前の PR で調停役を 1 本にまとめましたが、BLE ゲートウェイはまだ自分でポートを列挙して開き、独自の読み取りループで行を分割していました。調停役と二重に探すので、CoreS3 と警告デバイスを 1 台の PC に挿すと奪い合いが残ります。手動でポートを選ぶボタンの経路も調停役を通らないため、そのままだと二重に開いてエラーになります。

CoreS3 を USB で直結して NFC を読む一連の変更 (Refs #182) の 3 本目です。次でこの受け口を使って NFC の読み取りを切り替えます。

## 変更

- 新規 `web/app/composables/useCoreS3Serial.ts` とそのテスト。調停役の利用側で、JSON の行と `EVT` の行をそれぞれ配ります
- `useBleGateway.ts` から自前の列挙、読み取りループ、警告デバイスを除外する分岐を削除。手動でポートを選ぶ経路も調停役に統合
- `web/coverage_100.toml` に新設ファイルを branches 付きで登録
- 調停役のファイルはコメント 1 か所のみ。機器一覧の説明が事実と合わなくなったため直したもので、コードは変えていません

## 挙動について

**BLE の外から見える挙動は変えていません。** 公開している値の名前と型 16 個、`processMessage` の 8 分岐、heartbeat の 30 秒監視、WebSocket のフォールバック一式は変更なしです。手動接続の関数の戻り型も従来のまま据え置きました。

**1 つだけ挙動が増えています。** WebSocket が開いたとき、CoreS3 側の登録を降ります。旧実装では早期 return で構造的に起きなかった競合ですが、載せ替え後は WebSocket 確定後に CoreS3 を挿されると経路を横取りされうるため、これを塞いでいます。

自動接続の初回は claim を 3 秒待って諦めます。登録は残るので、調停役の次の巡回で接続されれば表示は自動で切り替わります。

## 確認

- `npm run test:coverage` → 50 ファイル / 1299 passed / 2 skipped、Lines 100%
- `node scripts/check_coverage_100.mjs` → All 38 files at 100% lines
- `npx nuxi typecheck` → エラー 0
- `grep -rn "navigator.serial.getPorts\|navigator.serial.requestPort" app/` で、BLE ゲートウェイから自前の列挙が消えたことを確認
- 画面側のファイルと警告デバイスの composable は 1 行も変えていません

Refs #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)
