### PR TITLE
fix(auth): 運行者端末では無操作ログアウトでページを離れず cookie だけ失効させる (Closes #189)

### DIFF
--- a/web/app/composables/useAuth.ts
+++ b/web/app/composables/useAuth.ts
@@ -41,6 +41,10 @@ export function useAuth() {
 
   const isAuthenticated = computed(() => !!accessToken.value)
   const isDeviceActivated = computed(() => !!deviceTenantId.value)
+  // 端末登録済みブラウザ (共用の運行者端末) の印。deviceTenantId は consumeAuthCookie が
+  // 全ログインユーザーに付けるため端末の判定には使えない。deviceId は実登録経路
+  // (activateDevice の第 2 引数) でしか入らない (Refs #189)。
+  const isDeviceRegistered = computed(() => !!deviceId.value)
 
   /** アプリ起動時に呼ぶ: cookie からログイン復元 + device 復元 + staging bypass */
   async function init() {
@@ -163,6 +167,12 @@ export function useAuth() {
     }
     inactivityTimerId = setTimeout(() => {
       console.log('[Auth] 5分間無操作のため自動ログアウト')
+      // 端末登録済みブラウザではページを離れない。フルページ遷移すると WebSerial が
+      // 閉じて警告デバイスへの heartbeat が切れ、沈黙として鳴ってしまう (Refs #189)。
+      if (isDeviceRegistered.value) {
+        void logoutInPlace()
+        return
+      }
       logout()
     }, INACTIVITY_TIMEOUT_MS)
   }
@@ -190,15 +200,57 @@ export function useAuth() {
     }
   }
 
-  /** ログアウト (端末の tenant_id は保持) */
-  function logout() {
-    // 無操作タイマー停止 + ローカル state クリア
+  /** client 側のログイン状態だけを消す (無操作タイマー停止 + state + refresh token)。
+   *  cookie とサーバ側セッションは触らない。logout / logoutInPlace の共通部分。 */
+  function clearClientSession() {
     stopInactivityWatch()
     accessToken.value = null
     user.value = null
-
     if (isClient) {
       localStorage.removeItem(REFRESH_TOKEN_KEY)
+    }
+  }
+
+  /**
+   * ページを離れずにログアウトする (端末登録済みブラウザの無操作 auto-logout、#189)。
+   * client 状態を消すだけでは logi_auth_token cookie が残り、次の 401 → refresh
+   * (refreshAccessToken → consumeAuthCookie) でセッションが復活してしまうため、
+   * cookie の失効まで行う。auth-worker /logout に Domain 付き / 無しの両 variant を
+   * 消させ (Domain/Path を client で推測しない)、併せて client 側でも上書きする。
+   * deviceId / deviceTenantId は保持する (端末登録は継続)。
+   */
+  async function logoutInPlace() {
+    const authWorker = (config.public.authWorkerUrl as string).replace(/\/$/, '')
+    try {
+      // no-cors のためレスポンスは読めない。Set-Cookie は反映される。
+      await fetch(`${authWorker}/logout`, {
+        credentials: 'include',
+        mode: 'no-cors',
+        keepalive: true,
+      })
+    }
+    catch { /* オフライン等。下の client 側上書きで cookie は落とす */ }
+    clearAuthCookieClientSide()
+    clearClientSession()
+  }
+
+  /** logi_auth_token を client 側でも失効させる。配布時の Domain (親ドメイン) 付きと
+   *  Domain 無しの 2 通りを書く (どちらで配布されたかは client から分からない)。 */
+  function clearAuthCookieClientSide() {
+    const base = 'logi_auth_token=; Max-Age=0; Path=/; Secure; SameSite=Lax'
+    document.cookie = base
+    const parentDomain = window.location.hostname.split('.').slice(1).join('.')
+    if (parentDomain) {
+      document.cookie = `${base}; Domain=.${parentDomain}`
+    }
+  }
+
+  /** ログアウト (端末の tenant_id は保持) */
+  function logout() {
+    // 無操作タイマー停止 + ローカル state クリア
+    clearClientSession()
+
+    if (isClient) {
       // #434: logi_auth_token cookie (Domain=.ippoan.org) のクリアと Google セッション
       // 破棄は auth-worker /logout に委譲する (rust は dumb backend で logout endpoint を
       // 持たない)。/logout 後は ?redirect_uri のログイン画面へ戻る。
@@ -378,6 +430,7 @@ export function useAuth() {
     deviceId: readonly(deviceId),
     deviceSettingsToken: readonly(deviceSettingsToken),
     isDeviceActivated,
+    isDeviceRegistered,
     init,
     loginWithGoogleRedirect,
     consumeAuthCookie,

--- a/web/tests/composables/useAuth.test.ts
+++ b/web/tests/composables/useAuth.test.ts
@@ -757,6 +757,145 @@ describe('useAuth', () => {
       vi.advanceTimersByTime(10 * 60 * 1000)
       // No error, nothing happens
     })
+
+    // --- 端末登録済みブラウザ (deviceId あり) はページを離れない (#189) ---
+
+    /** document.cookie を getter/setter で差し替え、書き込みを記録する。
+     *  Max-Age=0 の書き込みは実ブラウザ同様に cookie を消す。 */
+    function mockCookieJar(initial = '') {
+      const writes: string[] = []
+      let value = initial
+      Object.defineProperty(document, 'cookie', {
+        get: () => value,
+        set: (v: string) => {
+          writes.push(v)
+          value = /Max-Age=0/.test(v) ? '' : v
+        },
+        configurable: true,
+      })
+      return writes
+    }
+
+    /** window.location を差し替え、href への代入を記録する */
+    function mockLocationWithSpy(hostname = 'alc.example.com') {
+      const hrefSetter = vi.fn()
+      const originalLocation = window.location
+      Object.defineProperty(window, 'location', {
+        value: {
+          ...originalLocation,
+          origin: `https://${hostname}`,
+          hostname,
+          href: '',
+          set href(val: string) { hrefSetter(val) },
+        },
+        writable: true,
+        configurable: true,
+      })
+      restoreLocation = () => Object.defineProperty(window, 'location', {
+        value: originalLocation, writable: true, configurable: true,
+      })
+      return hrefSetter
+    }
+
+    it('stays on the page and expires the cookie when the device is registered', async () => {
+      const fakeJwt = createFakeJwtWithExp(defaultPayload, 3600)
+      const writes = mockCookieJar(`logi_auth_token=${fakeJwt}`)
+      const hrefSetter = mockLocationWithSpy()
+      mockFetch.mockResolvedValue({ ok: true })
+
+      const { useAuth } = await import('~/composables/useAuth')
+      const auth = useAuth()
+      auth.activateDevice('tenant-1', 'device-1')
+      auth.consumeAuthCookie()
+
+      expect(auth.isDeviceRegistered.value).toBe(true)
+      expect(auth.isAuthenticated.value).toBe(true)
+
+      vi.advanceTimersByTime(5 * 60 * 1000)
+
+      await vi.waitFor(() => {
+        expect(auth.isAuthenticated.value).toBe(false)
+      })
+      expect(auth.user.value).toBeNull()
+      // ページ遷移しない (WebSerial を閉じない)
+      expect(hrefSetter).not.toHaveBeenCalled()
+      // auth-worker /logout を cookie 付きで叩く
+      const [url, init] = mockFetch.mock.calls[0]
+      expect(url).toContain('/logout')
+      expect(init).toMatchObject({ credentials: 'include', mode: 'no-cors', keepalive: true })
+      // client 側でも Domain 付き / 無しの 2 通りを Max-Age=0 で上書き
+      const expiries = writes.filter(w => w.includes('logi_auth_token=;') && w.includes('Max-Age=0'))
+      expect(expiries).toHaveLength(2)
+      expect(expiries.some(w => !w.includes('Domain='))).toBe(true)
+      expect(expiries.some(w => w.includes('Domain=.example.com'))).toBe(true)
+      // 端末登録は継続
+      expect(auth.deviceId.value).toBe('device-1')
+      expect(auth.isDeviceActivated.value).toBe(true)
+    })
+
+    it('does not restore the session on a later refresh (cookie is gone)', async () => {
+      const fakeJwt = createFakeJwtWithExp(defaultPayload, 3600)
+      mockCookieJar(`logi_auth_token=${fakeJwt}`)
+      mockLocationWithSpy()
+      // /logout が失敗しても client 側の cookie 上書きで失効する
+      mockFetch.mockRejectedValue(new Error('offline'))
+
+      const { useAuth } = await import('~/composables/useAuth')
+      const auth = useAuth()
+      auth.activateDevice('tenant-1', 'device-1')
+      auth.consumeAuthCookie()
+
+      vi.advanceTimersByTime(5 * 60 * 1000)
+      await vi.waitFor(() => {
+        expect(auth.isAuthenticated.value).toBe(false)
+      })
+
+      // 401 → refresh → retry (api.ts) が来ても復活しない
+      await expect(auth.refreshAccessToken()).rejects.toThrow()
+      expect(auth.isAuthenticated.value).toBe(false)
+    })
+
+    it('writes only the Domain-less cookie on a single-label hostname', async () => {
+      const fakeJwt = createFakeJwtWithExp(defaultPayload, 3600)
+      const writes = mockCookieJar(`logi_auth_token=${fakeJwt}`)
+      mockLocationWithSpy('localhost')
+      mockFetch.mockResolvedValue({ ok: true })
+
+      const { useAuth } = await import('~/composables/useAuth')
+      const auth = useAuth()
+      auth.activateDevice('tenant-1', 'device-1')
+      auth.consumeAuthCookie()
+
+      vi.advanceTimersByTime(5 * 60 * 1000)
+      await vi.waitFor(() => {
+        expect(auth.isAuthenticated.value).toBe(false)
+      })
+
+      const expiries = writes.filter(w => w.includes('logi_auth_token=;') && w.includes('Max-Age=0'))
+      expect(expiries).toHaveLength(1)
+      expect(expiries[0]).not.toContain('Domain=')
+    })
+
+    it('still redirects to /logout when no device is registered', async () => {
+      const fakeJwt = createFakeJwtWithExp(defaultPayload, 3600)
+      setDocCookie(`logi_auth_token=${fakeJwt}`)
+
+      const { useAuth } = await import('~/composables/useAuth')
+      const auth = useAuth()
+      auth.consumeAuthCookie()
+
+      const hrefSetter = mockLocationWithSpy()
+      expect(auth.isDeviceRegistered.value).toBe(false)
+
+      vi.advanceTimersByTime(5 * 60 * 1000)
+
+      await vi.waitFor(() => {
+        expect(auth.isAuthenticated.value).toBe(false)
+      })
+      expect(hrefSetter).toHaveBeenCalledTimes(1)
+      expect(hrefSetter.mock.calls[0][0]).toContain('/logout?redirect_uri=')
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
   })
 
   describe('loginWithGoogleRedirect', () => {


### PR DESCRIPTION
## 何を
端末登録済みのブラウザ (`deviceId` あり = 運行者端末) では、5 分無操作の自動ログアウトで**ページを離れない**。client の管理者状態 (`accessToken` / `user` / refresh) を消し、cookie `logi_auth_token` を auth-worker `/logout` への `fetch` (credentials: include, no-cors, keepalive) とクライアント側の `Max-Age=0` 上書き (Domain 付き / 無し) の両方で失効させる。端末登録の無いブラウザは従来どおり `/logout?redirect_uri=` へ遷移。明示の「ログアウト」ボタンは変えない。

## なぜ
実機 (2026-09-09): 運行者端末で警告デバイスを WebSerial で接続したまま待機 → 5 分でフルページ遷移 → シリアルが閉じて heartbeat が止まり、VoiceS3R が鳴った (ippoan/alc-app-s3#135 の設計どおりの誤鳴動)。遷移する側を直す。
- 端末登録の印は `deviceId`。`deviceTenantId` は JWT の tenant_id から全ログインユーザーに付くので判定に使わない
- cookie を残すと `refreshAccessToken` (401 → refresh → retry) が cookie を読み直して管理者セッションが復活するので、失効は必須

## テスト
- `useAuth.test.ts` の inactivity auto-logout に 4 it (deviceId あり: token/user null・href 不変・fetch と cookie 書き込み / その後 refresh しても復活しない / 単一ラベル hostname / deviceId なし: 従来どおり遷移)
- `tsc --noEmit` 0 / `vitest run` 1333 passed / coverage 100% (`useAuth.ts` lines・branches)

## 実機確認 (マージ後)
運行者端末で警告デバイスを接続したまま 6 分放置 → ページそのまま・鳴らない・システム管理者タブは認証前に戻る。

Closes #189
Refs ippoan/alc-app-s3#135

🤖 Generated with [Claude Code](https://claude.com/claude-code)
