### PR TITLE
fix(alarm): 意図した reload では鳴らさない — reload 直前に HB grace=45 / 即再接続 / HB NG 15 秒デバウンス / 診断ログ (Closes #197, #198)

### DIFF
--- a/web/app/app.vue
+++ b/web/app/app.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { StagingFooter, VersionBadge } from '@ippoan/auth-client'
+import { RELOAD_REASON_KEY } from '~/utils/reload-reason'
 
 const { init, isLoading } = useAuth()
 const { isAndroidApp } = useFingerprint()
@@ -10,21 +11,42 @@ const stagingApiKey = config.public.stagingApiKey as string
 const appVersion = config.public.appVersion as string
 
 onMounted(async () => {
-  // --- リロード検知ログ ---
+  // --- リロード検知ログ (Refs #197) ---
+  // reason は plugins/reload-grace.client.ts が chunk 読み込み失敗の自動復旧 reload の直前に書く。
+  // 無ければ利用者の F5 か Chrome のメモリセーバー (タブ破棄 → 復帰は document.wasDiscarded)
   const now = Date.now()
   const navEntry = performance.getEntriesByType('navigation')[0] as PerformanceNavigationTiming | undefined
   const navType = navEntry?.type ?? 'unknown'
   const lastLoad = Number(sessionStorage.getItem('_lastLoad') || '0')
   const gap = lastLoad ? ((now - lastLoad) / 1000).toFixed(1) : null
   sessionStorage.setItem('_lastLoad', String(now))
+  const reason = sessionStorage.getItem(RELOAD_REASON_KEY) ?? 'unknown (user/memory-saver?)'
+  sessionStorage.removeItem(RELOAD_REASON_KEY)
+  const discarded = (document as Document & { wasDiscarded?: boolean }).wasDiscarded === true
   const ts = new Date().toLocaleTimeString('ja-JP')
+  const detail = `navType=${navType}, discarded=${discarded}, reason=${reason}`
   if (gap && Number(gap) < 10) {
-    console.warn(`[RELOAD-DETECT] ${ts} SUSPICIOUS RELOAD — last load was ${gap}s ago, navType=${navType}`)
+    console.warn(`[RELOAD-DETECT] ${ts} SUSPICIOUS RELOAD — last load was ${gap}s ago, ${detail}`)
   } else {
-    console.log(`[RELOAD-DETECT] ${ts} page loaded (gap=${gap ?? 'first'}s, navType=${navType})`)
+    console.log(`[RELOAD-DETECT] ${ts} page loaded (gap=${gap ?? 'first'}s, ${detail})`)
   }
+  const stamp = () => new Date().toLocaleTimeString('ja-JP')
   document.addEventListener('visibilitychange', () => {
-    console.log(`[RELOAD-DETECT] visibility=${document.visibilityState} at ${new Date().toLocaleTimeString('ja-JP')}`)
+    console.log(`[RELOAD-DETECT] visibility=${document.visibilityState} at ${stamp()}`)
+  })
+  // Page Lifecycle: freeze/resume はメモリセーバーの前段、pagehide/beforeunload は reload・閉じる
+  document.addEventListener('freeze', () => console.log(`[RELOAD-DETECT] freeze at ${stamp()}`))
+  document.addEventListener('resume', () => console.log(`[RELOAD-DETECT] resume at ${stamp()}`))
+  // 利用者の F5 / タブ閉じでも、握っている警告デバイス / CoreS3 へ grace を送っておく (best-effort。
+  // 書き込みが reload に間に合わないこともあるが、間に合えば 45 秒は鳴らない。Refs ippoan/alc-app-s3#192)
+  const alarm = useAlarmDevice()
+  window.addEventListener('pagehide', (e) => {
+    console.log(`[RELOAD-DETECT] pagehide persisted=${e.persisted} at ${stamp()}`)
+    alarm.notifyIntentionalReload()
+  })
+  window.addEventListener('beforeunload', () => {
+    console.log(`[RELOAD-DETECT] beforeunload at ${stamp()}`)
+    alarm.notifyIntentionalReload()
   })
 
   await init()

--- a/web/app/composables/useAlarmDevice.ts
+++ b/web/app/composables/useAlarmDevice.ts
@@ -14,22 +14,29 @@
  *   host → dev  `STATUS`                    … 機種判定のためのプローブ (arbiter が撃つ)
  *   dev  → host `STATUS alarm state=<idle|alarming|muted> cause=<none|silence|ng:<reason>|call> hb_age_ms=<n|-> VER=<ver>`
  *   dev  → host `EVT ALARM state=<...> cause=<...>` … 状態遷移のたび + 5 秒ごと無条件
- * 末尾トークン ` call=1` / ` call=0` は任意 (無ければ 0)。
+ * 末尾トークン ` call=1` / ` call=0` は任意 (無ければ 0)。` grace=<秒>` も任意 (下記)。
  *
  * 送る中身は useActiveRooms から組み立てる:
- *   room 一覧の購読 (WebSocket) が切れている → `HB NG signaling` (着信を受けられない)
- *   それ以外                                → `HB OK`
+ *   room 一覧の購読 (WebSocket) が 15 秒以上切れている → `HB NG signaling` (着信を受けられない)
+ *   それ以外                                          → `HB OK`
  *   room が立っていて管理者がまだどれにも入っていない → 末尾に ` call=1` (着信中)
+ *
+ * 意図した reload (chunk 読み込み失敗の自動復旧 / アプリ内の reload / 利用者の F5) では
+ * シリアルが閉じて heartbeat が途絶するが、鳴らさずに再接続を待ってほしい。reload の
+ * 直前に ` grace=45` 付きの heartbeat を 1 行送ると firmware はその 1 回だけ沈黙の猶予を
+ * 広げる (Refs ippoan/alc-app-s3#192)。呼び口は notifyIntentionalReload()。
  *
  * 機種識別を USB 記述子では行えない: CoreS3 の BLE ゲートウェイも VoiceS3R も
  * VID 0x303A / PID 0x1001 で同一。ポートの探索・open・`STATUS` プローブは
  * useSerialArbiter が 1 本で行い、ここは「`STATUS alarm` / `EVT ALARM` が来たら
  * 自分のものだ」と名乗り出る述語と、預かったポートの使い方だけを持つ
  * (Refs ippoan/alc-app#182)。
+ *
+ * 診断ログ (`[ALARM-DEV]`) は運行者端末の DevTools で読む用に出しっぱなし (Refs #197)。
  */
 
 import type { SerialClaimant } from '~/composables/useSerialArbiter'
-import { writeLine } from '~/composables/useSerialArbiter'
+import { msSinceLoad, writeLine } from '~/composables/useSerialArbiter'
 
 /** デバイスが報告する鳴動状態 */
 export interface AlarmDeviceState {
@@ -49,11 +56,43 @@ const INITIAL_SCAN_DELAY = 5000
  */
 export const HEARTBEAT_INTERVAL = 3000
 
+/**
+ * 意図した reload の直前に送る ` grace=<秒>`。firmware はこの 1 回だけ沈黙の猶予を
+ * 10 秒からこの秒数に広げる (Refs ippoan/alc-app-s3#192)。旧 firmware は ERR で捨てる (害なし)。
+ * CoreS3 (useCoreS3Serial) も同じ値を送るのでここを唯一の出どころにする。
+ */
+export const RELOAD_GRACE_SEC = 45
+
+/**
+ * 購読 (WebSocket) が切れてから `HB NG signaling` に切り替えるまでの猶予。
+ * WS の 3 秒再接続 (useActiveRooms) で鳴らさないため。沈黙の 10 秒より長いのは、
+ * 本当に切れていれば heartbeat 自体が NG で届き続けるため (Refs ippoan/alc-app#198)。
+ */
+export const NG_GRACE_MS = 15_000
+
+/**
+ * reload をまたいで「直前まで握っていた」ことを次の page load に伝える印 (sessionStorage)。
+ * onOpen で立て、disconnect() の明示切断で消す。connect() が読んだら消して即スキャンする。
+ */
+const RECONNECT_MARK_KEY = 'alarm_dev_connected'
+
 // シングルトン: 管理者 PC につながる警告デバイスは 1 台なので状態も 1 つ
 const isConnected = ref(false)
 const deviceState = ref<AlarmDeviceState | null>(null)
 
 let heartbeatTimer: ReturnType<typeof setInterval> | null = null
+/** 預かっているポートの writer (未接続なら null)。grace の送り先 */
+let held: WritableStreamDefaultWriter<Uint8Array> | null = null
+/** 購読が切れた時刻 (購読中は null)。NG_GRACE_MS の起点 */
+let ngSince: number | null = null
+/** 購読の監視を張ったか (アプリ全体で 1 本) */
+let ngWatchInstalled = false
+/** 直前に送った heartbeat の中身。変化したときだけログに出す */
+let lastLine: string | null = null
+
+function log(message: string): void {
+  console.log(`[ALARM-DEV] ${message} (+${msSinceLoad()}ms)`)
+}
 
 export function useAlarmDevice() {
   // ポートの探索と調停は arbiter に任せる (navigator.serial を自前で叩かない)
@@ -90,6 +129,21 @@ export function useAlarmDevice() {
 
   // --- heartbeat ---
 
+  /**
+   * 購読が切れた瞬間の時刻を覚える。heartbeat の周期 (3 秒) に丸めず切れた瞬間から
+   * 数えるため、送信側ではなく state の変化で取る。component の scope に縛られないよう
+   * 独立した effectScope に置く (呼び元の unmount で消えると数え直せなくなる)。
+   */
+  function installNgWatch(): void {
+    if (ngWatchInstalled) return
+    ngWatchInstalled = true
+    effectScope(true).run(() => {
+      watch(rooms.isWatching, (watching) => {
+        ngSince = watching ? null : Date.now()
+      }, { immediate: true, flush: 'sync' })
+    })
+  }
+
   function startHeartbeat(w: WritableStreamDefaultWriter<Uint8Array>): void {
     stopHeartbeat()
     void sendHeartbeat(w)
@@ -103,18 +157,41 @@ export function useAlarmDevice() {
     }
   }
 
-  /** 今の状態を 1 行に畳む。`HB OK` / `HB NG signaling` に着信中だけ ` call=1` を足す */
+  /**
+   * 今の状態を 1 行に畳む。`HB OK` / `HB NG signaling` に着信中だけ ` call=1` を足す。
+   * 購読が切れていても NG_GRACE_MS 経つまでは `HB OK` (復旧すれば即 `HB OK` に戻る)。
+   */
   function heartbeatLine(): string {
-    const status = rooms.isWatching.value ? 'HB OK' : 'HB NG signaling'
+    const ngFor = ngSince === null ? 0 : Date.now() - ngSince
+    const status = ngFor >= NG_GRACE_MS ? 'HB NG signaling' : 'HB OK'
     // room はあるが管理者がまだどれにも入っていない = 呼び出しに応答していない
     const calling = rooms.activeRooms.value.length > 0 && rooms.joinedRoomId.value === null
-    return calling ? `${status} call=1` : status
+    const line = calling ? `${status} call=1` : status
+    if (line !== lastLine) {
+      log(`heartbeat ${lastLine ?? '(start)'} -> ${line}`)
+      lastLine = line
+    }
+    return line
   }
 
   async function sendHeartbeat(w: WritableStreamDefaultWriter<Uint8Array>): Promise<void> {
     const ok = await writeLine(w, heartbeatLine())
     // 書けなくなった = 抜線・クラッシュ → ポートを返して掴み直しへ
-    if (!ok) await arbiter.release(CLAIMANT_NAME)
+    if (!ok) {
+      console.warn(`[ALARM-DEV] heartbeat write failed -> release port (+${msSinceLoad()}ms)`)
+      await arbiter.release(CLAIMANT_NAME)
+    }
+  }
+
+  /**
+   * 接続中なら今の heartbeat に ` grace=45` を足した 1 行を送る。await しない・失敗は握る
+   * (reload の直前なので、ポートを返す後始末は要らない)。送ったら true
+   */
+  function sendGrace(): boolean {
+    if (!held) return false
+    void writeLine(held, `${heartbeatLine()} grace=${RELOAD_GRACE_SEC}`)
+    log(`sent grace=${RELOAD_GRACE_SEC}`)
+    return true
   }
 
   // --- arbiter に預ける述語とハンドラ ---
@@ -124,7 +201,10 @@ export function useAlarmDevice() {
     reject: lines => lines.some(line => classify(line) === 'other'),
 
     onOpen(_port, _reader, w, lines) {
+      held = w
       isConnected.value = true
+      sessionStorage.setItem(RECONNECT_MARK_KEY, '1')
+      log(`claimed port (probe lines=${lines.length})`)
       // プローブ中に来ていた行 (名乗り出た根拠) をここで畳む
       for (const line of lines) handleLine(line)
       startHeartbeat(w)
@@ -133,9 +213,12 @@ export function useAlarmDevice() {
     onLine: handleLine,
 
     onClose() {
+      held = null
+      lastLine = null
       isConnected.value = false
       deviceState.value = null
       stopHeartbeat()
+      log('port closed')
     },
   }
 
@@ -144,11 +227,17 @@ export function useAlarmDevice() {
   /**
    * 探索を始める。`delay` ミリ秒待って最初のスキャン、以後 10 秒ごとに再スキャン。
    * BLE ゲートウェイと同居しない管理者 PC では 0 を渡してすぐ探してよい。
+   * reload の直前まで握っていた印 (sessionStorage) があれば delay を待たず即スキャンする。
    */
   function connect(delay = INITIAL_SCAN_DELAY): void {
     if (!isSupported) return
+    installNgWatch()
+    const resumed = sessionStorage.getItem(RECONNECT_MARK_KEY) === '1'
+    sessionStorage.removeItem(RECONNECT_MARK_KEY)
+    const scanDelay = resumed ? 0 : delay
+    log(`connect(delay=${scanDelay}${resumed ? ', resumed after reload' : ''})`)
     arbiter.register(CLAIMANT_NAME, claimant)
-    arbiter.start(delay)
+    arbiter.start(scanDelay)
   }
 
   /**
@@ -160,8 +249,21 @@ export function useAlarmDevice() {
     if (granted) connect(0)
   }
 
+  /** 明示的な切断。再接続の印も消す (次の page load で即スキャンしない) */
   async function disconnect(): Promise<void> {
+    log('disconnect()')
+    sessionStorage.removeItem(RECONNECT_MARK_KEY)
     await arbiter.unregister(CLAIMANT_NAME)
+  }
+
+  /**
+   * 意図した reload の直前に呼ぶ。握っている警告デバイスと CoreS3 の両方へ
+   * ` grace=45` 付きの heartbeat を送り、reload 中の沈黙で鳴らさないよう頼む。
+   * 何も握っていなければ何もしない。await しない (reload を止めない)。
+   */
+  function notifyIntentionalReload(): void {
+    sendGrace()
+    useCoreS3Serial().sendGrace()
   }
 
   return {
@@ -171,5 +273,6 @@ export function useAlarmDevice() {
     connect,
     disconnect,
     requestPort,
+    notifyIntentionalReload,
   }
 }

--- a/web/app/composables/useCoreS3Serial.ts
+++ b/web/app/composables/useCoreS3Serial.ts
@@ -26,10 +26,13 @@
  * PC がフリーズした、のいずれも「無音」という同じ形で拾える (Refs ippoan/alc-app-s3#187)。
  * 送る中身は `HB OK` 固定: CoreS3 が見るのは「ブラウザの沈黙」だけで、着信の通知や
  * signaling の生死は警告デバイス (useAlarmDevice) の役割のまま。
+ * 意図した reload の直前だけ `HB OK grace=45` を 1 行送り、その 1 回の沈黙の猶予を
+ * 広げてもらう (sendGrace、呼び口は useAlarmDevice.notifyIntentionalReload。
+ * Refs ippoan/alc-app-s3#192)。
  */
 
 import type { SerialClaimant } from '~/composables/useSerialArbiter'
-import { HEARTBEAT_INTERVAL } from '~/composables/useAlarmDevice'
+import { HEARTBEAT_INTERVAL, RELOAD_GRACE_SEC } from '~/composables/useAlarmDevice'
 import { writeLine } from '~/composables/useSerialArbiter'
 
 /** arbiter に登録する名前 */
@@ -125,6 +128,14 @@ export function useCoreS3Serial() {
       clearInterval(heartbeatTimer)
       heartbeatTimer = null
     }
+  }
+
+  /**
+   * 意図した reload の直前に `HB OK grace=45` を 1 行送る。未接続なら何もしない。
+   * await しない (reload を止めない)。旧 firmware は ERR で捨てるだけ (害なし)
+   */
+  function sendGrace(): void {
+    void write(`HB OK grace=${RELOAD_GRACE_SEC}`)
   }
 
   // --- claim を待つ ---
@@ -243,6 +254,7 @@ export function useCoreS3Serial() {
     onOpen,
     onClose,
     write,
+    sendGrace,
     connect,
     requestPort,
     release,

--- a/web/app/composables/useSerialArbiter.ts
+++ b/web/app/composables/useSerialArbiter.ts
@@ -20,6 +20,10 @@
  *
  * ポートの列挙と許可は useSerialDeviceManager に任せる (navigator.serial を自前で
  * 叩かない)。
+ *
+ * 診断ログ (`[SERIAL]`、Refs ippoan/alc-app#197): scan の開始 / セッションを閉じた理由 /
+ * 60 秒再訪は常時。候補ごとの claim・見送り・open 失敗は本番のノイズになるので
+ * `localStorage.alc_debug_serial=1` の端末だけ。
  */
 
 import { isWebSerialSupported } from '~/utils/webserial'
@@ -62,6 +66,22 @@ const PROBE_MAX_SENDS = 8
 const PROBE_TIMEOUT = 8000
 /** 誰も名乗り出なかったポートを再訪するまでの間隔 (永久除外はしない) */
 const PASS_OVER_COOLDOWN = 60000
+/** これが '1' の端末だけ候補ごとの `[SERIAL]` ログを出す */
+const DEBUG_KEY = 'alc_debug_serial'
+
+/** page load からの経過 ms (診断ログ用。再接続に何秒かかったかを読むため) */
+export function msSinceLoad(): number {
+  return Math.round(performance.now())
+}
+
+function log(message: string): void {
+  console.log(`[SERIAL] ${message} (+${msSinceLoad()}ms)`)
+}
+
+/** 候補ごとの行。`localStorage.alc_debug_serial=1` のときだけ出す */
+function debug(message: string): void {
+  if (localStorage.getItem(DEBUG_KEY) === '1') log(message)
+}
 
 /**
  * ポートを使う側。プロトコルの解釈はすべてこちら側の知識。
@@ -183,12 +203,13 @@ export function useSerialArbiter() {
 
   // --- ストリーム ---
 
-  async function closeSession(s: PortSession): Promise<void> {
+  async function closeSession(s: PortSession, reason: string): Promise<void> {
     // 受信ループの finally が二重に release を呼ばないよう、先に持ち主を落とす
     const owner = s.owner
     s.owner = null
     s.active = false
     sessions.delete(s)
+    log(`close ${owner ? `port of ${owner.name}` : 'probed port'}: ${reason}`)
     try { s.writer.releaseLock() } catch {}
     try { await s.reader.cancel() } catch {}
     try { s.reader.releaseLock() } catch {}
@@ -300,10 +321,12 @@ export function useSerialArbiter() {
     }
     catch {
       // InvalidStateError = 他の探索者が使用中 → 印を残さず次の候補へ
+      debug('open failed (in use by another explorer?) -> next candidate')
       return
     }
 
     if (!candidate.readable || !candidate.writable) {
+      debug('no readable/writable stream -> close')
       try { await closePortQuietly(candidate) } catch {}
       return
     }
@@ -322,6 +345,7 @@ export function useSerialArbiter() {
     const owner = await probe(s)
 
     if (owner) {
+      debug(`claimed by ${owner.name} (probe lines=${s.lines.length})`)
       s.owner = owner
       held.set(owner.name, s)
       owner.claimant.onOpen(s.port, s.reader, s.writer, s.lines)
@@ -331,8 +355,14 @@ export function useSerialArbiter() {
     // 応答はあったが誰も名乗り出なかった → 60 秒おいて再訪する (永久除外にはしない)。
     // 無応答 (行が 1 つも来なかった) は印を残さない: open のリセットで返事が遅れた
     // だけかもしれないため
-    if (s.lines.length > 0) passedOver.set(candidate, Date.now())
-    await closeSession(s)
+    if (s.lines.length > 0) {
+      passedOver.set(candidate, Date.now())
+      debug(`passed over (nobody claimed ${s.lines.length} lines) -> revisit in ${PASS_OVER_COOLDOWN / 1000}s`)
+      await closeSession(s, 'passed over')
+      return
+    }
+    debug('no response within probe window -> retry next scan')
+    await closeSession(s, 'no response')
   }
 
   // --- 探索 ---
@@ -342,6 +372,7 @@ export function useSerialArbiter() {
     if (passedAt === undefined) return true
     if (Date.now() - passedAt < PASS_OVER_COOLDOWN) return false
     passedOver.delete(port)
+    log('revisiting a passed-over port (cooldown elapsed)')
     return true
   }
 
@@ -350,6 +381,8 @@ export function useSerialArbiter() {
     scanning = true
     try {
       await refreshPorts()
+      const candidates = ports.value.filter(entry => entry.info.usbVendorId === ARBITRATED_VID).length
+      log(`scan start: candidates=${candidates} pending=${pending().map(([name]) => name).join(',')}`)
       for (const entry of ports.value) {
         if (entry.info.usbVendorId !== ARBITRATED_VID) continue
         // ports は ref 越しなのでプロキシが刺さる。他の探索者
@@ -388,7 +421,7 @@ export function useSerialArbiter() {
     const s = held.get(name)
     if (s) {
       held.delete(name)
-      await closeSession(s)
+      await closeSession(s, `unregister(${name})`)
     }
     if (claimants.size === 0 && scanTimer) {
       clearTimeout(scanTimer)
@@ -401,7 +434,7 @@ export function useSerialArbiter() {
     const s = held.get(name)
     if (!s) return
     held.delete(name)
-    await closeSession(s)
+    await closeSession(s, `release(${name})`)
     scheduleScan(RESCAN_INTERVAL)
   }
 

--- a/web/app/pages/index.vue
+++ b/web/app/pages/index.vue
@@ -204,7 +204,12 @@ onUnmounted(() => document.removeEventListener('click', onClickOutside))
 // 同タブ再クリックで再認証させるためのキー
 const managerAuthKey = ref(0)
 const adminAuthKey = ref(0)
-function reloadPage() { window.location.reload() }
+// reload の直前に警告デバイス / CoreS3 へ grace を送り、再接続までの沈黙で鳴らさない (Refs ippoan/alc-app-s3#192)
+const alarmDevice = useAlarmDevice()
+function reloadPage() {
+  alarmDevice.notifyIntentionalReload()
+  window.location.reload()
+}
 function onRoleTabClick(role: RoleTab) {
   if (activeRole.value === role) {
     if (role === 'manager') managerAuthKey.value++

--- a/web/app/plugins/reload-grace.client.ts
+++ b/web/app/plugins/reload-grace.client.ts
@@ -1,0 +1,65 @@
+/**
+ * chunk 読み込み失敗の自動復旧 reload の直前に、警告デバイス / CoreS3 へ ` grace=45` 付きの
+ * heartbeat を送り、reload の理由を sessionStorage に残す
+ * (Refs ippoan/alc-app#197, ippoan/alc-app-s3#192)。
+ *
+ * 実際に reload するのは `@ippoan/auth-client/module` が注入する chunkReload plugin
+ * (Refs ippoan/auth-worker#452)。あちらは `app:chunkError` hook と window の
+ * `vite:preloadError` / `unhandledrejection` の 3 入口から同じ `recover()` に入り、失敗した
+ * chunk を `fetch(url, { cache: 'reload' })` で取り直してから `location.reload()` する。
+ * Nuxt の hook は登録順に直列で呼ばれ、window のリスナーも登録順なので `enforce: 'pre'` で
+ * あちらより先に登録する。仮に後になっても、あちらは取り直しの fetch を await してから
+ * reload するので、同期的に書き込むここは間に合う。
+ *
+ * 理由は `app.vue` の `[RELOAD-DETECT] page loaded … reason=<理由>` が起動時に読んで消す。
+ * 理由が残っていない reload は利用者の F5 か Chrome のメモリセーバー (`document.wasDiscarded`)。
+ */
+
+import { RELOAD_REASON_KEY } from '~/utils/reload-reason'
+
+/** unknown なエラー値から message 相当の文字列を取り出す */
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message
+  if (typeof error === 'string') return error
+  return ''
+}
+
+/**
+ * chunk 読み込み失敗が原因の reject か。`unhandledrejection` は無関係な reject も拾うので、
+ * この入口だけ判定を通す (chunkReload plugin と同じ 3 文言)
+ */
+export function isChunkLoadError(message: string): boolean {
+  return message.includes('dynamically imported module')
+    || message.includes('Importing a module script failed')
+    || message.includes('Loading chunk')
+}
+
+/** 失敗した chunk の URL (無ければ message の先頭) */
+function describeChunkError(message: string): string {
+  return message.match(/https?:\/\/[^\s'"()]+\.(?:m?js|css)/)?.[0] ?? message.slice(0, 120)
+}
+
+export default defineNuxtPlugin({
+  name: 'reload-grace',
+  enforce: 'pre',
+  setup(nuxtApp) {
+    function beforeRecoveryReload(kind: string, error: unknown): void {
+      const detail = describeChunkError(errorMessage(error))
+      const at = new Date().toLocaleTimeString('ja-JP')
+      sessionStorage.setItem(RELOAD_REASON_KEY, `${kind} ${detail} at ${at}`)
+      console.warn(`[RELOAD-DETECT] ${at} ${kind}: ${detail} -> sending grace before auto-recovery reload`)
+      // event handler の中では Nuxt の context が無いので明示的に載せる
+      void nuxtApp.runWithContext(() => useAlarmDevice().notifyIntentionalReload())
+    }
+
+    nuxtApp.hook('app:chunkError', ({ error }) => beforeRecoveryReload('chunkError', error))
+
+    window.addEventListener('vite:preloadError', (event) => {
+      beforeRecoveryReload('vite:preloadError', (event as Event & { payload?: unknown }).payload)
+    })
+
+    window.addEventListener('unhandledrejection', (event) => {
+      if (isChunkLoadError(errorMessage(event.reason))) beforeRecoveryReload('unhandledrejection', event.reason)
+    })
+  },
+})

--- a/web/app/utils/reload-reason.ts
+++ b/web/app/utils/reload-reason.ts
@@ -1,0 +1,7 @@
+/**
+ * reload の理由の置き場 (sessionStorage の key)。
+ *
+ * 書くのは plugins/reload-grace.client.ts (chunk 読み込み失敗の自動復旧 reload の直前)、
+ * 読んで消すのは app.vue の `[RELOAD-DETECT] page loaded … reason=<理由>` (Refs ippoan/alc-app#197)。
+ */
+export const RELOAD_REASON_KEY = 'reload_reason'

--- a/web/coverage_100.toml
+++ b/web/coverage_100.toml
@@ -122,6 +122,12 @@ branches = true
 path = "app/composables/useCoreS3Serial.ts"
 branches = true
 
+# --- plugins ---
+
+[[files]]
+path = "app/plugins/reload-grace.client.ts"
+branches = true
+
 # --- middleware ---
 
 [[files]]
@@ -168,4 +174,8 @@ branches = true
 
 [[files]]
 path = "app/utils/webserial.ts"
+branches = true
+
+[[files]]
+path = "app/utils/reload-reason.ts"
 branches = true

--- a/web/tests/composables/useAlarmDevice.test.ts
+++ b/web/tests/composables/useAlarmDevice.test.ts
@@ -127,8 +127,14 @@ describe('useAlarmDevice', () => {
     alarm = mod.useAlarmDevice()
   }
 
+  let logSpy: ReturnType<typeof vi.spyOn>
+
   beforeEach(async () => {
     vi.clearAllMocks()
+    // 診断ログ ([ALARM-DEV] / [SERIAL]) はテスト出力に流さない。中身を見るテストは logSpy を読む
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    // 再接続の印は reload をまたぐ想定 (sessionStorage) なのでテスト間で持ち越さない
+    sessionStorage.clear()
     // 見送ったポートの再訪判定が Date.now() を見るので Date も止める
     vi.useFakeTimers({ toFake: ['setTimeout', 'setInterval', 'clearTimeout', 'clearInterval', 'Date'] })
     delete (navigator as any).serial
@@ -138,7 +144,16 @@ describe('useAlarmDevice', () => {
     await alarm?.disconnect()
     delete (navigator as any).serial
     vi.useRealTimers()
+    logSpy.mockRestore()
   })
+
+  /** `[ALARM-DEV] …` のログだけ (prefix と末尾の経過 ms を落とした本文) */
+  function alarmLogs(): string[] {
+    return logSpy.mock.calls
+      .map(args => String(args[0]))
+      .filter(line => line.startsWith('[ALARM-DEV] '))
+      .map(line => line.replace('[ALARM-DEV] ', '').replace(/ \(\+\d+ms\)$/, ''))
+  }
 
   // ---------- isSupported ----------
 
@@ -420,6 +435,7 @@ describe('useAlarmDevice', () => {
         'disconnect',
         'isConnected',
         'isSupported',
+        'notifyIntentionalReload',
         'requestPort',
       ])
     })
@@ -530,17 +546,65 @@ describe('useAlarmDevice', () => {
       expect(dev.writes).toHaveLength(4)
     })
 
-    it('room 購読が切れているとき HB NG signaling を送る', async () => {
+    it('room 購読が切れても 15 秒までは HB OK、超えたら HB NG signaling、復旧で即 HB OK (#198)', async () => {
       const dev = await connectDevice()
+      const before = dev.writes.length
       setRooms({ watching: false })
 
-      await vi.advanceTimersByTimeAsync(3000)
+      // WS の 3 秒再接続の窓では鳴らさない — 14 秒までの heartbeat は全部 OK
+      await vi.advanceTimersByTimeAsync(14000)
+      expect(dev.writes.slice(before)).toEqual(['HB OK\n', 'HB OK\n', 'HB OK\n', 'HB OK\n'])
+
+      // 15 秒を超えた最初の heartbeat から NG
+      await vi.advanceTimersByTimeAsync(2000)
       expect(dev.writes.at(-1)).toBe('HB NG signaling\n')
 
-      // 張り直せたら OK に戻る
+      // 張り直せたら次の heartbeat で即 OK に戻る
       setRooms({ watching: true })
       await vi.advanceTimersByTimeAsync(3000)
       expect(dev.writes.at(-1)).toBe('HB OK\n')
+    })
+
+    it('購読が切れた瞬間から数える (heartbeat の周期に丸めない)', async () => {
+      const dev = await connectDevice()
+      // 直前の heartbeat (5000ms) の 1 秒後に切れる → 15 秒後 = 21000ms。heartbeat は 20000 / 23000
+      await vi.advanceTimersByTimeAsync(1000)
+      setRooms({ watching: false })
+
+      await vi.advanceTimersByTimeAsync(14000) // 20000ms: 切れてから 14 秒
+      expect(dev.writes.at(-1)).toBe('HB OK\n')
+      await vi.advanceTimersByTimeAsync(3000) // 23000ms: 切れてから 17 秒
+      expect(dev.writes.at(-1)).toBe('HB NG signaling\n')
+    })
+
+    it('購読が開く前に接続しても、connect() から 15 秒までは HB OK', async () => {
+      const dev = createMockPort()
+      dev.emit('EVT ALARM state=idle cause=none\n')
+      installSerialMock({ getPorts: vi.fn(async () => [dev.port]) })
+      await load()
+      setRooms({ watching: false })
+      alarm.connect() // 0ms: ここから数え始める
+      await vi.advanceTimersByTimeAsync(5000) // claim + 1 本目
+      expect(dev.writes.at(-1)).toBe('HB OK\n')
+
+      await vi.advanceTimersByTimeAsync(9000) // 14000ms
+      expect(dev.writes.at(-1)).toBe('HB OK\n')
+      await vi.advanceTimersByTimeAsync(3000) // 17000ms
+      expect(dev.writes.at(-1)).toBe('HB NG signaling\n')
+    })
+
+    it('heartbeat の中身は変化したときだけログに出す', async () => {
+      const dev = await connectDevice()
+      await vi.advanceTimersByTimeAsync(6000)
+      expect(dev.writes.filter(w => w === 'HB OK\n')).toHaveLength(3)
+      expect(alarmLogs().filter(l => l.startsWith('heartbeat'))).toEqual(['heartbeat (start) -> HB OK'])
+
+      setRooms({ rooms: ['room-a'] })
+      await vi.advanceTimersByTimeAsync(3000)
+      expect(alarmLogs().filter(l => l.startsWith('heartbeat'))).toEqual([
+        'heartbeat (start) -> HB OK',
+        'heartbeat HB OK -> HB OK call=1',
+      ])
     })
 
     it('room が立っていて管理者が未参加なら call=1 を付ける', async () => {
@@ -570,19 +634,25 @@ describe('useAlarmDevice', () => {
       expect(dev.writes.at(-1)).toBe('HB OK\n')
     })
 
-    it('購読が切れていても着信中なら call=1 は付く', async () => {
+    it('購読が切れていても着信中なら call=1 は付く (猶予中も、NG になっても)', async () => {
       const dev = await connectDevice()
       setRooms({ watching: false, rooms: ['room-a'] })
 
       await vi.advanceTimersByTimeAsync(3000)
+      expect(dev.writes.at(-1)).toBe('HB OK call=1\n')
+
+      await vi.advanceTimersByTimeAsync(15000)
       expect(dev.writes.at(-1)).toBe('HB NG signaling call=1\n')
     })
 
-    it('write に失敗したら後始末して再スキャンへ', async () => {
+    it('write に失敗したら console.warn して後始末し、再スキャンへ', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
       const dev = await connectDevice()
       dev.setWriteError(true)
 
       await vi.advanceTimersByTimeAsync(3000)
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('[ALARM-DEV] heartbeat write failed'))
+      warn.mockRestore()
       expect(alarm.isConnected.value).toBe(false)
       expect(alarm.deviceState.value).toBeNull()
       expect(dev.port.close).toHaveBeenCalledTimes(1)
@@ -618,6 +688,122 @@ describe('useAlarmDevice', () => {
       await load()
       await alarm.disconnect()
       expect(alarm.isConnected.value).toBe(false)
+    })
+  })
+
+  // ---------- 意図した reload (alc-app-s3#192) ----------
+
+  describe('notifyIntentionalReload', () => {
+    async function connectDevice() {
+      const dev = createMockPort()
+      dev.emit('EVT ALARM state=idle cause=none\n')
+      installSerialMock({ getPorts: vi.fn(async () => [dev.port]) })
+      await load()
+      alarm.connect(0)
+      await vi.advanceTimersByTimeAsync(0)
+      return dev
+    }
+
+    it('接続中なら今の heartbeat に grace=45 を足した 1 行を送る', async () => {
+      const dev = await connectDevice()
+      expect(dev.writes).toEqual(['STATUS\n', 'HB OK\n'])
+
+      alarm.notifyIntentionalReload()
+      await vi.advanceTimersByTimeAsync(0)
+      expect(dev.writes.at(-1)).toBe('HB OK grace=45\n')
+      expect(alarmLogs()).toContain('sent grace=45')
+
+      // 周期の heartbeat はそのまま続く (grace は 1 回きり)
+      await vi.advanceTimersByTimeAsync(3000)
+      expect(dev.writes.at(-1)).toBe('HB OK\n')
+    })
+
+    it('着信中なら call=1 も残す (順不同で firmware が読む)', async () => {
+      const dev = await connectDevice()
+      setRooms({ rooms: ['room-a'] })
+
+      alarm.notifyIntentionalReload()
+      await vi.advanceTimersByTimeAsync(0)
+      expect(dev.writes.at(-1)).toBe('HB OK call=1 grace=45\n')
+    })
+
+    it('未接続なら何も送らない (落ちない)', async () => {
+      installSerialMock({ getPorts: vi.fn(async () => []) })
+      await load()
+      alarm.connect(0)
+      await vi.advanceTimersByTimeAsync(0)
+
+      alarm.notifyIntentionalReload()
+      await vi.advanceTimersByTimeAsync(0)
+      expect(alarmLogs()).not.toContain('sent grace=45')
+    })
+
+    it('書き込みに失敗してもポートは返さない (reload の直前なので後始末は要らない)', async () => {
+      const dev = await connectDevice()
+      dev.setWriteError(true)
+
+      alarm.notifyIntentionalReload()
+      await vi.advanceTimersByTimeAsync(0)
+      expect(alarm.isConnected.value).toBe(true)
+      expect(dev.port.close).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('reload 後の即再接続', () => {
+    it('握っていた印 (sessionStorage) があれば connect() は 5 秒待たずに探索し、印を消す', async () => {
+      const dev = createMockPort()
+      dev.emit('EVT ALARM state=idle cause=none\n')
+      installSerialMock({ getPorts: vi.fn(async () => [dev.port]) })
+      await load()
+      alarm.connect(0)
+      await vi.advanceTimersByTimeAsync(0)
+      expect(alarm.isConnected.value).toBe(true)
+      expect(sessionStorage.getItem('alarm_dev_connected')).toBe('1')
+
+      // reload: module の状態は消えるが sessionStorage は残る
+      const reloaded = createMockPort()
+      reloaded.emit('EVT ALARM state=idle cause=none\n')
+      installSerialMock({ getPorts: vi.fn(async () => [reloaded.port]) })
+      vi.resetModules()
+      mod = await import('~/composables/useAlarmDevice')
+      alarm = mod.useAlarmDevice()
+
+      alarm.connect()
+      expect(sessionStorage.getItem('alarm_dev_connected')).toBeNull()
+      await vi.advanceTimersByTimeAsync(0)
+      expect(reloaded.port.open).toHaveBeenCalledTimes(1)
+      expect(alarmLogs()).toContain('connect(delay=0, resumed after reload)')
+    })
+
+    it('disconnect() の明示切断で印を消す → 次の connect() は 5 秒待つ', async () => {
+      const dev = createMockPort()
+      dev.emit('EVT ALARM state=idle cause=none\n')
+      installSerialMock({ getPorts: vi.fn(async () => [dev.port]) })
+      await load()
+      alarm.connect(0)
+      await vi.advanceTimersByTimeAsync(0)
+      await alarm.disconnect()
+      expect(sessionStorage.getItem('alarm_dev_connected')).toBeNull()
+
+      alarm.connect()
+      await vi.advanceTimersByTimeAsync(4999)
+      expect(dev.port.open).toHaveBeenCalledTimes(1)
+      await vi.advanceTimersByTimeAsync(1)
+      expect(dev.port.open).toHaveBeenCalledTimes(2)
+    })
+
+    it('抜線 (onClose) では印を消さない — 挿し直しの前に reload しても即スキャンする', async () => {
+      const dev = createMockPort()
+      dev.emit('EVT ALARM state=idle cause=none\n')
+      installSerialMock({ getPorts: vi.fn(async () => [dev.port]) })
+      await load()
+      alarm.connect(0)
+      await vi.advanceTimersByTimeAsync(0)
+
+      dev.push({ value: undefined, done: true })
+      await vi.advanceTimersByTimeAsync(0)
+      expect(alarm.isConnected.value).toBe(false)
+      expect(sessionStorage.getItem('alarm_dev_connected')).toBe('1')
     })
   })
 

--- a/web/tests/composables/useCoreS3Serial.test.ts
+++ b/web/tests/composables/useCoreS3Serial.test.ts
@@ -119,8 +119,12 @@ describe('useCoreS3Serial', () => {
     expect(await connect()).toBe(true)
   }
 
+  let logSpy: ReturnType<typeof vi.spyOn>
+
   beforeEach(async () => {
     vi.clearAllMocks()
+    // arbiter の診断ログ ([SERIAL]) はテスト出力に流さない
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
     // 見送ったポートの再訪判定が Date.now() を見るので Date も止める
     vi.useFakeTimers({ toFake: ['setTimeout', 'setInterval', 'clearTimeout', 'clearInterval', 'Date'] })
     delete (navigator as any).serial
@@ -130,6 +134,7 @@ describe('useCoreS3Serial', () => {
     await core?.disconnect()
     delete (navigator as any).serial
     vi.useRealTimers()
+    logSpy.mockRestore()
   })
 
   // ---------- isSupported ----------
@@ -299,6 +304,31 @@ describe('useCoreS3Serial', () => {
 
     expect(json).toEqual([])
     expect(events).toEqual([])
+  })
+
+  // ---------- 意図した reload (alc-app-s3#192) ----------
+
+  describe('sendGrace', () => {
+    it('接続中なら HB OK grace=45 を 1 行書く (周期の HB OK はそのまま)', async () => {
+      const dev = createMockPort()
+      await connectWithJson(dev)
+
+      core.sendGrace()
+      await vi.advanceTimersByTimeAsync(0)
+      expect(dev.writes).toEqual(['STATUS\n', 'HB OK\n', 'HB OK grace=45\n'])
+
+      await vi.advanceTimersByTimeAsync(3000)
+      expect(dev.writes.at(-1)).toBe('HB OK\n')
+    })
+
+    it('未接続なら何も書かない (落ちない)', async () => {
+      installSerialMock({ getPorts: vi.fn(async () => []) })
+      await load()
+
+      core.sendGrace()
+      await vi.advanceTimersByTimeAsync(0)
+      expect(core.isConnected.value).toBe(false)
+    })
   })
 
   // ---------- write ----------

--- a/web/tests/composables/useSerialArbiter.test.ts
+++ b/web/tests/composables/useSerialArbiter.test.ts
@@ -154,8 +154,13 @@ describe('useSerialArbiter', () => {
     arbiter = mod.useSerialArbiter()
   }
 
+  let logSpy: ReturnType<typeof vi.spyOn>
+
   beforeEach(() => {
     vi.clearAllMocks()
+    // 診断ログ ([SERIAL]) はテスト出力に流さない。中身を見るテストは logSpy を読む
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    localStorage.removeItem('alc_debug_serial')
     // 見送り印の再訪判定が Date.now() を見るので Date も止める
     vi.useFakeTimers({ toFake: ['setTimeout', 'setInterval', 'clearTimeout', 'clearInterval', 'Date'] })
     delete (navigator as any).serial
@@ -166,7 +171,17 @@ describe('useSerialArbiter', () => {
     await arbiter?.unregister('core')
     delete (navigator as any).serial
     vi.useRealTimers()
+    localStorage.removeItem('alc_debug_serial')
+    logSpy.mockRestore()
   })
+
+  /** `[SERIAL] …` のログだけ (prefix と末尾の経過 ms を落とした本文) */
+  function serialLogs(): string[] {
+    return logSpy.mock.calls
+      .map(args => String(args[0]))
+      .filter(line => line.startsWith('[SERIAL] '))
+      .map(line => line.replace('[SERIAL] ', '').replace(/ \(\+\d+ms\)$/, ''))
+  }
 
   // ---------- WebSerial 非対応 ----------
 
@@ -730,6 +745,143 @@ describe('useSerialArbiter', () => {
 
       const ngWriter = ng.port.writable.getWriter()
       expect(await mod.writeLine(ngWriter, 'HB OK')).toBe(false)
+    })
+  })
+})
+
+// ---------- 診断ログ (#197) ----------
+
+describe('useSerialArbiter 診断ログ', () => {
+  let mod: typeof import('~/composables/useSerialArbiter')
+  let arbiter: ReturnType<typeof mod.useSerialArbiter>
+  let logSpy: ReturnType<typeof vi.spyOn>
+
+  function serialLogs(): string[] {
+    return logSpy.mock.calls
+      .map(args => String(args[0]))
+      .filter(line => line.startsWith('[SERIAL] '))
+      .map(line => line.replace('[SERIAL] ', '').replace(/ \(\+\d+ms\)$/, ''))
+  }
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    localStorage.removeItem('alc_debug_serial')
+    vi.useFakeTimers({ toFake: ['setTimeout', 'setInterval', 'clearTimeout', 'clearInterval', 'Date'] })
+    delete (navigator as any).serial
+  })
+
+  /** isSupported は useSerialArbiter() の呼び出し時に決まるので installSerialMock の後で呼ぶ */
+  async function load() {
+    vi.resetModules()
+    mod = await import('~/composables/useSerialArbiter')
+    arbiter = mod.useSerialArbiter()
+  }
+
+  afterEach(async () => {
+    await arbiter?.unregister('alarm')
+    delete (navigator as any).serial
+    vi.useRealTimers()
+    localStorage.removeItem('alc_debug_serial')
+    logSpy.mockRestore()
+  })
+
+  it('msSinceLoad は page load からの経過 ms (整数)', async () => {
+    await load()
+    expect(Number.isInteger(mod.msSinceLoad())).toBe(true)
+  })
+
+  it('scan の開始・閉じた理由・60 秒再訪は常時出す (候補ごとの行は出さない)', async () => {
+    const other = createMockPort()
+    other.emit('CORE LAN=up\n')
+    installSerialMock({ getPorts: vi.fn(async () => [other.port]) })
+    await load()
+    const { claimant } = createClaimant('ALARM', 'CORE')
+    arbiter.register('alarm', claimant)
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(serialLogs()).toEqual([
+      'scan start: candidates=1 pending=alarm',
+      'close probed port: passed over',
+    ])
+
+    // 60 秒後の再訪
+    await vi.advanceTimersByTimeAsync(60000)
+    expect(serialLogs()).toContain('revisiting a passed-over port (cooldown elapsed)')
+  })
+
+  it('release / unregister は誰のポートをなぜ閉じたかを出す', async () => {
+    const dev = createMockPort()
+    dev.emit('ALARM state=idle\n')
+    installSerialMock({ getPorts: vi.fn(async () => [dev.port]) })
+    await load()
+    const { claimant } = createClaimant('ALARM', 'CORE')
+    arbiter.register('alarm', claimant)
+    await vi.advanceTimersByTimeAsync(0)
+
+    await arbiter.release('alarm')
+    expect(serialLogs()).toContain('close port of alarm: release(alarm)')
+
+    // 掴み直したところで unregister (mock の reader は cancel 後に再利用できないので別ポート)
+    const dev2 = createMockPort()
+    dev2.emit('ALARM state=idle\n')
+    installSerialMock({ getPorts: vi.fn(async () => [dev2.port]) })
+    await vi.advanceTimersByTimeAsync(10000)
+    await arbiter.unregister('alarm')
+    expect(serialLogs()).toContain('close port of alarm: unregister(alarm)')
+  })
+
+  describe('localStorage.alc_debug_serial=1 のときだけ候補ごとの行を出す', () => {
+    beforeEach(() => {
+      localStorage.setItem('alc_debug_serial', '1')
+    })
+
+    it('claim', async () => {
+      const dev = createMockPort()
+      dev.emit('ALARM state=idle\n')
+      installSerialMock({ getPorts: vi.fn(async () => [dev.port]) })
+    await load()
+      const { claimant } = createClaimant('ALARM', 'CORE')
+      arbiter.register('alarm', claimant)
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(serialLogs()).toContain('claimed by alarm (probe lines=1)')
+    })
+
+    it('見送り (全員 reject)', async () => {
+      const other = createMockPort()
+      other.emit('CORE LAN=up\n')
+      installSerialMock({ getPorts: vi.fn(async () => [other.port]) })
+    await load()
+      const { claimant } = createClaimant('ALARM', 'CORE')
+      arbiter.register('alarm', claimant)
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(serialLogs()).toContain('passed over (nobody claimed 1 lines) -> revisit in 60s')
+    })
+
+    it('無応答', async () => {
+      const silent = createMockPort()
+      installSerialMock({ getPorts: vi.fn(async () => [silent.port]) })
+    await load()
+      const { claimant } = createClaimant('ALARM', 'CORE')
+      arbiter.register('alarm', claimant)
+      await vi.advanceTimersByTimeAsync(8000)
+
+      expect(serialLogs()).toContain('no response within probe window -> retry next scan')
+    })
+
+    it('open 失敗 / ストリームが取れない', async () => {
+      const busy = createMockPort({ openError: new DOMException('busy', 'InvalidStateError') })
+      const broken = createMockPort({ readable: false })
+      installSerialMock({ getPorts: vi.fn(async () => [busy.port, broken.port]) })
+    await load()
+      const { claimant } = createClaimant('ALARM', 'CORE')
+      arbiter.register('alarm', claimant)
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(serialLogs()).toContain('open failed (in use by another explorer?) -> next candidate')
+      expect(serialLogs()).toContain('no readable/writable stream -> close')
     })
   })
 })

--- a/web/tests/plugins/reload-grace.test.ts
+++ b/web/tests/plugins/reload-grace.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+import plugin, { isChunkLoadError } from '~/plugins/reload-grace.client'
+import { RELOAD_REASON_KEY } from '~/utils/reload-reason'
+
+const notifyIntentionalReload = vi.fn()
+mockNuxtImport('useAlarmDevice', () => () => ({ notifyIntentionalReload }))
+
+type Listener = (event: Event) => void
+
+/**
+ * chunk 読み込み失敗の自動復旧 reload の直前に走る plugin。
+ * window へ実イベントを dispatch すると auth-client の chunkReload plugin (テスト環境の
+ * Nuxt app にも載っている) まで発火して fetch + reload に行くので、addEventListener を
+ * spy して登録された listener を直接呼ぶ。
+ */
+describe('plugins/reload-grace.client', () => {
+  let hooks: Record<string, (payload: any) => void>
+  let listeners: Record<string, Listener>
+  let warn: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    sessionStorage.clear()
+    hooks = {}
+    listeners = {}
+    warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.spyOn(window, 'addEventListener').mockImplementation(((type: string, listener: Listener) => {
+      listeners[type] = listener
+    }) as typeof window.addEventListener)
+    const nuxtApp = {
+      hook: (name: string, fn: (payload: any) => void) => { hooks[name] = fn },
+      runWithContext: (fn: () => unknown) => fn(),
+    }
+    ;(plugin as unknown as (app: typeof nuxtApp) => void)(nuxtApp)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('Nuxt の hook より先に走るよう enforce: pre で登録する', () => {
+    expect((plugin as unknown as { enforce: string }).enforce).toBe('pre')
+    expect(hooks['app:chunkError']).toBeTypeOf('function')
+    expect(listeners['vite:preloadError']).toBeTypeOf('function')
+    expect(listeners['unhandledrejection']).toBeTypeOf('function')
+  })
+
+  it('app:chunkError → 失敗した chunk の URL を理由として残し、grace を送る', () => {
+    hooks['app:chunkError']!({
+      error: new Error('Failed to fetch dynamically imported module: https://example.test/_nuxt/Abc.def.js'),
+    })
+
+    expect(sessionStorage.getItem(RELOAD_REASON_KEY)).toMatch(
+      /^chunkError https:\/\/example\.test\/_nuxt\/Abc\.def\.js at \d/,
+    )
+    expect(notifyIntentionalReload).toHaveBeenCalledTimes(1)
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('[RELOAD-DETECT]'))
+  })
+
+  it('vite:preloadError → payload を理由として残す (URL が無ければ message の先頭)', () => {
+    listeners['vite:preloadError']!(Object.assign(new Event('vite:preloadError'), {
+      payload: 'Unable to preload CSS',
+    }))
+
+    expect(sessionStorage.getItem(RELOAD_REASON_KEY)).toMatch(/^vite:preloadError Unable to preload CSS at /)
+    expect(notifyIntentionalReload).toHaveBeenCalledTimes(1)
+  })
+
+  it('payload が Error でも文字列でもなければ理由は種別だけ', () => {
+    listeners['vite:preloadError']!(new Event('vite:preloadError'))
+
+    expect(sessionStorage.getItem(RELOAD_REASON_KEY)).toMatch(/^vite:preloadError {2}at /)
+    expect(notifyIntentionalReload).toHaveBeenCalledTimes(1)
+  })
+
+  it('unhandledrejection は chunk 読み込み失敗のときだけ拾う', () => {
+    listeners['unhandledrejection']!(Object.assign(new Event('unhandledrejection'), {
+      reason: new Error('something else failed'),
+    }))
+    expect(sessionStorage.getItem(RELOAD_REASON_KEY)).toBeNull()
+    expect(notifyIntentionalReload).not.toHaveBeenCalled()
+
+    listeners['unhandledrejection']!(Object.assign(new Event('unhandledrejection'), {
+      reason: new Error('Loading chunk 12 failed. (https://example.test/_nuxt/x.js)'),
+    }))
+    expect(sessionStorage.getItem(RELOAD_REASON_KEY)).toMatch(/^unhandledrejection https:\/\/example\.test\/_nuxt\/x\.js at /)
+    expect(notifyIntentionalReload).toHaveBeenCalledTimes(1)
+  })
+
+  it.each([
+    ['Failed to fetch dynamically imported module: https://x/a.js', true],
+    ['Importing a module script failed.', true],
+    ['Loading chunk 3 failed', true],
+    ['TypeError: foo is not a function', false],
+    ['', false],
+  ])('isChunkLoadError(%j) = %s', (message, expected) => {
+    expect(isChunkLoadError(message)).toBe(expected)
+  })
+})


### PR DESCRIPTION
## 何を
警告デバイス (VoiceS3R) と CoreS3 が、運行者端末 PWA の**意図した reload** で鳴らないようにする。3 点を 1 PR で入れる (どれか 1 つだけでは 30 分に 1 回の誤報が止まらない)。

1. **reload 直前に `HB … grace=45` を 1 行送る** — `useAlarmDevice.notifyIntentionalReload()` が警告デバイスへ今の HB に `grace=45` を付けて、CoreS3 へ `HB OK grace=45` を送る。呼び口は新規 plugin `reload-grace.client.ts` (auth-client の chunkReload が `location.reload()` する前、`enforce: 'pre'`)、`app.vue` の pagehide/beforeunload、`index.vue` の reloadPage()。reload 後は sessionStorage の印で `INITIAL_SCAN_DELAY` を待たずに再接続する
2. **HB NG を 15 秒デバウンス** — `isWatching` が切れても 15 秒は `HB OK` を送り続け、超えたら `HB NG signaling`、復旧で即 OK。`call=1` は不変
3. **診断ログ** — `page loaded (gap=, navType=, discarded=, reason=)` (reason は plugin が sessionStorage に「種別 chunkURL at 時刻」で残す)、freeze/resume/pagehide/beforeunload、`[ALARM-DEV]` の connect/claim/close/write 失敗/HB の変化/grace 送信、`[SERIAL]` の scan/close 理由/60 秒再訪。候補ごとの詳細は `localStorage.alc_debug_serial=1` のときだけ

## なぜ
実機 (2026-09-09) で警告デバイスが 30 分に 1 回鳴っていた。原因は PWA の reload (`[RELOAD-DETECT] navType=reload`: chunk 読み込み失敗の自動復旧、F5、Chrome メモリセーバー) でシリアルが閉じて heartbeat が 10 秒途絶すること、および WS 再接続の数秒で即 `HB NG` を送っていたこと。ユーザー決定「意図した reload では鳴らさない」。firmware 側は ippoan/alc-app-s3#193 (grace=<秒> の受理) で入っている。旧 firmware は `grace=` を `ERR HB` で捨てるだけなので、この PR を先に入れても害は無い。

## 既存テストの書き換え (仕様変更で不可避)
`useAlarmDevice.test.ts` の 3 件: 「購読が切れたら即 HB NG」→ 14 秒 OK / 16 秒 NG / 復旧即 OK、「購読が切れていても call=1」→ 15 秒後に `HB NG signaling call=1`、公開 API のキー一覧に `notifyIntentionalReload` を追加。3 テストファイルの beforeEach に console.log の spy を足して診断ログを出力に流さない。

## テスト
- 新規: `tests/plugins/reload-grace.test.ts`、`coverage_100.toml` に plugin と `reload-reason.ts` を登録
- `tsc --noEmit` 0 / `vitest run` 53 files 1367 passed 2 skipped / coverage 100% (lines・branches)
- #200 (closePortQuietly の 3 段化) の上に rebase 済み。`useSerialArbiter.ts` はログ追加と `closeSession(reason)` のみで、調停ロジックと closePortQuietly は不変

## 申し送り
`ManagerAlarmBar` は元々 `alarm.connect(0)` なので、sessionStorage の印による「待たずに再接続」の効果は現状の呼び元では出ない (再接続の所要は `[ALARM-DEV] claimed port (+Nms)` で実測できる)。`useAlarmDevice` ↔ `useCoreS3Serial` は相互 import になるが、どちらも関数内でしか使わない。

## 実機確認 (マージ後、v0.0.83+ の PWA と firmware 17f0b27+)
- F5 → 警告デバイスも CoreS3 も鳴らずに再接続、コンソールに `page loaded (… reason=…)` と `[ALARM-DEV] claimed port (+Nms)`
- DevTools Offline 3 秒 → 鳴らない。15 秒以上 → 3 連、復旧で止まる
- PWA を閉じたまま → 45 秒後に鳴る

Closes #197
Closes #198
Refs ippoan/alc-app-s3#192, ippoan/alc-app-s3#135

🤖 Generated with [Claude Code](https://claude.com/claude-code)
