### PR TITLE
fix(serial): ポートを閉じる前に DTR/RTS を落とし、ESP32-S3 を再起動させない (Refs ippoan/alc-app-s3#186)

### DIFF
--- a/web/app/composables/useSerialArbiter.ts
+++ b/web/app/composables/useSerialArbiter.ts
@@ -140,6 +140,16 @@ export async function writeLine(
   }
 }
 
+/**
+ * ポートを閉じる。ESP32-S3 の USB-Serial-JTAG は「DTR=0 かつ RTS=1」で chip reset が
+ * かかる (自動書き込み回路の模倣) ため、close の直前に DTR と RTS を両方落とす。
+ * S3 にはこれを無効化するレジスタが無く、firmware 側では直せない。
+ */
+async function closePortQuietly(port: SerialPort): Promise<void> {
+  try { await port.setSignals({ dataTerminalReady: false, requestToSend: false }) } catch { /* 非対応でも close は続ける */ }
+  await port.close()
+}
+
 export function useSerialArbiter() {
   const { ports, refreshPorts, requestNewPort } = useSerialDeviceManager()
 
@@ -172,7 +182,7 @@ export function useSerialArbiter() {
     try { s.writer.releaseLock() } catch {}
     try { await s.reader.cancel() } catch {}
     try { s.reader.releaseLock() } catch {}
-    try { await s.port.close() } catch {}
+    try { await closePortQuietly(s.port) } catch {}
     if (owner) owner.claimant.onClose()
   }
 
@@ -284,7 +294,7 @@ export function useSerialArbiter() {
     }
 
     if (!candidate.readable || !candidate.writable) {
-      try { await candidate.close() } catch {}
+      try { await closePortQuietly(candidate) } catch {}
       return
     }
 

--- a/web/tests/composables/useSerialArbiter.test.ts
+++ b/web/tests/composables/useSerialArbiter.test.ts
@@ -6,6 +6,8 @@ import type { SerialClaimant } from '~/composables/useSerialArbiter'
 interface MockPortHandle {
   port: any
   writes: string[]
+  /** setSignals / close の呼び出し順 (ESP32-S3 のリセット回避の検証に使う) */
+  calls: string[]
   /** デバイスからの受信行を流す (未読なら queue に積まれる) */
   emit: (text: string) => void
   push: (chunk: { value?: Uint8Array; done: boolean }) => void
@@ -17,6 +19,8 @@ function createMockPort(options?: {
   vid?: number
   openError?: Error
   writeError?: boolean
+  /** setSignals 非対応のポート (古い Chrome / 一部ドライバ) を模す */
+  signalsError?: boolean
 }): MockPortHandle {
   const queue: Array<{ value?: Uint8Array; done: boolean }> = []
   let pending: ((chunk: { value?: Uint8Array; done: boolean }) => void) | null = null
@@ -60,11 +64,18 @@ function createMockPort(options?: {
     releaseLock: vi.fn(),
   }
 
+  const calls: string[] = []
   const port = {
     open: vi.fn(async () => {
       if (options?.openError) throw options.openError
     }),
-    close: vi.fn(async () => {}),
+    setSignals: vi.fn(async (_signals: { dataTerminalReady?: boolean; requestToSend?: boolean }) => {
+      calls.push('setSignals')
+      if (options?.signalsError) throw new Error('setSignals unsupported')
+    }),
+    close: vi.fn(async () => {
+      calls.push('close')
+    }),
     readable: options?.readable === false ? null : { getReader: vi.fn(() => reader) },
     writable: options?.writable === false ? null : { getWriter: vi.fn(() => writer) },
     getInfo: vi.fn(() => ({ usbVendorId: options?.vid ?? 0x303A, usbProductId: 0x1001 })),
@@ -73,6 +84,7 @@ function createMockPort(options?: {
   return {
     port,
     writes,
+    calls,
     emit: (text: string) => push({ value: new TextEncoder().encode(text), done: false }),
     push,
   }
@@ -251,6 +263,20 @@ describe('useSerialArbiter', () => {
       expect(other.port.open).toHaveBeenCalledTimes(1)
     })
 
+    it('見送った候補も DTR/RTS を落としてから閉じる (再訪のたびに再起動させない)', async () => {
+      const other = createMockPort()
+      other.emit('CORE LAN=up\n')
+      installSerialMock({ getPorts: vi.fn(async () => [other.port]) })
+      await load()
+
+      const { claimant } = createClaimant('ALARM', 'CORE')
+      arbiter.register('alarm', claimant)
+      await vi.advanceTimersByTimeAsync(0)
+
+      // BLE 相乗り中の CoreS3 が 10 秒ごとのプローブで毎回リセットされないこと
+      expect(other.calls).toEqual(['setSignals', 'close'])
+    })
+
     it('60 秒経ったら見送ったポートを再訪する (永久除外にしない)', async () => {
       const other = createMockPort()
       other.emit('CORE LAN=up\n')
@@ -406,6 +432,43 @@ describe('useSerialArbiter', () => {
       expect(dev.port.open).toHaveBeenCalledTimes(2)
     })
 
+    it('close の前に DTR/RTS を落とす (ESP32-S3 を再起動させない)', async () => {
+      const dev = createMockPort()
+      dev.emit('ALARM state=idle\n')
+      installSerialMock({ getPorts: vi.fn(async () => [dev.port]) })
+      await load()
+
+      const { claimant } = createClaimant('ALARM', 'CORE')
+      arbiter.register('alarm', claimant)
+      await vi.advanceTimersByTimeAsync(0)
+
+      await arbiter.release('alarm')
+
+      // DTR=0 かつ RTS=1 が S3 の chip reset の条件。両方落としてから閉じる
+      expect(dev.port.setSignals).toHaveBeenCalledWith({
+        dataTerminalReady: false,
+        requestToSend: false,
+      })
+      expect(dev.calls).toEqual(['setSignals', 'close'])
+    })
+
+    it('setSignals が失敗しても close は呼ぶ (非対応のポート)', async () => {
+      const dev = createMockPort({ signalsError: true })
+      dev.emit('ALARM state=idle\n')
+      installSerialMock({ getPorts: vi.fn(async () => [dev.port]) })
+      await load()
+
+      const { claimant, seen } = createClaimant('ALARM', 'CORE')
+      arbiter.register('alarm', claimant)
+      await vi.advanceTimersByTimeAsync(0)
+
+      await arbiter.release('alarm')
+
+      expect(dev.port.setSignals).toHaveBeenCalledTimes(1)
+      expect(dev.port.close).toHaveBeenCalledTimes(1)
+      expect(seen.closed).toBe(1)
+    })
+
     it('預かっていない名前の release は何もしない', async () => {
       installSerialMock({ getPorts: vi.fn(async () => []) })
       await load()
@@ -505,6 +568,20 @@ describe('useSerialArbiter', () => {
       expect(noRead.port.close).toHaveBeenCalledTimes(1)
       expect(noWrite.port.close).toHaveBeenCalledTimes(1)
       expect(seen.opened).toBe(0)
+    })
+
+    it('readable / writable が取れないポートも DTR/RTS を落としてから閉じる', async () => {
+      const noRead = createMockPort({ readable: false })
+      const noWrite = createMockPort({ writable: false })
+      installSerialMock({ getPorts: vi.fn(async () => [noRead.port, noWrite.port]) })
+      await load()
+
+      const { claimant } = createClaimant('ALARM', 'CORE')
+      arbiter.register('alarm', claimant)
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(noRead.calls).toEqual(['setSignals', 'close'])
+      expect(noWrite.calls).toEqual(['setSignals', 'close'])
     })
 
     it('書き込めないポートでも、先に名乗り出があればそちらが勝つ', async () => {


### PR DESCRIPTION
## 何を
WebSerial のポートを閉じる直前に DTR と RTS を両方 false にしてから `close()` する。`useSerialArbiter.ts` の close 2 か所 (`closeSession` と、readable/writable の取れない候補を閉じる側) を module 内の `closePortQuietly(port)` に寄せた。`setSignals` が非対応で reject しても `close()` は続ける。

## なぜ
実機 (2026-09-09) で PWA を閉じるたびに CoreS3 が再起動していた。ESP32-S3 の USB-Serial-JTAG は「DTR=0 かつ RTS=1」の組合せで chip reset がかかり (自動書き込み回路の模倣)、OS が close 時に DTR を先に落とすとこの形になる。esp-idf v5.5.3 の S3 には無効化するレジスタが無い (`USB_UART_CHIP_RST_DIS` は esp32p4 のみ) ので、ブラウザ側で制御線を先に落とすのが唯一の直し方。10 秒ごとのプローブで見送る候補も同じ経路を通るので、BLE 相乗り中の CoreS3 がプローブで再起動することも無くなる。

調停のロジック (claim / reject / 60 秒再訪 / register で再スキャン / 切断時にポートを手放さない) は触っていない。

## テスト
- `useSerialArbiter.test.ts` に 4 it 追加 (順序 `setSignals → close` / `setSignals` reject でも close と onClose / 見送り候補 / readable の無い候補)
- `tsc --noEmit` 0 / `vitest run` 1326 passed / coverage 100% (lines・branches)

## 実機確認 (マージ後)
Windows + Chrome で PWA を閉じて CoreS3 が再起動しない。VoiceS3R は PWA を閉じて 10〜15 秒で短い 2 連が鳴り始める (30 秒待たない)。

Refs ippoan/alc-app-s3#186, ippoan/alc-app-s3#135

🤖 Generated with [Claude Code](https://claude.com/claude-code)
