### PR TITLE
fix(tenko): 乗務員照会の失敗文言を 1 本化し、理由と次の操作を出す (Closes #187)

### DIFF
--- a/web/app/components/NormalMeasurement.vue
+++ b/web/app/components/NormalMeasurement.vue
@@ -4,6 +4,7 @@ import { getEmployeeByNfcId, getEmployeeByCode, startMeasurement, updateMeasurem
 import { saveVideo, markVideoUploaded, getPendingVideos, cleanupOldVideos } from '~/utils/video-store'
 import { checkLicenseExpiry, formatExpiryDate, type LicenseExpiryStatus } from '~/utils/license'
 import { checkFaceApproval } from '~/utils/face-approval'
+import { employeeNotFoundByNfc, employeeNotFoundByCode } from '~/utils/employee-lookup-messages'
 
 const { isDemoMode: isDemoModeFromUrl } = useDemoMode()
 
@@ -90,7 +91,7 @@ async function onNfcRead(nfcId: string, expiryDate?: Date) {
     await faceSync()
     step.value = 'face_auth'
   } catch {
-    console.error(`乗務員が見つかりません (NFC ID: ${nfcId})`)
+    console.error(employeeNotFoundByNfc(nfcId))
   }
 }
 
@@ -111,7 +112,7 @@ async function onManualSubmit() {
     await faceSync()
     step.value = 'face_auth'
   } catch {
-    manualError.value = `社員番号「${input}」の乗務員が見つかりません`
+    manualError.value = employeeNotFoundByCode(input)
   }
 }
 

--- a/web/app/components/RoleAuthGate.vue
+++ b/web/app/components/RoleAuthGate.vue
@@ -11,6 +11,7 @@
 import type { FaceAuthResult } from '~/types'
 import { getEmployeeByNfcId, getEmployeeByCode, getEmployeeById, updateDeviceLastLogin } from '~/utils/api'
 import { checkFaceApproval } from '~/utils/face-approval'
+import { employeeNotFoundByNfc, employeeNotFoundByCode } from '~/utils/employee-lookup-messages'
 
 const props = defineProps<{
   requiredRole: 'manager' | 'admin'
@@ -87,7 +88,7 @@ async function onNfcRead(nfcId: string) {
     await faceSync()
     step.value = 'face_auth'
   } catch {
-    errorMessage.value = `乗務員が見つかりません (NFC ID: ${nfcId})`
+    errorMessage.value = employeeNotFoundByNfc(nfcId)
   } finally {
     isSubmitting.value = false
   }
@@ -114,7 +115,7 @@ async function onManualSubmit() {
     await faceSync()
     step.value = 'face_auth'
   } catch {
-    manualError.value = `社員番号「${input}」の乗務員が見つかりません`
+    manualError.value = employeeNotFoundByCode(input)
   } finally {
     isSubmitting.value = false
   }

--- a/web/app/components/TenkoKiosk.vue
+++ b/web/app/components/TenkoKiosk.vue
@@ -2,6 +2,7 @@
 import type { FaceAuthResult, MeasurementResult, SubmitMedicalData } from '~/types'
 import { getEmployeeByNfcId, getEmployeeByCode } from '~/utils/api'
 import { checkFaceApproval } from '~/utils/face-approval'
+import { employeeNotFoundByNfc, employeeNotFoundByCode } from '~/utils/employee-lookup-messages'
 
 const props = defineProps<{
   demoMode?: boolean
@@ -123,7 +124,7 @@ async function onNfcRead(nfcId: string) {
     if (approvalErr) { error.value = approvalErr; return }
     await identifyEmployee(emp.id, emp.name)
   } catch {
-    error.value = `乗務員が見つかりません (NFC ID: ${nfcId})`
+    error.value = employeeNotFoundByNfc(nfcId)
   }
 }
 
@@ -137,7 +138,7 @@ async function onManualSubmit() {
     if (approvalErr) { error.value = approvalErr; return }
     await identifyEmployee(emp.id, emp.name)
   } catch {
-    manualError.value = `社員番号「${input}」の乗務員が見つかりません`
+    manualError.value = employeeNotFoundByCode(input)
   }
 }
 

--- a/web/app/components/TenkoRemoteAdminView.vue
+++ b/web/app/components/TenkoRemoteAdminView.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { FaceAuthResult, TenkoSession, DriverInfo } from '~/types'
 import { getEmployeeByCode, getEmployeeById, getEmployees, getTenkoSession, getDeviceSettings, getDriverInfo } from '~/utils/api'
+import { employeeNotFoundByCode } from '~/utils/employee-lookup-messages'
 
 const props = defineProps<{
   initialRoomId?: string | null
@@ -175,7 +176,7 @@ async function onModalIdSubmit() {
     setManagerId(emp.id)
     modalStep.value = 'face_auth'
   } catch {
-    modalIdError.value = `社員番号「${input}」の乗務員が見つかりません`
+    modalIdError.value = employeeNotFoundByCode(input)
   }
 }
 

--- a/web/app/composables/useTenkoKiosk.ts
+++ b/web/app/composables/useTenkoKiosk.ts
@@ -11,6 +11,7 @@ import {
   cancelTenkoSession, uploadFacePhoto,
   getCarryingItems, submitCarryingItemChecks,
 } from '~/utils/api'
+import { noPendingSchedule } from '~/utils/employee-lookup-messages'
 
 /** UI ステップ (バックエンド status とは別) */
 export type TenkoStep =
@@ -96,7 +97,7 @@ export function useTenkoKiosk(options?: { remoteMode?: boolean }) {
       const schedules = await getPendingSchedules(empId)
       pendingSchedules.value = schedules
       if (schedules.length === 0) {
-        error.value = '未消費の点呼予定がありません'
+        error.value = noPendingSchedule()
         return
       }
       step.value = 'schedule_select'

--- a/web/app/utils/employee-lookup-messages.ts
+++ b/web/app/utils/employee-lookup-messages.ts
@@ -1,0 +1,16 @@
+/** 乗務員照会が失敗したときの文言 (理由 + 次の操作) を 1 か所にまとめる */
+
+/** NFC (免許証) で引けなかったとき */
+export function employeeNotFoundByNfc(nfcId: string): string {
+  return `この免許証は乗務員に登録されていません (NFC ID: ${nfcId})。管理者画面の「免許証」で読み取り → 保存してください`
+}
+
+/** 社員番号で引けなかったとき */
+export function employeeNotFoundByCode(code: string): string {
+  return `社員番号「${code}」の乗務員が見つかりません。社員番号を確認するか、管理者に乗務員登録を依頼してください`
+}
+
+/** 乗務員は引けたが未消費の点呼予定が無いとき */
+export function noPendingSchedule(): string {
+  return '未消費の点呼予定がありません。点呼予定を作成してから読み取り直してください'
+}

--- a/web/coverage_100.toml
+++ b/web/coverage_100.toml
@@ -139,6 +139,10 @@ path = "app/utils/face-approval.ts"
 branches = true
 
 [[files]]
+path = "app/utils/employee-lookup-messages.ts"
+branches = true
+
+[[files]]
 path = "app/utils/face-db.ts"
 branches = true
 

--- a/web/tests/composables/useTenkoKiosk.test.ts
+++ b/web/tests/composables/useTenkoKiosk.test.ts
@@ -17,6 +17,7 @@ vi.mock('~/utils/api', () => ({
 }))
 
 import { useTenkoKiosk } from '~/composables/useTenkoKiosk'
+import { noPendingSchedule } from '~/utils/employee-lookup-messages'
 import {
   getPendingSchedules,
   startTenkoSession,
@@ -231,7 +232,7 @@ describe('useTenkoKiosk', () => {
       vi.mocked(getPendingSchedules).mockResolvedValue([])
       const k = useTenkoKiosk()
       await k.identifyEmployee('emp-1', '田中')
-      expect(k.error.value).toBe('未消費の点呼予定がありません')
+      expect(k.error.value).toBe(noPendingSchedule())
       expect(k.step.value).toBe('nfc')
     })
 

--- a/web/tests/utils/employee-lookup-messages.test.ts
+++ b/web/tests/utils/employee-lookup-messages.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest'
+import {
+  employeeNotFoundByNfc,
+  employeeNotFoundByCode,
+  noPendingSchedule,
+} from '~/utils/employee-lookup-messages'
+
+describe('employee-lookup-messages', () => {
+  it('employeeNotFoundByNfc は NFC ID と次の操作 (管理者画面で保存) を含む', () => {
+    const msg = employeeNotFoundByNfc('0123ABCD')
+    expect(msg).toContain('0123ABCD')
+    expect(msg).toContain('保存')
+  })
+
+  it('employeeNotFoundByCode は社員番号と次の操作 (確認 / 乗務員登録) を含む', () => {
+    const msg = employeeNotFoundByCode('E-42')
+    expect(msg).toContain('E-42')
+    expect(msg).toContain('乗務員登録')
+  })
+
+  it('noPendingSchedule は次の操作 (点呼予定を作成) を含む', () => {
+    const msg = noPendingSchedule()
+    expect(msg).toContain('未消費の点呼予定がありません')
+    expect(msg).toContain('点呼予定を作成')
+  })
+})


### PR DESCRIPTION
## 何を
点呼の免許証ステップで「読み取れたのに進まない」ときの理由が利用者に伝わらなかった (実機報告 2026-09-09)。乗務員照会に失敗したときの文言を `web/app/utils/employee-lookup-messages.ts` の 3 関数に 1 本化し、理由に加えて**次の操作**を含める:

| 関数 | 使う場面 | 次の操作 |
|---|---|---|
| `employeeNotFoundByNfc(nfcId)` | 免許証 / NFC の 16 桁が乗務員に紐づいていない | 管理者画面の「免許証」で読み取り → **保存** |
| `employeeNotFoundByCode(code)` | 社員番号の手入力が見つからない | 社員番号の確認、乗務員登録の依頼 |
| `noPendingSchedule()` | 未消費の点呼予定が無い | 点呼予定を作成してから読み取り直す |

同型の文言が散っていた 8 か所 (`TenkoKiosk.vue` / `RoleAuthGate.vue` / `NormalMeasurement.vue` / `TenkoRemoteAdminView.vue` / `useTenkoKiosk.ts`) を全部この関数に置換。

## 変えていないこと
- 赤枠の位置・markup、`error` の型 (string)。新コンポーネント無し
- `face-approval.ts` (既に氏名 + 理由を返す) と `TenkoScheduleSelect.vue` の静的文言

## テスト
- 新規 `web/tests/utils/employee-lookup-messages.test.ts` (3 it)、`useTenkoKiosk.test.ts` の assert を関数の戻り値に更新
- `tsc --noEmit` / `vitest run` 1325 passed / coverage 100% (新 util を `coverage_100.toml` に登録、branches = true)

## 実機確認 (マージ後)
未登録の免許証をタッチ → 赤枠に新文言。登録済み + 予定ありの免許証 → 顔認証へ 1 つだけ進む。

Closes #187
Refs ippoan/alc-app-s3#135

🤖 Generated with [Claude Code](https://claude.com/claude-code)
