### PR TITLE
feat(cores3): CoreS3 セッションに 3 秒ごと HB OK を送る (Refs ippoan/alc-app-s3#187)

### DIFF
--- a/web/app/composables/useAlarmDevice.ts
+++ b/web/app/composables/useAlarmDevice.ts
@@ -42,7 +42,12 @@ const CLAIMANT_NAME = 'alarm-device'
 
 /** mount 直後は BLE ゲートウェイに先にポートを選ばせる (同居しない PC では 0 を渡す) */
 const INITIAL_SCAN_DELAY = 5000
-const HEARTBEAT_INTERVAL = 3000
+
+/**
+ * heartbeat の送信間隔。CoreS3 (useCoreS3Serial) も同じ間隔で `HB OK` を送るので
+ * ここを唯一の出どころにする — firmware 側の失効判定は両機とも同じ前提で組んである。
+ */
+export const HEARTBEAT_INTERVAL = 3000
 
 // シングルトン: 管理者 PC につながる警告デバイスは 1 台なので状態も 1 つ
 const isConnected = ref(false)

--- a/web/app/composables/useCoreS3Serial.ts
+++ b/web/app/composables/useCoreS3Serial.ts
@@ -7,6 +7,7 @@
  *
  * プロトコル (行指向 \n / ASCII / 115200 8N1):
  *   host → dev  `STATUS`                     … 機種判定のためのプローブ (arbiter が撃つ)
+ *   host → dev  `HB OK`                      … 3 秒ごと。CoreS3 は返信しない
  *   dev  → host `{"type":"ready",...}`       … BLE ゲートウェイの JSON メッセージ
  *   dev  → host `STATUS BOARD=cores3 ...`    … プローブへの応答 (名乗り)
  *   dev  → host `EVT <NAME> <args...>`       … NFC など状態遷移の通知
@@ -19,9 +20,16 @@
  *
  * ready まで無言のファームウェアが「無応答」で閉じられ続けないよう、JSON 行が
  * 先着したら `STATUS` の応答を待たずに claim する。
+ *
+ * 接続しているあいだは 3 秒ごとに `HB OK` を送る。CoreS3 は heartbeat が途切れたら
+ * 自分の判断で鳴るので、ブラウザは「鳴れ」と命令しない — タブを閉じた・別タブへ移った・
+ * PC がフリーズした、のいずれも「無音」という同じ形で拾える (Refs ippoan/alc-app-s3#187)。
+ * 送る中身は `HB OK` 固定: CoreS3 が見るのは「ブラウザの沈黙」だけで、着信の通知や
+ * signaling の生死は警告デバイス (useAlarmDevice) の役割のまま。
  */
 
 import type { SerialClaimant } from '~/composables/useSerialArbiter'
+import { HEARTBEAT_INTERVAL } from '~/composables/useAlarmDevice'
 import { writeLine } from '~/composables/useSerialArbiter'
 
 /** arbiter に登録する名前 */
@@ -50,6 +58,9 @@ const waiters = new Set<() => void>()
 
 /** 預かっているポートの writer (未接続なら null) */
 let held: WritableStreamDefaultWriter<Uint8Array> | null = null
+
+/** 走っている heartbeat のタイマー (未接続なら null) */
+let heartbeatTimer: ReturnType<typeof setInterval> | null = null
 
 /**
  * 行の接頭辞から素性を決める。
@@ -100,6 +111,22 @@ export function useCoreS3Serial() {
     // 'status' (名乗りそのもの) / 'alarm' / 'unknown' は捨てる
   }
 
+  // --- heartbeat ---
+
+  /** 接続直後に 1 回送ってから 3 秒ごと。firmware の初回武装を早めるため即時に 1 本目 */
+  function startHeartbeat(): void {
+    stopHeartbeat()
+    void write('HB OK')
+    heartbeatTimer = setInterval(() => { void write('HB OK') }, HEARTBEAT_INTERVAL)
+  }
+
+  function stopHeartbeat(): void {
+    if (heartbeatTimer) {
+      clearInterval(heartbeatTimer)
+      heartbeatTimer = null
+    }
+  }
+
   // --- claim を待つ ---
 
   /** 呼ぶ前に connect() が接続済みを弾いているので、ここは必ず未接続から始まる */
@@ -136,11 +163,13 @@ export function useCoreS3Serial() {
       for (const cb of [...openHandlers]) cb()
       for (const line of lines) handleLine(line)
       for (const notify of [...waiters]) notify()
+      startHeartbeat()
     },
 
     onLine: handleLine,
 
     onClose() {
+      stopHeartbeat()
       held = null
       isConnected.value = false
       for (const cb of [...closeHandlers]) cb()

--- a/web/tests/composables/useCoreS3Serial.test.ts
+++ b/web/tests/composables/useCoreS3Serial.test.ts
@@ -155,8 +155,8 @@ describe('useCoreS3Serial', () => {
 
       expect(await connect()).toBe(true)
       expect(core.isConnected.value).toBe(true)
-      // プローブの 8 秒窓を待っていない
-      expect(dev.writes).toEqual(['STATUS\n'])
+      // プローブの 8 秒窓を待っていない (`HB OK` は claim 直後の 1 本目)
+      expect(dev.writes).toEqual(['STATUS\n', 'HB OK\n'])
     })
 
     it('STATUS に BOARD=cores3 が含まれれば claim する', async () => {
@@ -309,7 +309,7 @@ describe('useCoreS3Serial', () => {
       await connectWithJson(dev)
 
       await expect(core.write('{"cmd":"reset"}')).resolves.toBe(true)
-      expect(dev.writes).toEqual(['STATUS\n', '{"cmd":"reset"}\n'])
+      expect(dev.writes).toEqual(['STATUS\n', 'HB OK\n', '{"cmd":"reset"}\n'])
     })
 
     it('未接続なら false (書きに行かない)', async () => {
@@ -327,6 +327,49 @@ describe('useCoreS3Serial', () => {
       await expect(core.write('{"cmd":"reset"}')).resolves.toBe(false)
       expect(core.isConnected.value).toBe(false)
       expect(dev.port.close).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  // ---------- heartbeat ----------
+
+  /**
+   * CoreS3 は heartbeat が途切れたら自分の判断で鳴る。送るのは `HB OK` 固定で、
+   * 着信や signaling の生死は警告デバイス側の役割 (Refs ippoan/alc-app-s3#187)。
+   */
+  describe('heartbeat', () => {
+    it('接続直後に 1 本、以後 3 秒ごとに HB OK を送る', async () => {
+      const dev = createMockPort()
+      await connectWithJson(dev)
+
+      // claim 直後の 1 本目 (firmware の初回武装を早める)
+      expect(dev.writes).toEqual(['STATUS\n', 'HB OK\n'])
+
+      await vi.advanceTimersByTimeAsync(3000)
+      expect(dev.writes).toEqual(['STATUS\n', 'HB OK\n', 'HB OK\n'])
+
+      await vi.advanceTimersByTimeAsync(3000)
+      expect(dev.writes.filter(line => line === 'HB OK\n')).toHaveLength(3)
+    })
+
+    it('ポートを返したら止まり、掴み直しても二重に走らない', async () => {
+      const dev = createMockPort()
+      await connectWithJson(dev)
+
+      await core.release()
+      const afterRelease = dev.writes.length
+      // 再スキャン (10 秒) の手前まで進めても沈黙している
+      await vi.advanceTimersByTimeAsync(9000)
+      expect(dev.writes.slice(afterRelease)).toEqual([])
+
+      // 登録は残っているので 10 秒後の再スキャンで掴み直す
+      dev.emit('{"type":"ready","version":"1.0.0"}\n')
+      await vi.advanceTimersByTimeAsync(1000)
+      expect(core.isConnected.value).toBe(true)
+
+      const afterReclaim = dev.writes.length
+      await vi.advanceTimersByTimeAsync(3000)
+      // 走っている heartbeat は 1 本だけ (前回のタイマーが残っていれば 2 本届く)
+      expect(dev.writes.slice(afterReclaim)).toEqual(['HB OK\n'])
     })
   })
 
@@ -438,6 +481,6 @@ describe('useCoreS3Serial', () => {
 
     // 探索 1 回。プローブは arbiter が撃つ
     expect(getPorts).toHaveBeenCalledTimes(1)
-    expect(dev.writes).toEqual(['STATUS\n'])
+    expect(dev.writes).toEqual(['STATUS\n', 'HB OK\n'])
   })
 })


### PR DESCRIPTION
## 何を
`useCoreS3Serial` が CoreS3 のポートを握っているあいだ、3 秒ごとに `HB OK` を送る。open 直後に 1 本、以後 `setInterval`、close で `clearInterval`。送信は既存の `write()` 経由 (書けなくなったときの release は既存経路)。間隔は警告デバイス側 `useAlarmDevice.ts` の `HEARTBEAT_INTERVAL` を `export` して共有 (新ファイル無し)。

## なぜ
CoreS3 にもブラウザの沈黙で鳴る警告を載せる (ippoan/alc-app-s3#187)。firmware 側は「初回 heartbeat を受けるまで鳴らない (武装方式)」で、武装後 10 秒途絶で短い 2 連を 5 秒ごとに鳴らす。ブラウザが先に heartbeat を送り始める必要があり、現行 firmware は `HB` を未対応コマンドとして捨てるので、この PR を先にマージして問題ない。

CoreS3 へ送るのは `HB OK` 固定。着信 (`call=1`) / `HB NG` は警告デバイス (VoiceS3R) の役割のままで、CoreS3 の警告は「ブラウザが居るか」だけを見る。`classify()` と `useSerialArbiter` は無変更。

## テスト
- `useCoreS3Serial.test.ts` に heartbeat の describe (接続直後 1 本 + 3 秒ごと / release 後は沈黙し、掴み直しても二重に走らない)
- `tsc --noEmit` 0 / `vitest run` 1324 passed / coverage 100% (`useCoreS3Serial.ts` `useAlarmDevice.ts` とも lines・branches)

## 実機確認
firmware 側 (ippoan/alc-app-s3#187) をユーザーが焼いた後に: PWA を閉じて 10〜15 秒で CoreS3 が短い 2 連を 5 秒ごとに鳴らす / PWA を開き直すと止まる。

Refs ippoan/alc-app-s3#187, ippoan/alc-app-s3#135

🤖 Generated with [Claude Code](https://claude.com/claude-code)
