### PR TITLE
fix(auth): Google サインアウトと無操作の在席ログアウトを端末登録の有無に関係なく全ブラウザで動かす (Closes #195)

### DIFF
--- a/web/app/composables/useAuth.ts
+++ b/web/app/composables/useAuth.ts
@@ -47,10 +47,6 @@ export function useAuth() {
 
   const isAuthenticated = computed(() => !!accessToken.value)
   const isDeviceActivated = computed(() => !!deviceTenantId.value)
-  // 端末登録済みブラウザ (共用の運行者端末) の印。deviceTenantId は consumeAuthCookie が
-  // 全ログインユーザーに付けるため端末の判定には使えない。deviceId は実登録経路
-  // (activateDevice の第 2 引数) でしか入らない (Refs #189)。
-  const isDeviceRegistered = computed(() => !!deviceId.value)
 
   /** アプリ起動時に呼ぶ: cookie からログイン復元 + device 復元 + staging bypass */
   async function init() {
@@ -173,13 +169,11 @@ export function useAuth() {
     }
     inactivityTimerId = setTimeout(() => {
       console.log('[Auth] 5分間無操作のため自動ログアウト')
-      // 端末登録済みブラウザではページを離れない。フルページ遷移すると WebSerial が
+      // どのブラウザでもページを離れない (#195)。フルページ遷移すると WebSerial が
       // 閉じて警告デバイスへの heartbeat が切れ、沈黙として鳴ってしまう (Refs #189)。
-      if (isDeviceRegistered.value) {
-        void logoutInPlace()
-        return
-      }
-      logout()
+      // 運行者端末が端末登録を通しているとは限らない (共用 PC は Google ログインのみ)
+      // ため、端末登録の有無で分けない。
+      void logoutInPlace()
     }, INACTIVITY_TIMEOUT_MS)
   }
 
@@ -218,7 +212,7 @@ export function useAuth() {
   }
 
   /**
-   * ページを離れずにログアウトする (端末登録済みブラウザの無操作 auto-logout、#189)。
+   * ページを離れずにログアウトする (無操作 auto-logout、#189, #195)。
    * client 状態を消すだけでは logi_auth_token cookie が残り、次の 401 → refresh
    * (refreshAccessToken → consumeAuthCookie) でセッションが復活してしまうため、
    * cookie の失効まで行う。auth-worker /logout に Domain 付き / 無しの両 variant を
@@ -257,20 +251,19 @@ export function useAuth() {
     clearClientSession()
 
     if (isClient) {
-      // 共用の運行者端末 (端末登録済みブラウザ) では Google のブラウザセッションも切る
-      // (#193)。切らないと「アカウントを選択」に管理者が残り、1 クリックで戻れてしまう。
+      // どのブラウザでも Google のブラウザセッションを切る (#193, #195)。切らないと
+      // 「アカウントを選択」に直前のユーザーが残り、1 クリックで戻れてしまう。共用の
+      // 運行者端末が端末登録を通しているとは限らない (共用 PC は Google ログインのみ)
+      // ため、端末登録の有無で分けない。管理者 PC でもサインアウトされる (許容)。
       // ★ await を挟まずクリックと同じ tick で呼ぶこと。ユーザー操作の中でしか
       //   window.open は popup blocker を通らない (呼び出し側も同期呼び出しのまま)。
-      //   端末登録の無いブラウザ (管理者 PC) は従来どおり = Google の SSO を維持する。
-      if (isDeviceRegistered.value) {
-        let opened: Window | null = null
-        try {
-          opened = window.open(GOOGLE_LOGOUT_URL, '_blank', 'noopener,noreferrer')
-        }
-        catch { /* WebView 等で window.open 自体が使えない場合。下の warn に落とす */ }
-        if (!opened) {
-          console.warn('[Auth] Google のログアウトタブを開けませんでした')
-        }
+      let opened: Window | null = null
+      try {
+        opened = window.open(GOOGLE_LOGOUT_URL, '_blank', 'noopener,noreferrer')
+      }
+      catch { /* WebView 等で window.open 自体が使えない場合。下の warn に落とす */ }
+      if (!opened) {
+        console.warn('[Auth] Google のログアウトタブを開けませんでした')
       }
 
       // #434: logi_auth_token cookie (Domain=.ippoan.org) のクリアと Google セッション
@@ -452,7 +445,6 @@ export function useAuth() {
     deviceId: readonly(deviceId),
     deviceSettingsToken: readonly(deviceSettingsToken),
     isDeviceActivated,
-    isDeviceRegistered,
     init,
     loginWithGoogleRedirect,
     consumeAuthCookie,

--- a/web/tests/composables/useAuth.test.ts
+++ b/web/tests/composables/useAuth.test.ts
@@ -45,6 +45,9 @@ vi.mock('~/utils/env', () => envMock)
 describe('useAuth', () => {
   beforeEach(async () => {
     vi.stubGlobal('fetch', mockFetch)
+    // logout() は端末登録の有無に関わらず window.open を呼ぶ (#195)。jsdom の未実装
+    // window.open を踏まないよう既定で無害な spy にしておく (個別テストは再 stub する)
+    vi.stubGlobal('open', vi.fn(() => ({} as Window)))
     vi.useFakeTimers()
     localStorage.clear()
     sessionStorage.clear()
@@ -681,17 +684,20 @@ describe('useAuth', () => {
       expect(url).toContain('/logout')
     })
 
-    // #193: 共用の運行者端末 (deviceId あり) では Google のブラウザセッションも切る
+    // #193, #195: どのブラウザでも Google のブラウザセッションを切る。運行者端末が
+    // 端末登録 (deviceId) を通しているとは限らないため、端末登録の有無で分けない
     const GOOGLE_LOGOUT_URL = 'https://accounts.google.com/Logout'
 
-    it('opens the Google logout tab before redirecting when the device is registered', async () => {
+    it('opens the Google logout tab before redirecting, registered or not', async () => {
       const openSpy = vi.fn(() => ({} as Window))
       vi.stubGlobal('open', openSpy)
 
       const { useAuth } = await import('~/composables/useAuth')
-      const { activateDevice, logout } = useAuth()
+      const { activateDevice, deviceId, logout } = useAuth()
 
-      activateDevice('tenant-abc', 'dev-1')
+      // (1) 端末登録の無いブラウザ (共用 PC は Google ログインのみ = deviceId 無し)
+      activateDevice('tenant-abc')
+      expect(deviceId.value).toBeNull()
       mockLocation()
       logout()
 
@@ -703,22 +709,16 @@ describe('useAuth', () => {
       expect(url).toContain(`redirect_uri=${encodeURIComponent('https://example.com/login')}`)
       expect(openSpy.mock.invocationCallOrder[0]!)
         .toBeLessThan(hrefSetter.mock.invocationCallOrder[0]!)
-    })
 
-    it('does not touch the Google session on a browser without device registration', async () => {
-      const openSpy = vi.fn(() => ({} as Window))
-      vi.stubGlobal('open', openSpy)
-
-      const { useAuth } = await import('~/composables/useAuth')
-      const { activateDevice, logout } = useAuth()
-
-      // deviceId 無し = 管理者 PC。Google の SSO は維持する
-      activateDevice('tenant-abc')
-      mockLocation()
+      // (2) 端末登録済みブラウザでも同じ挙動
+      activateDevice('tenant-abc', 'dev-1')
+      expect(deviceId.value).toBe('dev-1')
       logout()
 
-      expect(openSpy).not.toHaveBeenCalled()
-      expect(hrefSetter.mock.calls[0]?.[0] as string).toContain('/logout')
+      expect(openSpy).toHaveBeenCalledTimes(2)
+      expect(openSpy.mock.calls[1]).toEqual([GOOGLE_LOGOUT_URL, '_blank', 'noopener,noreferrer'])
+      expect(hrefSetter).toHaveBeenCalledTimes(2)
+      expect(hrefSetter.mock.calls[1]?.[0] as string).toContain('/logout')
     })
 
     it('warns and still redirects when the Google logout tab is blocked', async () => {
@@ -729,7 +729,7 @@ describe('useAuth', () => {
       const { useAuth } = await import('~/composables/useAuth')
       const { activateDevice, logout } = useAuth()
 
-      activateDevice('tenant-abc', 'dev-1')
+      activateDevice('tenant-abc')
       mockLocation()
       logout()
 
@@ -746,7 +746,7 @@ describe('useAuth', () => {
       const { useAuth } = await import('~/composables/useAuth')
       const { activateDevice, logout } = useAuth()
 
-      activateDevice('tenant-abc', 'dev-1')
+      activateDevice('tenant-abc')
       mockLocation()
       logout()
 
@@ -763,7 +763,14 @@ describe('useAuth', () => {
     function mockLocation() {
       const originalLocation = window.location
       Object.defineProperty(window, 'location', {
-        value: { ...originalLocation, origin: 'https://example.com', href: '', set href(_v: string) {} },
+        value: {
+          ...originalLocation,
+          origin: 'https://example.com',
+          // clearAuthCookieClientSide が Domain 決定に読む (spread では乗らない)
+          hostname: 'alc.example.com',
+          href: '',
+          set href(_v: string) {},
+        },
         writable: true,
         configurable: true,
       })
@@ -831,7 +838,7 @@ describe('useAuth', () => {
       // No error, nothing happens
     })
 
-    // --- 端末登録済みブラウザ (deviceId あり) はページを離れない (#189) ---
+    // --- 無操作 auto-logout はどのブラウザでもページを離れない (#189, #195) ---
 
     /** document.cookie を getter/setter で差し替え、書き込みを記録する。
      *  Max-Age=0 の書き込みは実ブラウザ同様に cookie を消す。 */
@@ -870,7 +877,7 @@ describe('useAuth', () => {
       return hrefSetter
     }
 
-    it('stays on the page and expires the cookie when the device is registered', async () => {
+    it('stays on the page and expires the cookie after inactivity', async () => {
       const fakeJwt = createFakeJwtWithExp(defaultPayload, 3600)
       const writes = mockCookieJar(`logi_auth_token=${fakeJwt}`)
       const hrefSetter = mockLocationWithSpy()
@@ -881,7 +888,6 @@ describe('useAuth', () => {
       auth.activateDevice('tenant-1', 'device-1')
       auth.consumeAuthCookie()
 
-      expect(auth.isDeviceRegistered.value).toBe(true)
       expect(auth.isAuthenticated.value).toBe(true)
 
       vi.advanceTimersByTime(5 * 60 * 1000)
@@ -949,25 +955,30 @@ describe('useAuth', () => {
       expect(expiries[0]).not.toContain('Domain=')
     })
 
-    it('still redirects to /logout when no device is registered', async () => {
+    it('behaves the same when no device is registered', async () => {
       const fakeJwt = createFakeJwtWithExp(defaultPayload, 3600)
-      setDocCookie(`logi_auth_token=${fakeJwt}`)
+      const writes = mockCookieJar(`logi_auth_token=${fakeJwt}`)
+      const hrefSetter = mockLocationWithSpy()
+      mockFetch.mockResolvedValue({ ok: true })
 
       const { useAuth } = await import('~/composables/useAuth')
       const auth = useAuth()
       auth.consumeAuthCookie()
 
-      const hrefSetter = mockLocationWithSpy()
-      expect(auth.isDeviceRegistered.value).toBe(false)
+      // 共用 PC は Google ログインのみ = deviceId 無し。それでも上の登録済みと同じ (#195)
+      expect(auth.deviceId.value).toBeNull()
 
       vi.advanceTimersByTime(5 * 60 * 1000)
 
       await vi.waitFor(() => {
         expect(auth.isAuthenticated.value).toBe(false)
       })
-      expect(hrefSetter).toHaveBeenCalledTimes(1)
-      expect(hrefSetter.mock.calls[0][0]).toContain('/logout?redirect_uri=')
-      expect(mockFetch).not.toHaveBeenCalled()
+      // ページ遷移しない
+      expect(hrefSetter).not.toHaveBeenCalled()
+      // auth-worker /logout を cookie 付きで叩き、client 側でも cookie を失効させる
+      expect(mockFetch.mock.calls[0][0]).toContain('/logout')
+      expect(writes.filter(w => w.includes('logi_auth_token=;') && w.includes('Max-Age=0')))
+        .toHaveLength(2)
     })
   })
 


### PR DESCRIPTION
## 何を
`logout()` の Google サインアウト (`window.open(accounts.google.com/Logout)`、#194) と、無操作 5 分の発火先 `logoutInPlace()` (ページを離れず cookie を失効、#192) を、**端末登録の有無 (`isDeviceRegistered` = `alc_device_id` あり) に関係なく全ブラウザで**動かす。無操作時の `logout()` 分岐と、使い道の無くなった `isDeviceRegistered` を削除。

## なぜ
実機 (2026-09-09、FE 0.0.80) で共用 PC (Windows + Chrome) のログアウトで Google のタブが開かなかった。`alc_device_id` が入るのは端末登録の claim / QR 承認か Android の Device Owner だけで、Google ログインしただけの共用 PC には入らない — 「運行者端末」の運用とアプリの「端末登録済み」が一致していなかった。要件「共用端末にアカウント情報を残さない」を優先し、管理者自身の PC でもログアウト時に Google からサインアウトされることは許容 (ユーザー確認済み)。

## テスト
- `useAuth.test.ts`: 登録の有無に関わらず `window.open` が開く 1 it に統合 / 無操作は未登録でも遷移せず `fetch(/logout)` + cookie 失効 / popup blocker・throw の 2 it は未登録で固定。`mockLocation` に example の hostname を明示
- `tsc` 0 / `vitest run` 1338 passed / coverage 100% (`useAuth.ts` lines・branches)

## 実機確認 (マージ後、PWA を再読み込み)
共用 PC でログアウト → 別タブに Google の「ログアウトしました」、次の Google ログインでアカウント選択が空。6 分放置 → ページはそのまま。

Closes #195
Refs #193, #189, ippoan/alc-app-s3#135

🤖 Generated with [Claude Code](https://claude.com/claude-code)
