### PR TITLE
feat(auth): 端末登録済みブラウザの明示ログアウトで Google セッションも切る (window.open) (Closes #193)

### DIFF
--- a/web/app/composables/useAuth.ts
+++ b/web/app/composables/useAuth.ts
@@ -16,6 +16,12 @@ const DEVICE_TENANT_KEY = 'alc_device_tenant_id'
 const DEVICE_ID_KEY = 'alc_device_id'
 const DEVICE_SETTINGS_TOKEN_KEY = 'alc_device_settings_token'
 
+/** 共用の運行者端末から Google のブラウザセッションを切るために開く URL (#193)。
+ *  実測 (2026-09-09): `?continue=` で自ホストへ戻す経路は Google 所有ホスト以外 400、
+ *  ログイン時の `prompt=login` は Google が守らない。このURLを開くだけならその場で
+ *  サインアウトが成立するので、別タブで開いて戻りは期待しない。 */
+const GOOGLE_LOGOUT_URL = 'https://accounts.google.com/Logout'
+
 // シングルトン state (composable の外で定義して複数コンポーネント間で共有)
 const user = ref<AuthUser | null>(null)
 const accessToken = ref<string | null>(null)
@@ -99,7 +105,7 @@ export function useAuth() {
     }
   }
 
-  /** Google OAuth ログイン (Authorization Code Flow + prompt=login) */
+  /** Google OAuth ログイン (Authorization Code Flow) */
   function loginWithGoogleRedirect(redirectAfterLogin?: string): void {
     if (!isClient) return
     const callbackUrl = `${window.location.origin}/auth/callback`
@@ -251,6 +257,22 @@ export function useAuth() {
     clearClientSession()
 
     if (isClient) {
+      // 共用の運行者端末 (端末登録済みブラウザ) では Google のブラウザセッションも切る
+      // (#193)。切らないと「アカウントを選択」に管理者が残り、1 クリックで戻れてしまう。
+      // ★ await を挟まずクリックと同じ tick で呼ぶこと。ユーザー操作の中でしか
+      //   window.open は popup blocker を通らない (呼び出し側も同期呼び出しのまま)。
+      //   端末登録の無いブラウザ (管理者 PC) は従来どおり = Google の SSO を維持する。
+      if (isDeviceRegistered.value) {
+        let opened: Window | null = null
+        try {
+          opened = window.open(GOOGLE_LOGOUT_URL, '_blank', 'noopener,noreferrer')
+        }
+        catch { /* WebView 等で window.open 自体が使えない場合。下の warn に落とす */ }
+        if (!opened) {
+          console.warn('[Auth] Google のログアウトタブを開けませんでした')
+        }
+      }
+
       // #434: logi_auth_token cookie (Domain=.ippoan.org) のクリアと Google セッション
       // 破棄は auth-worker /logout に委譲する (rust は dumb backend で logout endpoint を
       // 持たない)。/logout 後は ?redirect_uri のログイン画面へ戻る。

--- a/web/tests/composables/useAuth.test.ts
+++ b/web/tests/composables/useAuth.test.ts
@@ -680,6 +680,79 @@ describe('useAuth', () => {
       const url = hrefSetter.mock.calls[0]?.[0] as string
       expect(url).toContain('/logout')
     })
+
+    // #193: 共用の運行者端末 (deviceId あり) では Google のブラウザセッションも切る
+    const GOOGLE_LOGOUT_URL = 'https://accounts.google.com/Logout'
+
+    it('opens the Google logout tab before redirecting when the device is registered', async () => {
+      const openSpy = vi.fn(() => ({} as Window))
+      vi.stubGlobal('open', openSpy)
+
+      const { useAuth } = await import('~/composables/useAuth')
+      const { activateDevice, logout } = useAuth()
+
+      activateDevice('tenant-abc', 'dev-1')
+      mockLocation()
+      logout()
+
+      // 別タブで Google の Logout を開く (戻りは期待しない)
+      expect(openSpy).toHaveBeenCalledWith(GOOGLE_LOGOUT_URL, '_blank', 'noopener,noreferrer')
+      // その後に auth-worker /logout へ遷移する (順序も担保。await を挟まないこと)
+      const url = hrefSetter.mock.calls[0]?.[0] as string
+      expect(url).toContain('/logout')
+      expect(url).toContain(`redirect_uri=${encodeURIComponent('https://example.com/login')}`)
+      expect(openSpy.mock.invocationCallOrder[0]!)
+        .toBeLessThan(hrefSetter.mock.invocationCallOrder[0]!)
+    })
+
+    it('does not touch the Google session on a browser without device registration', async () => {
+      const openSpy = vi.fn(() => ({} as Window))
+      vi.stubGlobal('open', openSpy)
+
+      const { useAuth } = await import('~/composables/useAuth')
+      const { activateDevice, logout } = useAuth()
+
+      // deviceId 無し = 管理者 PC。Google の SSO は維持する
+      activateDevice('tenant-abc')
+      mockLocation()
+      logout()
+
+      expect(openSpy).not.toHaveBeenCalled()
+      expect(hrefSetter.mock.calls[0]?.[0] as string).toContain('/logout')
+    })
+
+    it('warns and still redirects when the Google logout tab is blocked', async () => {
+      const openSpy = vi.fn(() => null)
+      vi.stubGlobal('open', openSpy)
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      const { useAuth } = await import('~/composables/useAuth')
+      const { activateDevice, logout } = useAuth()
+
+      activateDevice('tenant-abc', 'dev-1')
+      mockLocation()
+      logout()
+
+      expect(openSpy).toHaveBeenCalled()
+      expect(warnSpy).toHaveBeenCalled()
+      expect(hrefSetter.mock.calls[0]?.[0] as string).toContain('/logout')
+    })
+
+    it('warns and still redirects when window.open throws', async () => {
+      const openSpy = vi.fn(() => { throw new Error('not implemented') })
+      vi.stubGlobal('open', openSpy)
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      const { useAuth } = await import('~/composables/useAuth')
+      const { activateDevice, logout } = useAuth()
+
+      activateDevice('tenant-abc', 'dev-1')
+      mockLocation()
+      logout()
+
+      expect(warnSpy).toHaveBeenCalled()
+      expect(hrefSetter.mock.calls[0]?.[0] as string).toContain('/logout')
+    })
   })
 
   describe('inactivity auto-logout', () => {


### PR DESCRIPTION
## 何を
端末登録済みのブラウザ (`deviceId` あり = 運行者端末) で管理者が「ログアウト」を押したとき、auth-worker `/logout` への遷移の**前に同期的に** `window.open('https://accounts.google.com/Logout', '_blank', 'noopener,noreferrer')` を撃ち、Google のブラウザセッションも切る。失敗 (popup blocker の null / WebView の例外) は `console.warn` だけで従来どおり遷移。端末登録の無いブラウザ (管理者 PC) は 1 byte も変えない (SSO 維持)。無操作 5 分の自動ログアウト (#192) はユーザー操作が無いので対象外。

## なぜ
共用端末で管理者がログアウトしても Google の「アカウントを選択」に残り、1 クリックで管理者に戻れた (実機 2026-09-09)。ユーザー要件は「共用端末にアカウント情報を残さない」。

auth-worker 側の実測 (ippoan/auth-worker#511):
- Google は `prompt=login` を守らない (アカウント選択から再認証なしに完走)
- `accounts.google.com/Logout?continue=` は Google 所有ホスト以外 400、appengine 経由も「リダイレクトの警告」ページでクリック待ち → サーバ側の chain では自動で戻れない
- ただしサインアウト自体は `Logout` を開いた時点で成立する

⇒ ログアウトボタンのクリック (ユーザー操作) の中で別タブに開くのが、popup blocker に落ちず PWA 本体の遷移も壊さない唯一の形。`loginWithGoogleRedirect` の doc の「prompt=login」は #434 以前の名残なので削除 (挙動変更なし)。

## テスト
- `useAuth.test.ts` に 4 it (deviceId あり: open の引数と `location.href` より前の呼び出し順 / なし: open されない / open が null / open が throw)
- `tsc` 0 / `vitest run` 1339 passed / coverage 100% (`useAuth.ts` lines・branches)

## 実機確認 (マージ後)
運行者端末で管理者がログアウト → 別タブに Google の「ログアウトしました」、PWA は `/login`。次に「Google アカウントでログイン」を押すとアカウント選択が空 (メール / パスワードから)。管理者 PC は従来どおり。

Closes #193
Refs ippoan/auth-worker#511, ippoan/alc-app-s3#135

🤖 Generated with [Claude Code](https://claude.com/claude-code)
