### PR TITLE
fix(nfc): 通常点呼で免許証が乗務員に未登録なら赤枠を出す / register の文言を helper に揃える (Closes #202)

### DIFF
--- a/web/app/components/NormalMeasurement.vue
+++ b/web/app/components/NormalMeasurement.vue
@@ -91,7 +91,9 @@ async function onNfcRead(nfcId: string, expiryDate?: Date) {
     await faceSync()
     step.value = 'face_auth'
   } catch {
-    console.error(employeeNotFoundByNfc(nfcId))
+    const msg = employeeNotFoundByNfc(nfcId)
+    console.error(msg)
+    approvalError.value = msg
   }
 }
 

--- a/web/app/composables/useNfcReader.ts
+++ b/web/app/composables/useNfcReader.ts
@@ -102,6 +102,8 @@ export function useNfcReader() {
       // 26 桁の契約を満たせない行は捨てる (utils/license.ts の桁が合わなくなる)
       if (issue.length !== DATE_LEN || expiry.length !== DATE_LEN) return
 
+      console.log('[NFC] License read (CoreS3):', { issue, expiry })
+
       const cardId = CARD_ID_PAD + issue + expiry
       // useNfcWebSocket と同じ順 — 先に期限を配り、続けて読み取りを配る
       emitLicenseRead({

--- a/web/app/pages/register.vue
+++ b/web/app/pages/register.vue
@@ -2,6 +2,7 @@
 import type { ApiEmployee } from '~/types'
 import { initApi, getEmployees, getEmployeeByNfcId, uploadFacePhoto, updateEmployeeFace } from '~/utils/api'
 import { getFaceDescriptor } from '~/utils/face-db'
+import { employeeNotFoundByNfc } from '~/utils/employee-lookup-messages'
 import { FACE_MODEL_VERSION } from '~/composables/useFaceDetection'
 
 const config = useRuntimeConfig()
@@ -39,7 +40,7 @@ async function onNfcRead(nfcId: string) {
     const emp = await getEmployeeByNfcId(nfcId)
     selectedEmployee.value = emp
   } catch {
-    lookupError.value = `このNFCカードに紐付いた乗務員が見つかりません`
+    lookupError.value = employeeNotFoundByNfc(nfcId)
   }
 }
 

--- a/web/tests/components/NormalMeasurement.test.ts
+++ b/web/tests/components/NormalMeasurement.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ref, readonly, defineComponent } from 'vue'
+import { mountSuspended, mockNuxtImport } from '@nuxt/test-utils/runtime'
+import NormalMeasurement from '~/components/NormalMeasurement.vue'
+import { employeeNotFoundByNfc } from '~/utils/employee-lookup-messages'
+
+// --- API のモック (NFC → 乗務員照合だけを動かす) ---
+
+const getEmployeeByNfcIdMock = vi.fn()
+
+vi.mock('~/utils/api', () => ({
+  getEmployeeByNfcId: (nfcId: string) => getEmployeeByNfcIdMock(nfcId),
+  getEmployeeByCode: vi.fn(),
+  startMeasurement: vi.fn(async () => ({ id: 'measurement-1' })),
+  updateMeasurement: vi.fn(async () => ({})),
+  uploadFacePhoto: vi.fn(async () => 'https://example.com/face.jpg'),
+  uploadBlowVideo: vi.fn(async () => 'https://example.com/blow.webm'),
+}))
+
+vi.mock('~/utils/video-store', () => ({
+  saveVideo: vi.fn(async () => 'video-1'),
+  markVideoUploaded: vi.fn(async () => {}),
+  getPendingVideos: vi.fn(async () => []),
+  cleanupOldVideos: vi.fn(async () => {}),
+}))
+
+// --- composable のモック (測定フロー本体は動かさない) ---
+
+mockNuxtImport('useDemoMode', () => () => ({
+  isDemoMode: ref(false),
+}))
+
+mockNuxtImport('useOfflineSync', () => () => ({
+  isOnline: ref(true),
+  pending: ref(0),
+  isSyncing: ref(false),
+  save: vi.fn(),
+  syncQueue: vi.fn(),
+}))
+
+mockNuxtImport('useAuth', () => () => ({
+  isDeviceActivated: ref(true),
+}))
+
+const faceSyncMock = vi.fn(async () => {})
+mockNuxtImport('useFaceSync', () => () => ({
+  isSyncing: ref(false),
+  sync: faceSyncMock,
+}))
+
+mockNuxtImport('useCamera', () => () => ({
+  stream: ref(null),
+  videoRef: ref(null),
+  isActive: ref(false),
+  start: vi.fn(async () => {}),
+  stop: vi.fn(),
+}))
+
+mockNuxtImport('useVideoRecorder', () => () => ({
+  isRecording: ref(false),
+  startRecording: vi.fn(),
+  stopRecording: vi.fn(async () => null),
+}))
+
+mockNuxtImport('useBleGateway', () => () => ({
+  latestTemperature: readonly(ref(null)),
+  latestBloodPressure: readonly(ref(null)),
+}))
+
+mockNuxtImport('useFingerprint', () => () => ({
+  isFingerprintAvailable: ref(false),
+  isEmployeeAuthorized: () => false,
+  authorizeEmployee: vi.fn(),
+  requestFingerprint: vi.fn(),
+}))
+
+// NfcStatus は表示と emit('read') だけなので、read を直接投げられるスタブに差し替える
+const NfcStatusStub = defineComponent({
+  name: 'NfcStatus',
+  emits: ['read'],
+  template: '<div data-testid="nfc-stub" />',
+})
+
+const APPROVED_EMPLOYEE = { id: 'emp-1', name: '山田太郎', face_approval_status: 'approved' }
+
+async function mountNfcStep() {
+  const wrapper = await mountSuspended(NormalMeasurement, {
+    global: { stubs: { NfcStatus: NfcStatusStub, ClientOnly: false, Teleport: true } },
+  })
+  return wrapper
+}
+
+/** NfcStatus の read を発火させ、onNfcRead の await を消化する */
+async function touch(wrapper: Awaited<ReturnType<typeof mountNfcStep>>, nfcId: string) {
+  wrapper.findComponent(NfcStatusStub).vm.$emit('read', nfcId)
+  await new Promise(resolve => setTimeout(resolve, 0))
+  await wrapper.vm.$nextTick()
+}
+
+describe('NormalMeasurement — NFC ステップの乗務員照合', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('免許証が乗務員に未登録 (by-nfc が失敗) なら赤枠に理由と次の操作を出す', async () => {
+    getEmployeeByNfcIdMock.mockRejectedValue(new Error('404'))
+    const wrapper = await mountNfcStep()
+
+    await touch(wrapper, '2601012901010')
+
+    const alert = wrapper.find('.bg-red-50')
+    expect(alert.exists()).toBe(true)
+    expect(alert.text()).toBe(employeeNotFoundByNfc('2601012901010'))
+    // 進まない (顔認証の見出しは出ない)
+    expect(wrapper.text()).toContain('乗務員ID')
+    wrapper.unmount()
+  })
+
+  it('乗務員が引ければ赤枠を出さずに次のステップへ進む', async () => {
+    getEmployeeByNfcIdMock.mockResolvedValue(APPROVED_EMPLOYEE)
+    const wrapper = await mountNfcStep()
+
+    await touch(wrapper, '2601012901010')
+
+    expect(wrapper.find('.bg-red-50').exists()).toBe(false)
+    expect(wrapper.text()).not.toContain('この免許証は乗務員に登録されていません')
+    // NFC ステップを抜けている
+    expect(wrapper.findComponent(NfcStatusStub).exists()).toBe(false)
+    expect(faceSyncMock).toHaveBeenCalledTimes(1)
+    wrapper.unmount()
+  })
+
+  it('赤枠は次のタッチで消える', async () => {
+    getEmployeeByNfcIdMock.mockRejectedValueOnce(new Error('404'))
+    const wrapper = await mountNfcStep()
+
+    await touch(wrapper, '2601012901010')
+    expect(wrapper.find('.bg-red-50').exists()).toBe(true)
+
+    getEmployeeByNfcIdMock.mockResolvedValueOnce(APPROVED_EMPLOYEE)
+    await touch(wrapper, '2701013001011')
+    expect(wrapper.find('.bg-red-50').exists()).toBe(false)
+    wrapper.unmount()
+  })
+})


### PR DESCRIPTION
## 何を
通常点呼の NFC ステップで、免許証 (NFC ID) が乗務員に未登録 (`GET /api/employees/by-nfc/:nfcId` が 404) のとき、赤枠に「この免許証は乗務員に登録されていません (NFC ID: …)」を出す。`NormalMeasurement.vue` の catch が console.error しか出しておらず、`approvalError` を立てていなかった。点呼予定ありの `TenkoKiosk.vue` は同じ場面で赤枠を出していたので、それに揃える。

あわせて `register.vue` の独自文言「このNFCカードに紐付いた乗務員が見つかりません」(NFC ID も次の操作も無し) を同じ helper `employeeNotFoundByNfc` に揃え、CoreS3 直結の経路 (`useNfcReader.ts` `handleCoreEvent`) に `[NFC] License read (CoreS3)` のログを 1 行足す (WebSocket 経路には元々ある)。

## なぜ
実機 (2026-09-09、FE v0.0.83、CoreS3 直結) で免許証をタッチすると「読み取り: <番号>」「有効期限」は緑で出るのに次へ進まず、赤枠も出なかった。画面とコンソールを見ても「読んだのに無反応」にしか見えない。#187 → #188 で文言を 1 本化したが、通常点呼と登録画面の catch には効いていなかった (同型 3 世代目)。共通化はしない (4 か所とも 1 行の代入で、折り畳んでも減らない)。

## テスト
- `tests/components/NormalMeasurement.test.ts` 新規 3 本: by-nfc reject → 赤枠に helper の文言 / 成功 → 赤枠なしで NFC ステップを抜ける / 次のタッチで赤枠が消える。修正を戻すと 2 本が落ちることを確認済み
- `tsc --noEmit` 0 / `vitest run` 54 files 1371 passed 2 skipped / coverage 100% (lines・branches)。`coverage_100.toml` は未変更 (.vue は登録しない方針)

## 実機確認 (マージ後、v0.0.84+ の PWA)
未登録の免許証を通常点呼でタッチ → 赤枠に「この免許証は乗務員に登録されていません (NFC ID: …)」。登録済みなら顔認証へ進む。コンソールに `[NFC] License read (CoreS3)` が出る。

Closes #202
Refs #187, #188, ippoan/alc-app-s3#188, ippoan/alc-app-s3#135

🤖 Generated with [Claude Code](https://claude.com/claude-code)
