### PR TITLE
fix(serial): close 前に RTS → DTR の順で個別に落とす (CoreS3 の再起動防止) (Closes #199)

### DIFF
--- a/web/app/composables/useSerialArbiter.ts
+++ b/web/app/composables/useSerialArbiter.ts
@@ -142,11 +142,21 @@ export async function writeLine(
 
 /**
  * ポートを閉じる。ESP32-S3 の USB-Serial-JTAG は「DTR=0 かつ RTS=1」で chip reset が
- * かかる (自動書き込み回路の模倣) ため、close の直前に DTR と RTS を両方落とす。
+ * かかる (自動書き込み回路の模倣) ため、close の直前に DTR と RTS を落とす。
  * S3 にはこれを無効化するレジスタが無く、firmware 側では直せない。
+ *
+ * **順序が本体** — RTS を先に落とさないと「DTR=0 かつ RTS=1」の瞬間ができて reset する。
+ * 1 回の `setSignals` に両方渡しても駄目で、OS/Chrome は DTR → RTS の順に個別に落とす
+ * (Windows は `EscapeCommFunction(CLRDTR)` → `CLRRTS`) ため、DTR が落ちた時点で RTS が
+ * まだ 1 のまま reset 条件を踏む。だから 2 回に分け、RTS → DTR の順で落とす
+ * (Refs ippoan/alc-app#199)。
+ *
+ * 各 `setSignals` は個別に try/catch する。setSignals 非対応のポート (古い Chrome /
+ * 一部ドライバ) で 1 つ目が throw しても、2 つ目と close は続ける。
  */
 async function closePortQuietly(port: SerialPort): Promise<void> {
-  try { await port.setSignals({ dataTerminalReady: false, requestToSend: false }) } catch { /* 非対応でも close は続ける */ }
+  try { await port.setSignals({ requestToSend: false }) } catch { /* 非対応でも次と close は続ける */ }
+  try { await port.setSignals({ dataTerminalReady: false }) } catch { /* 非対応でも close は続ける */ }
   await port.close()
 }
 

--- a/web/tests/composables/useSerialArbiter.test.ts
+++ b/web/tests/composables/useSerialArbiter.test.ts
@@ -6,7 +6,7 @@ import type { SerialClaimant } from '~/composables/useSerialArbiter'
 interface MockPortHandle {
   port: any
   writes: string[]
-  /** setSignals / close の呼び出し順 (ESP32-S3 のリセット回避の検証に使う) */
+  /** setSignals (引数つき) / close の呼び出し順 (ESP32-S3 のリセット回避の検証に使う) */
   calls: string[]
   /** デバイスからの受信行を流す (未読なら queue に積まれる) */
   emit: (text: string) => void
@@ -21,6 +21,8 @@ function createMockPort(options?: {
   writeError?: boolean
   /** setSignals 非対応のポート (古い Chrome / 一部ドライバ) を模す */
   signalsError?: boolean
+  /** 1 回目の setSignals (RTS) だけ失敗するポートを模す */
+  firstSignalsError?: boolean
 }): MockPortHandle {
   const queue: Array<{ value?: Uint8Array; done: boolean }> = []
   let pending: ((chunk: { value?: Uint8Array; done: boolean }) => void) | null = null
@@ -65,13 +67,17 @@ function createMockPort(options?: {
   }
 
   const calls: string[] = []
+  let signalsCalls = 0
   const port = {
     open: vi.fn(async () => {
       if (options?.openError) throw options.openError
     }),
-    setSignals: vi.fn(async (_signals: { dataTerminalReady?: boolean; requestToSend?: boolean }) => {
-      calls.push('setSignals')
+    setSignals: vi.fn(async (signals: { dataTerminalReady?: boolean; requestToSend?: boolean }) => {
+      signalsCalls += 1
+      // 引数まで記録する — RTS → DTR の順序が S3 のリセット回避の本体なので
+      calls.push(`setSignals(${JSON.stringify(signals)})`)
       if (options?.signalsError) throw new Error('setSignals unsupported')
+      if (options?.firstSignalsError && signalsCalls === 1) throw new Error('setSignals failed')
     }),
     close: vi.fn(async () => {
       calls.push('close')
@@ -263,7 +269,7 @@ describe('useSerialArbiter', () => {
       expect(other.port.open).toHaveBeenCalledTimes(1)
     })
 
-    it('見送った候補も DTR/RTS を落としてから閉じる (再訪のたびに再起動させない)', async () => {
+    it('見送った候補も RTS → DTR の順で落としてから閉じる (再訪のたびに再起動させない)', async () => {
       const other = createMockPort()
       other.emit('CORE LAN=up\n')
       installSerialMock({ getPorts: vi.fn(async () => [other.port]) })
@@ -274,7 +280,7 @@ describe('useSerialArbiter', () => {
       await vi.advanceTimersByTimeAsync(0)
 
       // BLE 相乗り中の CoreS3 が 10 秒ごとのプローブで毎回リセットされないこと
-      expect(other.calls).toEqual(['setSignals', 'close'])
+      expect(other.calls).toEqual(['setSignals({"requestToSend":false})', 'setSignals({"dataTerminalReady":false})', 'close'])
     })
 
     it('60 秒経ったら見送ったポートを再訪する (永久除外にしない)', async () => {
@@ -432,7 +438,7 @@ describe('useSerialArbiter', () => {
       expect(dev.port.open).toHaveBeenCalledTimes(2)
     })
 
-    it('close の前に DTR/RTS を落とす (ESP32-S3 を再起動させない)', async () => {
+    it('close の前に RTS → DTR の順で落とす (ESP32-S3 を再起動させない)', async () => {
       const dev = createMockPort()
       dev.emit('ALARM state=idle\n')
       installSerialMock({ getPorts: vi.fn(async () => [dev.port]) })
@@ -444,12 +450,11 @@ describe('useSerialArbiter', () => {
 
       await arbiter.release('alarm')
 
-      // DTR=0 かつ RTS=1 が S3 の chip reset の条件。両方落としてから閉じる
-      expect(dev.port.setSignals).toHaveBeenCalledWith({
-        dataTerminalReady: false,
-        requestToSend: false,
-      })
-      expect(dev.calls).toEqual(['setSignals', 'close'])
+      // DTR=0 かつ RTS=1 が S3 の chip reset の条件。RTS を先に落として
+      // その瞬間を作らない (同時指定では OS が DTR → RTS の順に落としてしまう)
+      expect(dev.port.setSignals).toHaveBeenNthCalledWith(1, { requestToSend: false })
+      expect(dev.port.setSignals).toHaveBeenNthCalledWith(2, { dataTerminalReady: false })
+      expect(dev.calls).toEqual(['setSignals({"requestToSend":false})', 'setSignals({"dataTerminalReady":false})', 'close'])
     })
 
     it('setSignals が失敗しても close は呼ぶ (非対応のポート)', async () => {
@@ -464,7 +469,26 @@ describe('useSerialArbiter', () => {
 
       await arbiter.release('alarm')
 
-      expect(dev.port.setSignals).toHaveBeenCalledTimes(1)
+      // 2 回とも throw しても close は呼ぶ
+      expect(dev.port.setSignals).toHaveBeenCalledTimes(2)
+      expect(dev.port.close).toHaveBeenCalledTimes(1)
+      expect(seen.closed).toBe(1)
+    })
+
+    it('RTS の setSignals が失敗しても DTR と close は続ける', async () => {
+      const dev = createMockPort({ firstSignalsError: true })
+      dev.emit('ALARM state=idle\n')
+      installSerialMock({ getPorts: vi.fn(async () => [dev.port]) })
+      await load()
+
+      const { claimant, seen } = createClaimant('ALARM', 'CORE')
+      arbiter.register('alarm', claimant)
+      await vi.advanceTimersByTimeAsync(0)
+
+      await arbiter.release('alarm')
+
+      // 1 つ目を個別に try/catch していないと DTR も close も飛ぶ
+      expect(dev.calls).toEqual(['setSignals({"requestToSend":false})', 'setSignals({"dataTerminalReady":false})', 'close'])
       expect(dev.port.close).toHaveBeenCalledTimes(1)
       expect(seen.closed).toBe(1)
     })
@@ -570,7 +594,7 @@ describe('useSerialArbiter', () => {
       expect(seen.opened).toBe(0)
     })
 
-    it('readable / writable が取れないポートも DTR/RTS を落としてから閉じる', async () => {
+    it('readable / writable が取れないポートも RTS → DTR の順で落としてから閉じる', async () => {
       const noRead = createMockPort({ readable: false })
       const noWrite = createMockPort({ writable: false })
       installSerialMock({ getPorts: vi.fn(async () => [noRead.port, noWrite.port]) })
@@ -580,8 +604,8 @@ describe('useSerialArbiter', () => {
       arbiter.register('alarm', claimant)
       await vi.advanceTimersByTimeAsync(0)
 
-      expect(noRead.calls).toEqual(['setSignals', 'close'])
-      expect(noWrite.calls).toEqual(['setSignals', 'close'])
+      expect(noRead.calls).toEqual(['setSignals({"requestToSend":false})', 'setSignals({"dataTerminalReady":false})', 'close'])
+      expect(noWrite.calls).toEqual(['setSignals({"requestToSend":false})', 'setSignals({"dataTerminalReady":false})', 'close'])
     })
 
     it('書き込めないポートでも、先に名乗り出があればそちらが勝つ', async () => {


### PR DESCRIPTION
## 何を
`useSerialArbiter.ts` の `closePortQuietly` を、`setSignals({ requestToSend: false })` → `setSignals({ dataTerminalReady: false })` → `close()` の 3 段に分ける。各 `setSignals` は個別に try/catch し、1 つ目が reject しても 2 つ目と `close()` は続ける。呼び出し口 2 か所 (`closeSession` / 見送り候補) と調停ロジックは触っていない。

## なぜ
#190 で DTR と RTS を同時に `setSignals` に渡したが、Windows + Chrome の実機 (FE v0.0.81) では PWA を閉じると CoreS3 がまだ再起動した。ESP32-S3 の USB-Serial-JTAG は「DTR=0 かつ RTS=1」の瞬間に chip reset がかかり、同時指定でも OS/Chrome は DTR → RTS の順に個別に落とすため、DTR を落とした瞬間に RTS がまだ 1 で reset 条件を踏む。RTS を先に落としてから DTR を落とせば、その組合せは一度も現れない。

再起動すると CoreS3 の「初回 HB で武装」した警告状態が消え、ブラウザ監視の警告が鳴らない (ippoan/alc-app-s3#187 の受け入れが通らない) — この順序がその根本。

## テスト
- `useSerialArbiter.test.ts`: mock の `setSignals` を引数つきで記録し、既存 4 it の順序 assert を `rts=false → dtr=false → close` の 3 段に更新。1 つ目の `setSignals` が reject しても 2 つ目と `close` が呼ばれる it を 1 本追加
- `tsc --noEmit` 0 / `vitest run` 52 files 1339 passed 2 skipped / coverage 100% (lines・branches)

## 実機確認 (マージ後、v0.0.82+ の PWA)
Windows + Chrome で PWA (NFC 待機中) を閉じて CoreS3 の画面が再起動しない → 10〜15 秒で CoreS3 が短い 2 連を鳴らす、タップで止まる。効かなければ次は firmware 側 (武装状態を NVS に残す、別 issue)。

Closes #199
Refs ippoan/alc-app-s3#186, ippoan/alc-app-s3#187, ippoan/alc-app-s3#135, #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)
