### PR TITLE
feat(nfc): 免許証の読み取りを CoreS3 直結に切り替える (Refs #182)

### DIFF
--- a/web/app/components/LicenseRegistration.vue
+++ b/web/app/components/LicenseRegistration.vue
@@ -24,7 +24,7 @@ const clearingId = ref<string | null>(null)
 // NFC 読み取り対象
 const nfcTargetId = ref<string | null>(null)
 const nfcCardId = ref<string | null>(null)
-const { isConnected, connect, onLicenseRead } = useNfcWebSocket()
+const { isConnected, connect, onLicenseRead } = useNfcReader()
 
 onLicenseRead((event: NfcLicenseReadEvent) => {
   if (!nfcTargetId.value || event.card_type !== 'driver_license') return

--- a/web/app/components/NfcStatus.vue
+++ b/web/app/components/NfcStatus.vue
@@ -1,13 +1,28 @@
 <script setup lang="ts">
 import type { NfcReadEvent, NfcLicenseReadEvent } from '~/types'
 import { parseLicenseExpiryDate, checkLicenseExpiry, formatExpiryDate, type LicenseExpiryStatus } from '~/utils/license'
+import { isWebSerialSupported } from '~/utils/webserial'
 
 const emit = defineEmits<{
   read: [employeeId: string, expiryDate?: Date]
 }>()
 
-const { isConnected, error, readers, bridgeVersion, connect, onRead, onLicenseRead } = useNfcWebSocket()
+const { isConnected, error, readers, bridgeVersion, connect, onRead, onLicenseRead } = useNfcReader()
 const { latestVersion, checkLatestVersion, isUpdateAvailable } = useNfcBridgeUpdate()
+
+// WebSerial の初回許可はユーザー操作が要る (CoreS3 直結のポート選択)
+const coreS3 = useCoreS3Serial()
+const canUseSerial = isWebSerialSupported()
+const isRequestingPort = ref(false)
+async function requestSerialPort() {
+  isRequestingPort.value = true
+  try {
+    await coreS3.requestPort()
+  }
+  finally {
+    isRequestingPort.value = false
+  }
+}
 
 const lastReadId = ref<string | null>(null)
 const readAnimation = ref(false)
@@ -17,6 +32,8 @@ const licenseExpiryStatus = ref<LicenseExpiryStatus | null>(null)
 const showUpdateBanner = computed(() => {
   if (isAndroidApp.value) return false
   if (!isConnected.value || !latestVersion.value) return false
+  // CoreS3 直結にブリッジは要らない (readers が 'CoreS3' なら直結)
+  if (readers.value?.[0] === 'CoreS3') return false
   // version 未送信（旧ブリッジ）→ 常にアップデート促す
   if (!bridgeVersion.value) return true
   return isUpdateAvailable(bridgeVersion.value)
@@ -59,7 +76,7 @@ onRead((event: NfcReadEvent) => {
 
 const statusText = computed(() => {
   if (error.value) return error.value
-  if (!isConnected.value) return 'NFC ブリッジ未接続'
+  if (!isConnected.value) return 'NFC リーダー未接続'
   if ((readers.value?.length ?? 0) === 0) return 'NFC リーダー未検出'
   return 'NFC 待機中'
 })
@@ -134,16 +151,33 @@ const showNfcGuide = ref(false)
       </div>
     </div>
 
-    <!-- NFC ブリッジ未接続時のダウンロードリンク -->
-    <p v-if="!isConnected && !isAndroidApp" class="text-sm text-center text-gray-500">
-      NFC ブリッジがインストールされていない場合は
-      <a
-        href="https://github.com/yhonda-ohishi-alc/rust-nfc-bridge/releases/latest"
-        target="_blank"
-        rel="noopener noreferrer"
-        class="text-blue-600 underline hover:text-blue-800"
-      >こちらからダウンロード</a>
-    </p>
+    <!-- 未接続時の案内 -->
+    <template v-if="!isConnected && !isAndroidApp">
+      <!-- CoreS3 直結 (WebSerial): 常駐アプリは要らない -->
+      <div v-if="canUseSerial" class="flex flex-col items-center gap-2">
+        <p class="text-sm text-center text-gray-500">
+          CoreS3 が USB でつながっているか確認してください。<br>
+          初めて使う端末では、下のボタンで USB デバイスの使用を許可してください。
+        </p>
+        <button
+          class="px-4 py-2 bg-blue-600 text-white rounded-lg text-sm hover:bg-blue-700 transition-colors disabled:bg-gray-300"
+          :disabled="isRequestingPort"
+          @click="requestSerialPort"
+        >
+          USB デバイスを選択
+        </button>
+      </div>
+      <!-- WebSerial が使えない環境は従来の NFC ブリッジ -->
+      <p v-else class="text-sm text-center text-gray-500">
+        NFC ブリッジがインストールされていない場合は
+        <a
+          href="https://github.com/yhonda-ohishi-alc/rust-nfc-bridge/releases/latest"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="text-blue-600 underline hover:text-blue-800"
+        >こちらからダウンロード</a>
+      </p>
+    </template>
 
     <!-- NFC ブリッジ更新通知 -->
     <p v-if="showUpdateBanner" class="text-sm text-center text-amber-600">

--- a/web/app/composables/useNfcReader.ts
+++ b/web/app/composables/useNfcReader.ts
@@ -1,0 +1,209 @@
+/**
+ * 免許証の読み取り口。CoreS3 直結 (USB) と NFC ブリッジ (WebSocket 9876) を束ねる。
+ *
+ * 公開 API は useNfcWebSocket と 1 対 1 で同じ 9 キー。呼び出し側 (NfcStatus /
+ * LicenseRegistration) は経路の違いを知らずに済む (Refs ippoan/alc-app#182)。
+ *
+ * 経路の選び方:
+ *   - WebSerial が使えない環境 (Android WebView 等) → useNfcWebSocket をそのまま返す
+ *   - 使える環境では CoreS3 を優先し、**直結しているあいだブリッジは購読しない**。
+ *     直結が切れたら 9876 へ戻す
+ *
+ * それでも経路の切り替わり際に同じ免許証が二重に届きうるので、同じ employee_id を
+ * DEDUPE_WINDOW_MS 以内に再受信したら捨てる。firmware 側にも重複除去はあるが、
+ * 経路をまたがない — 二重に配ると NfcStatus の emit('read') が計測ステップを
+ * 2 つ進めてしまう。
+ */
+
+import type { NfcReadEvent, NfcLicenseReadEvent, NfcErrorEvent } from '~/types'
+import { isWebSerialSupported } from '~/utils/webserial'
+
+/** 同じ免許証を配り直さない窓 (経路の切り替わり際の二重配布を断つ) */
+const DEDUPE_WINDOW_MS = 3000
+
+/**
+ * CoreS3 が寄越す日付 1 つぶんの桁数。
+ *
+ * firmware (`nfc_shim.cpp`) は交付日・有効期限それぞれに 9 バイト以上のバッファを
+ * 要求しており、どちらも YYYYMMDD の 8 文字。
+ */
+const DATE_LEN = 8
+
+/**
+ * card_id / expiry_date の頭に詰める 10 桁の詰め物。
+ *
+ * 免許証 IC の hex 文字列は「先頭 10 文字 + 交付日 8 + 有効期限 8 = 26 文字」で、
+ * utils/license.ts は substring(10,18) を交付日、substring(18,26) を有効期限として
+ * 読む。CoreS3 は日付 2 つしか寄越さないので、**先頭 10 桁は意味を持たない詰め物**を
+ * 置いて桁を合わせる (LicenseRegistration の `card_id.substring(10, 26)` もこの契約に
+ * 乗っている)。
+ */
+const CARD_ID_PAD = '0'.repeat(10)
+
+/** `EVT` を受け取る、生きている useNfcReader の受け口 */
+type EventSink = (name: string, args: string[]) => void
+
+// useNfcReader は複数の component から呼ばれる。useCoreS3Serial.onEvent に解除が
+// 無いので、繋ぐのは 1 度だけにして、配る先はここで出し入れする
+const sinks = new Set<EventSink>()
+let wired = false
+
+/** `key=value` の並びから値を取り出す (無ければ空文字) */
+function argValue(args: string[], key: string): string {
+  const prefix = `${key}=`
+  const hit = args.find(arg => arg.startsWith(prefix))
+  return hit === undefined ? '' : hit.slice(prefix.length)
+}
+
+export function useNfcReader() {
+  const ws = useNfcWebSocket()
+  // WebSerial が無ければ CoreS3 は繋げない。従来どおりブリッジだけを使う
+  if (!isWebSerialSupported()) return ws
+
+  const core = useCoreS3Serial()
+
+  const isConnected = ref(false)
+  const error = ref<string | null>(null)
+  const readers = ref<string[]>([])
+  const bridgeVersion = ref<string | null>(null)
+
+  const readCallbacks = new Set<(event: NfcReadEvent) => void>()
+  const licenseReadCallbacks = new Set<(event: NfcLicenseReadEvent) => void>()
+  const errorCallbacks = new Set<(event: NfcErrorEvent) => void>()
+
+  /** connect() 済みか (直結が切れたときブリッジへ戻すかの判断に使う) */
+  let wantConnected = false
+  /** 直前に配った employee_id と、配った時刻 */
+  let lastEmployeeId: string | null = null
+  let lastEmittedAt = 0
+
+  function emitRead(employeeId: string): void {
+    const now = Date.now()
+    if (employeeId === lastEmployeeId && now - lastEmittedAt < DEDUPE_WINDOW_MS) return
+    lastEmployeeId = employeeId
+    lastEmittedAt = now
+    for (const cb of [...readCallbacks]) cb({ type: 'nfc_read', employee_id: employeeId })
+  }
+
+  function emitLicenseRead(event: NfcLicenseReadEvent): void {
+    for (const cb of [...licenseReadCallbacks]) cb(event)
+  }
+
+  function emitError(event: NfcErrorEvent): void {
+    for (const cb of [...errorCallbacks]) cb(event)
+  }
+
+  // --- CoreS3 直結 ---
+
+  function handleCoreEvent(name: string, args: string[]): void {
+    if (name === 'NFC_LICENSE') {
+      const issue = argValue(args, 'issue')
+      const expiry = argValue(args, 'expiry')
+      // 26 桁の契約を満たせない行は捨てる (utils/license.ts の桁が合わなくなる)
+      if (issue.length !== DATE_LEN || expiry.length !== DATE_LEN) return
+
+      const cardId = CARD_ID_PAD + issue + expiry
+      // useNfcWebSocket と同じ順 — 先に期限を配り、続けて読み取りを配る
+      emitLicenseRead({
+        type: 'nfc_license_read',
+        card_type: 'driver_license',
+        card_id: cardId,
+        expiry_date: cardId,
+        // ATR は USB CDC の行に乗らない (ブリッジ経由でのみ得られる)
+        atr: '',
+      })
+      emitRead(issue + expiry)
+      return
+    }
+
+    // firmware は「画面が受け付ける状態 かつ 期限切れ」のときだけ寄越す。
+    // 来ないことは異常ではないので、待ち受けるだけにする
+    if (name === 'LICENSE_EXPIRED') {
+      emitError({ type: 'nfc_error', error: 'license_expired' })
+    }
+  }
+
+  sinks.add(handleCoreEvent)
+  if (!wired) {
+    wired = true
+    core.onEvent((name, args) => {
+      for (const sink of [...sinks]) sink(name, args)
+    })
+  }
+
+  // --- NFC ブリッジ (9876) ---
+
+  ws.onLicenseRead(event => emitLicenseRead(event))
+  ws.onRead(event => emitRead(event.employee_id))
+  ws.onError(event => emitError(event))
+
+  // --- 状態 ---
+
+  function sync(): void {
+    if (core.isConnected.value) {
+      isConnected.value = true
+      readers.value = ['CoreS3']
+      // 直結が生きているあいだはブリッジの再接続エラーを見せない
+      error.value = null
+      bridgeVersion.value = null
+      return
+    }
+    isConnected.value = ws.isConnected.value
+    readers.value = [...ws.readers.value]
+    error.value = ws.error.value
+    bridgeVersion.value = ws.bridgeVersion.value
+  }
+
+  watch(core.isConnected, (connected) => {
+    // 直結しているあいだはブリッジを購読しない (同じ免許証の二重発火を断つ)
+    if (connected) ws.disconnect()
+    else if (wantConnected) ws.connect()
+  })
+
+  watch([core.isConnected, ws.isConnected, ws.error, ws.readers, ws.bridgeVersion], sync)
+
+  function connect(): void {
+    wantConnected = true
+    // claim は 3 秒で諦めるが登録は残る。後から掴めば isConnected が立つ
+    void core.connect()
+    if (!core.isConnected.value) ws.connect()
+  }
+
+  function disconnect(): void {
+    wantConnected = false
+    ws.disconnect()
+    // CoreS3 のポートは BLE ゲートウェイと共有しているので手放さない
+    sync()
+  }
+
+  function onRead(callback: (event: NfcReadEvent) => void) {
+    readCallbacks.add(callback)
+    return () => { readCallbacks.delete(callback) }
+  }
+
+  function onLicenseRead(callback: (event: NfcLicenseReadEvent) => void) {
+    licenseReadCallbacks.add(callback)
+    return () => { licenseReadCallbacks.delete(callback) }
+  }
+
+  function onError(callback: (event: NfcErrorEvent) => void) {
+    errorCallbacks.add(callback)
+    return () => { errorCallbacks.delete(callback) }
+  }
+
+  onUnmounted(() => {
+    sinks.delete(handleCoreEvent)
+  })
+
+  return {
+    isConnected: readonly(isConnected),
+    error: readonly(error),
+    readers: readonly(readers),
+    bridgeVersion: readonly(bridgeVersion),
+    connect,
+    disconnect,
+    onRead,
+    onLicenseRead,
+    onError,
+  }
+}

--- a/web/coverage_100.toml
+++ b/web/coverage_100.toml
@@ -71,6 +71,10 @@ path = "app/composables/useNfcWebSocket.ts"
 branches = true
 
 [[files]]
+path = "app/composables/useNfcReader.ts"
+branches = true
+
+[[files]]
 path = "app/composables/useOfflineSync.ts"
 branches = true
 

--- a/web/tests/composables/useNfcReader.test.ts
+++ b/web/tests/composables/useNfcReader.test.ts
@@ -1,0 +1,427 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { ref, readonly, nextTick } from 'vue'
+import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+import type { NfcReadEvent, NfcLicenseReadEvent, NfcErrorEvent } from '~/types'
+import { parseLicenseIssueDate, parseLicenseExpiryDate } from '~/utils/license'
+import { withSetup } from '../helpers/with-setup'
+
+// --- WebSerial 対応判定 ---
+
+const serialSupport = vi.hoisted(() => ({ supported: true }))
+vi.mock('~/utils/webserial', () => ({
+  isWebSerialSupported: () => serialSupport.supported,
+}))
+
+// --- useCoreS3Serial のモック (公開 API 11 キー) ---
+
+const coreState = {
+  isConnected: ref(false),
+}
+/** useNfcReader が繋いだ EVT の受け口 */
+let coreEventHandlers: Array<(name: string, args: string[]) => void> = []
+const coreMock = {
+  isSupported: true,
+  onJson: vi.fn(),
+  onEvent: vi.fn((cb: (name: string, args: string[]) => void) => { coreEventHandlers.push(cb) }),
+  onOpen: vi.fn(),
+  onClose: vi.fn(),
+  write: vi.fn(async () => true),
+  connect: vi.fn(async () => coreState.isConnected.value),
+  requestPort: vi.fn(async () => true),
+  release: vi.fn(async () => {}),
+  disconnect: vi.fn(async () => {}),
+}
+mockNuxtImport('useCoreS3Serial', () => () => ({
+  ...coreMock,
+  isConnected: readonly(coreState.isConnected),
+}))
+
+/** CoreS3 から `EVT <NAME> <args...>` が届いた体にする */
+function emitCoreEvent(name: string, args: string[] = []) {
+  for (const cb of [...coreEventHandlers]) cb(name, args)
+}
+
+// --- useNfcWebSocket のモック (公開 API 9 キー) ---
+
+const wsState = {
+  isConnected: ref(false),
+  error: ref<string | null>(null),
+  readers: ref<string[]>([]),
+  bridgeVersion: ref<string | null>(null),
+}
+const wsCallbacks = {
+  read: [] as Array<(e: NfcReadEvent) => void>,
+  license: [] as Array<(e: NfcLicenseReadEvent) => void>,
+  error: [] as Array<(e: NfcErrorEvent) => void>,
+}
+const wsMock = {
+  connect: vi.fn(),
+  disconnect: vi.fn(() => { wsState.isConnected.value = false }),
+  onRead: vi.fn((cb: (e: NfcReadEvent) => void) => {
+    wsCallbacks.read.push(cb)
+    return () => {}
+  }),
+  onLicenseRead: vi.fn((cb: (e: NfcLicenseReadEvent) => void) => {
+    wsCallbacks.license.push(cb)
+    return () => {}
+  }),
+  onError: vi.fn((cb: (e: NfcErrorEvent) => void) => {
+    wsCallbacks.error.push(cb)
+    return () => {}
+  }),
+}
+mockNuxtImport('useNfcWebSocket', () => () => ({
+  ...wsMock,
+  isConnected: readonly(wsState.isConnected),
+  error: readonly(wsState.error),
+  readers: readonly(wsState.readers),
+  bridgeVersion: readonly(wsState.bridgeVersion),
+}))
+
+/**
+ * ブリッジ経由で免許証が届いた体にする。
+ * 実物の useNfcWebSocket は onLicenseRead → onRead の順で配る (:57 → :64)。
+ */
+function emitBridgeLicense(cardId: string) {
+  for (const cb of [...wsCallbacks.license]) {
+    cb({ type: 'nfc_license_read', card_type: 'driver_license', card_id: cardId, atr: '', expiry_date: cardId })
+  }
+  for (const cb of [...wsCallbacks.read]) {
+    cb({ type: 'nfc_read', employee_id: cardId.substring(10, 26) })
+  }
+}
+
+// --- Tests ---
+
+const ISSUE = '20230401'
+const EXPIRY = '20280401'
+/** CoreS3 が組み立てるはずの 26 桁 (先頭 10 桁は詰め物) */
+const CARD_ID = '0000000000' + ISSUE + EXPIRY
+
+describe('useNfcReader', () => {
+  let mod: typeof import('~/composables/useNfcReader')
+  let app: ReturnType<typeof withSetup>[1] | null = null
+
+  /** モジュール状態 (wired) ごと作り直して composable を立ち上げる */
+  async function load() {
+    vi.resetModules()
+    mod = await import('~/composables/useNfcReader')
+    const [reader, created] = withSetup(() => mod.useNfcReader())
+    app = created
+    return reader
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'Date'] })
+    serialSupport.supported = true
+    coreEventHandlers = []
+    wsCallbacks.read = []
+    wsCallbacks.license = []
+    wsCallbacks.error = []
+    coreState.isConnected.value = false
+    wsState.isConnected.value = false
+    wsState.error.value = null
+    wsState.readers.value = []
+    wsState.bridgeVersion.value = null
+  })
+
+  afterEach(() => {
+    app?.unmount()
+    app = null
+    vi.useRealTimers()
+  })
+
+  // ---------- 公開 API ----------
+
+  it('useNfcWebSocket と同じ 9 キーを返す', async () => {
+    const reader = await load()
+    expect(Object.keys(reader).sort()).toEqual([
+      'bridgeVersion', 'connect', 'disconnect', 'error', 'isConnected',
+      'onError', 'onLicenseRead', 'onRead', 'readers',
+    ])
+  })
+
+  it('WebSerial が無ければ useNfcWebSocket にそのまま委譲する', async () => {
+    serialSupport.supported = false
+    const reader = await load()
+
+    expect(reader.connect).toBe(wsMock.connect)
+    expect(reader.disconnect).toBe(wsMock.disconnect)
+    // CoreS3 には一切触らない
+    expect(coreMock.onEvent).not.toHaveBeenCalled()
+  })
+
+  it('EVT の受け口は 1 度しか繋がない (解除できないため)', async () => {
+    const reader = await load()
+    expect(coreMock.onEvent).toHaveBeenCalledTimes(1)
+
+    // 2 つ目の component が同じ composable を呼んでも増えない
+    const [second, secondApp] = withSetup(() => mod.useNfcReader())
+    expect(coreMock.onEvent).toHaveBeenCalledTimes(1)
+
+    // それでも 2 つ目にもイベントは配られる
+    const seen: string[] = []
+    second.onRead(e => seen.push(e.employee_id))
+    reader.onRead(() => {})
+    emitCoreEvent('NFC_LICENSE', [`issue=${ISSUE}`, `expiry=${EXPIRY}`])
+    expect(seen).toEqual([ISSUE + EXPIRY])
+
+    secondApp.unmount()
+  })
+
+  it('unmount した component には配らない', async () => {
+    const reader = await load()
+    const seen: string[] = []
+    reader.onRead(e => seen.push(e.employee_id))
+
+    app!.unmount()
+    app = null
+    emitCoreEvent('NFC_LICENSE', [`issue=${ISSUE}`, `expiry=${EXPIRY}`])
+    expect(seen).toEqual([])
+  })
+
+  // ---------- CoreS3 直結の組み立て ----------
+
+  it('NFC_LICENSE を 26 桁に組み立て、onLicenseRead → onRead の順で配る', async () => {
+    const reader = await load()
+    const order: string[] = []
+    let license: NfcLicenseReadEvent | null = null
+    let read: NfcReadEvent | null = null
+    reader.onLicenseRead((e) => { order.push('license'); license = e })
+    reader.onRead((e) => { order.push('read'); read = e })
+
+    emitCoreEvent('NFC_LICENSE', [`issue=${ISSUE}`, `expiry=${EXPIRY}`])
+
+    expect(order).toEqual(['license', 'read'])
+    expect(license).toEqual({
+      type: 'nfc_license_read',
+      card_type: 'driver_license',
+      card_id: CARD_ID,
+      expiry_date: CARD_ID,
+      atr: '',
+    })
+    expect(read).toEqual({ type: 'nfc_read', employee_id: ISSUE + EXPIRY })
+  })
+
+  it('組み立てた 26 桁は utils/license.ts の桁の契約を満たす', async () => {
+    const reader = await load()
+    let license: NfcLicenseReadEvent | null = null
+    reader.onLicenseRead((e) => { license = e })
+
+    emitCoreEvent('NFC_LICENSE', [`expiry=${EXPIRY}`, `issue=${ISSUE}`])
+
+    const hex = license!.expiry_date!
+    expect(hex).toHaveLength(26)
+    expect(parseLicenseIssueDate(hex)).toEqual(new Date(2023, 3, 1))
+    expect(parseLicenseExpiryDate(hex)).toEqual(new Date(2028, 3, 1))
+    // LicenseRegistration が nfc_id に使う 16 桁
+    expect(license!.card_id.substring(10, 26)).toBe(ISSUE + EXPIRY)
+  })
+
+  it.each([
+    ['issue が無い', [`expiry=${EXPIRY}`]],
+    ['expiry の桁が足りない', [`issue=${ISSUE}`, 'expiry=2028040']],
+  ])('26 桁にできない NFC_LICENSE (%s) は捨てる', async (_label, args) => {
+    const reader = await load()
+    const seen: unknown[] = []
+    reader.onLicenseRead(e => seen.push(e))
+    reader.onRead(e => seen.push(e))
+
+    emitCoreEvent('NFC_LICENSE', args)
+    expect(seen).toEqual([])
+  })
+
+  it('LICENSE_EXPIRED を onError へ配る', async () => {
+    const reader = await load()
+    const seen: NfcErrorEvent[] = []
+    reader.onError(e => seen.push(e))
+
+    emitCoreEvent('LICENSE_EXPIRED', ['20200401'])
+    expect(seen).toEqual([{ type: 'nfc_error', error: 'license_expired' }])
+  })
+
+  it('引数の無い EVT (NFC_REMOVED) は何も起こさない', async () => {
+    const reader = await load()
+    const seen: unknown[] = []
+    reader.onRead(e => seen.push(e))
+    reader.onError(e => seen.push(e))
+    reader.onLicenseRead(e => seen.push(e))
+
+    emitCoreEvent('NFC_REMOVED')
+    expect(seen).toEqual([])
+  })
+
+  // ---------- 重複除去 ----------
+
+  it('両経路から同じ免許証が来ても onRead は 1 回だけ', async () => {
+    const reader = await load()
+    const seen: string[] = []
+    reader.onRead(e => seen.push(e.employee_id))
+
+    emitCoreEvent('NFC_LICENSE', [`issue=${ISSUE}`, `expiry=${EXPIRY}`])
+    // 常駐アプリがまだ生きていて 9876 からも同じ免許証が届く
+    emitBridgeLicense(CARD_ID)
+
+    expect(seen).toEqual([ISSUE + EXPIRY])
+  })
+
+  it('3 秒を過ぎれば同じ免許証をもう一度配る', async () => {
+    const reader = await load()
+    const seen: string[] = []
+    reader.onRead(e => seen.push(e.employee_id))
+
+    emitCoreEvent('NFC_LICENSE', [`issue=${ISSUE}`, `expiry=${EXPIRY}`])
+    vi.advanceTimersByTime(3000)
+    emitCoreEvent('NFC_LICENSE', [`issue=${ISSUE}`, `expiry=${EXPIRY}`])
+
+    expect(seen).toHaveLength(2)
+  })
+
+  it('別の免許証は窓の中でも配る', async () => {
+    const reader = await load()
+    const seen: string[] = []
+    reader.onRead(e => seen.push(e.employee_id))
+
+    emitCoreEvent('NFC_LICENSE', [`issue=${ISSUE}`, `expiry=${EXPIRY}`])
+    emitCoreEvent('NFC_LICENSE', ['issue=20240501', `expiry=${EXPIRY}`])
+
+    expect(seen).toEqual([ISSUE + EXPIRY, '2024050120280401'])
+  })
+
+  // ---------- ブリッジ経由の中継 ----------
+
+  it('ブリッジ経由の免許証も onLicenseRead / onRead へ中継する', async () => {
+    const reader = await load()
+    const licenses: NfcLicenseReadEvent[] = []
+    const reads: string[] = []
+    reader.onLicenseRead(e => licenses.push(e))
+    reader.onRead(e => reads.push(e.employee_id))
+
+    emitBridgeLicense(CARD_ID)
+
+    expect(licenses).toHaveLength(1)
+    expect(reads).toEqual([ISSUE + EXPIRY])
+  })
+
+  it('ブリッジのエラーを onError へ中継する', async () => {
+    const reader = await load()
+    const seen: NfcErrorEvent[] = []
+    reader.onError(e => seen.push(e))
+
+    for (const cb of wsCallbacks.error) cb({ type: 'nfc_error', error: 'no_readers' })
+    expect(seen).toEqual([{ type: 'nfc_error', error: 'no_readers' }])
+  })
+
+  it('購読を解除したら配られない', async () => {
+    const reader = await load()
+    const reads: string[] = []
+    const licenses: unknown[] = []
+    const errors: unknown[] = []
+    reader.onRead(e => reads.push(e.employee_id))()
+    reader.onLicenseRead(e => licenses.push(e))()
+    reader.onError(e => errors.push(e))()
+
+    emitCoreEvent('NFC_LICENSE', [`issue=${ISSUE}`, `expiry=${EXPIRY}`])
+    emitCoreEvent('LICENSE_EXPIRED', ['20200401'])
+
+    expect(reads).toEqual([])
+    expect(licenses).toEqual([])
+    expect(errors).toEqual([])
+  })
+
+  // ---------- 経路の切り替え ----------
+
+  it('connect(): CoreS3 を掴みに行き、直結していなければブリッジも繋ぐ', async () => {
+    const reader = await load()
+    reader.connect()
+
+    expect(coreMock.connect).toHaveBeenCalledTimes(1)
+    expect(wsMock.connect).toHaveBeenCalledTimes(1)
+  })
+
+  it('connect(): 直結済みならブリッジは繋がない', async () => {
+    coreState.isConnected.value = true
+    const reader = await load()
+    reader.connect()
+
+    expect(coreMock.connect).toHaveBeenCalledTimes(1)
+    expect(wsMock.connect).not.toHaveBeenCalled()
+  })
+
+  it('直結したらブリッジを切り、readers は CoreS3 になる', async () => {
+    const reader = await load()
+    reader.connect()
+    wsState.error.value = 'NFC ブリッジとの接続でエラーが発生しました'
+    wsState.bridgeVersion.value = '0.1.0'
+
+    coreState.isConnected.value = true
+    await nextTick()
+
+    expect(wsMock.disconnect).toHaveBeenCalledTimes(1)
+    expect(reader.isConnected.value).toBe(true)
+    expect(reader.readers.value).toEqual(['CoreS3'])
+    // 直結中はブリッジ側の状態を見せない
+    expect(reader.error.value).toBeNull()
+    expect(reader.bridgeVersion.value).toBeNull()
+  })
+
+  it('直結が切れたらブリッジへ戻す', async () => {
+    const reader = await load()
+    reader.connect()
+    coreState.isConnected.value = true
+    await nextTick()
+    wsMock.connect.mockClear()
+
+    coreState.isConnected.value = false
+    await nextTick()
+
+    expect(wsMock.connect).toHaveBeenCalledTimes(1)
+  })
+
+  it('connect() していなければ直結が切れてもブリッジへ戻さない', async () => {
+    const reader = await load()
+    coreState.isConnected.value = true
+    await nextTick()
+    coreState.isConnected.value = false
+    await nextTick()
+
+    expect(wsMock.connect).not.toHaveBeenCalled()
+    expect(reader.isConnected.value).toBe(false)
+  })
+
+  it('直結していないあいだはブリッジの状態が透ける', async () => {
+    const reader = await load()
+
+    wsState.isConnected.value = true
+    wsState.readers.value = ['ACS ACR122U']
+    wsState.bridgeVersion.value = '0.3.1'
+    wsState.error.value = null
+    await nextTick()
+
+    expect(reader.isConnected.value).toBe(true)
+    expect(reader.readers.value).toEqual(['ACS ACR122U'])
+    expect(reader.bridgeVersion.value).toBe('0.3.1')
+  })
+
+  it('disconnect(): ブリッジを切って未接続になり、以後は戻さない', async () => {
+    const reader = await load()
+    reader.connect()
+    wsState.isConnected.value = true
+    await nextTick()
+
+    reader.disconnect()
+    expect(wsMock.disconnect).toHaveBeenCalledTimes(1)
+    expect(reader.isConnected.value).toBe(false)
+
+    // CoreS3 のポートは BLE ゲートウェイと共有しているので手放さない
+    expect(coreMock.disconnect).not.toHaveBeenCalled()
+
+    wsMock.connect.mockClear()
+    coreState.isConnected.value = true
+    await nextTick()
+    coreState.isConnected.value = false
+    await nextTick()
+    expect(wsMock.connect).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
Windows の常駐アプリを経由せず、CoreS3 を USB でつなぐだけで免許証を読めるようにします。読み取り口を束ねる composable を新設し、点呼の NFC ステップと免許証登録を差し替えました。

Refs #182 の 4 本目、最後の PR です。

## なぜ

運行者の点呼で免許証を読むとき、これまでは Windows に常駐するブリッジのアプリが必要でした。CoreS3 を USB で直結すれば、そのアプリなしで読めます。ブリッジの導入と更新が運用から 1 つ減ります。

前の 3 本でポート調停を 1 本にまとめ、CoreS3 用の受け口を用意してあります。この PR はその上に読み取り口を載せるだけです。

## 変更

- 新規 `web/app/composables/useNfcReader.ts` とそのテスト。既存のブリッジ用と**同じ 9 キーを型ごと同一**にしてあるので、呼び出し元は 1 行の差し替えで済みます
- `NfcStatus.vue` の未接続表示を書き換え。USB の許可ボタンを出し、文言を直結でも通じる表現に
- `LicenseRegistration.vue` は 1 行のみ
- `web/coverage_100.toml` に新設ファイルを branches 付きで登録

## 挙動

**CoreS3 を優先します。** 直結しているあいだはブリッジを購読せず、切れたら戻します。切り替わり際に同じ免許証が両方から届きうるので、同じ 16 桁を 3 秒以内に再受信したら捨てます。これがないと計測のステップが二重に進みます。

読み取りの発火順と桁は既存の契約に合わせました。交付日と期限はそれぞれ 8 桁で、先頭に詰め物を付けた 26 桁として渡します。日付の解釈は既存の共通処理をそのまま使い、この composable では桁を切り出しません。

期限切れの通知は、機器側が「画面が受け付ける状態かつ期限切れ」のときだけ出します。**来ないことを異常として扱いません。**

WebSerial に対応しない環境では、従来どおりブリッジ経由に委譲します。

## 実装で分かったこと

**切断時に CoreS3 のポートを手放していません。** CoreS3 の受け口はシングルトンで、BLE ゲートウェイと同じ名前で登録されています。ここで登録を降ろすと体温計と血圧計まで切れます。ブリッジ側だけを切る形にしました。

直結時はブリッジのバージョンが送られてこないため、放置すると更新の案内が出続けます。直結を検出しているあいだは抑止します。

## 触っていないもの

タイムカード端末の 2 画面は従来どおりブリッジ経由です。交通系 IC の識別子が必要で、CoreS3 の USB では代替できません。

## 確認

- `npm run test:coverage` → 51 ファイル / 1322 passed / 2 skipped、新設ファイルは 100%
- `node scripts/check_coverage_100.mjs` → All 39 files at 100% lines
- 両方の経路から同じ免許証が届いても読み取りが 1 回しか出ないことをテストで固定
- 日付の解釈が共通処理を通ることをテストで確認
- ブリッジ用を直接呼ぶのは、新設ファイルとタイムカード端末の 2 画面だけになりました

Refs #182

🤖 Generated with [Claude Code](https://claude.com/claude-code)
