### PR TITLE
feat(pwa): 二重起動を防ぐ — manifest launch_handler focus-existing + Web Locks で同 role の 2 つ目は案内して閉じる (Closes #204)

### DIFF
--- a/web/app/app.vue
+++ b/web/app/app.vue
@@ -63,6 +63,11 @@ const route = useRoute()
 const manifestRole = computed(() => manifestRoleFromQuery(route.query))
 const { manifestHref, themeColor } = useRoleManifest(manifestRole)
 
+// --- 二重起動の検知 (Refs #204) ---
+// 同じ role の PWA / タブが既に開いていれば案内を出して本体を描かない。
+// OS からの PWA 起動は manifest の launch_handler (focus-existing) が既存ウィンドウへ寄せる。
+const { duplicate, closeWindow } = useSingleInstance(manifestRole)
+
 useHead({
   htmlAttrs: {
     class: computed(() => isAndroidApp.value ? 'android-app' : ''),
@@ -75,7 +80,20 @@ useHead({
 <template>
   <div class="min-h-screen flex flex-col bg-gray-50">
     <NuxtRouteAnnouncer />
-    <div v-if="isLoading" class="flex-1 flex items-center justify-center">
+    <div v-if="duplicate" class="flex-1 flex items-center justify-center p-6">
+      <div class="w-full max-w-md bg-white rounded-xl shadow p-8 text-center">
+        <p class="text-xl font-bold text-gray-900">このアプリは既に開いています。</p>
+        <p class="mt-2 text-gray-600">開いている方を使ってください。</p>
+        <button
+          type="button"
+          class="mt-6 px-6 py-3 bg-blue-600 text-white rounded-xl font-medium hover:bg-blue-700 transition-colors"
+          @click="closeWindow"
+        >
+          このウィンドウを閉じる
+        </button>
+      </div>
+    </div>
+    <div v-else-if="isLoading" class="flex-1 flex items-center justify-center">
       <div class="animate-spin h-8 w-8 border-4 border-blue-500 border-t-transparent rounded-full" />
     </div>
     <NuxtPage v-else />

--- a/web/app/composables/useSingleInstance.ts
+++ b/web/app/composables/useSingleInstance.ts
@@ -1,0 +1,75 @@
+import type { MaybeRefOrGetter } from 'vue'
+
+/** ロック名の接頭辞。role ごと (driver / manager は別) に 1 つ */
+export const SINGLE_INSTANCE_LOCK_PREFIX = 'alc-pwa:'
+/** 再試行の間隔 (ms) */
+export const SINGLE_INSTANCE_RETRY_MS = 250
+/** 再試行の回数 (250 ms × 8 = 2 秒) */
+export const SINGLE_INSTANCE_MAX_TRIES = 8
+
+export function singleInstanceLockName(role: string): string {
+  return SINGLE_INSTANCE_LOCK_PREFIX + role
+}
+
+/**
+ * `ifAvailable` で 1 回だけロックを試す。取れたらページが閉じるまで握り続ける
+ * (callback が resolve するとロックは解放されるので、resolve しない Promise を返す)。
+ * 取得の成否は callback に渡る `lock` の有無で判定して外へ返す。
+ * `request` 自体が reject したとき (仕様外の環境) は判定不能なので「取れた」扱い = 案内を出さない。
+ */
+function tryAcquire(name: string): Promise<boolean> {
+  return new Promise<boolean>((resolve) => {
+    navigator.locks
+      .request(name, { ifAvailable: true }, (lock) => {
+        if (!lock) {
+          resolve(false)
+          return
+        }
+        resolve(true)
+        return new Promise<void>(() => {})
+      })
+      .catch(() => resolve(true))
+  })
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+/**
+ * 同じ PC で同じ role の PWA / タブが 2 つ開くのを検知する (Refs #204)。
+ * CoreS3 / 警告デバイスのシリアルポートは片方しか握れず、もう片方が誤った警告を出すため。
+ *
+ * - `navigator.locks` (Web Locks) が無い環境では何もしない
+ * - `alc-pwa:<role>` のロックを 250 ms 間隔で最大 8 回 (2 秒) 試す。reload や chunk 復旧の
+ *   自動 reload (`plugins/reload-grace.client.ts`) では旧ページの解放が新ページの mount より
+ *   遅れることがあるので、即断せず待つ
+ * - 8 回とも取れなければ `duplicate` を true にする。**fail-open**: 自動で閉じるのは
+ *   PWA ウィンドウ (`display-mode: standalone`) かつ `history.length === 1` のときだけ。
+ *   通常タブでは案内だけ出し、利用者がボタンを押したときに `closeWindow()` で閉じる
+ *   (履歴が 2 以上のタブでは `window.close()` は仕様上無視される)
+ * - 取れた側はページが閉じる (unload) まで握り続ける
+ */
+export function useSingleInstance(role: MaybeRefOrGetter<string>) {
+  const duplicate = ref(false)
+
+  async function detect(): Promise<void> {
+    if (!navigator.locks) return
+    const name = singleInstanceLockName(toValue(role))
+    for (let i = 0; i < SINGLE_INSTANCE_MAX_TRIES; i++) {
+      if (i > 0) await delay(SINGLE_INSTANCE_RETRY_MS)
+      if (await tryAcquire(name)) return
+    }
+    duplicate.value = true
+    const standalone = window.matchMedia('(display-mode: standalone)').matches
+    if (standalone && window.history.length === 1) window.close()
+  }
+
+  function closeWindow(): void {
+    window.close()
+  }
+
+  onMounted(() => { void detect() })
+
+  return { duplicate, closeWindow }
+}

--- a/web/coverage_100.toml
+++ b/web/coverage_100.toml
@@ -23,6 +23,10 @@ path = "app/composables/useRoleManifest.ts"
 branches = true
 
 [[files]]
+path = "app/composables/useSingleInstance.ts"
+branches = true
+
+[[files]]
 path = "app/composables/useActiveRooms.ts"
 branches = true
 

--- a/web/public/manifest-driver.webmanifest
+++ b/web/public/manifest-driver.webmanifest
@@ -6,6 +6,7 @@
   "short_name": "点呼",
   "lang": "ja",
   "display": "standalone",
+  "launch_handler": { "client_mode": "focus-existing" },
   "background_color": "#ffffff",
   "theme_color": "#1e40af",
   "icons": [

--- a/web/public/manifest-manager.webmanifest
+++ b/web/public/manifest-manager.webmanifest
@@ -6,6 +6,7 @@
   "short_name": "運行管理",
   "lang": "ja",
   "display": "standalone",
+  "launch_handler": { "client_mode": "focus-existing" },
   "background_color": "#ffffff",
   "theme_color": "#b45309",
   "icons": [

--- a/web/tests/composables/useSingleInstance.test.ts
+++ b/web/tests/composables/useSingleInstance.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { computed, ref } from 'vue'
+import { withSetup } from '../helpers/with-setup'
+import {
+  useSingleInstance,
+  singleInstanceLockName,
+  SINGLE_INSTANCE_MAX_TRIES,
+  SINGLE_INSTANCE_RETRY_MS,
+} from '~/composables/useSingleInstance'
+
+type LockCallback = (lock: object | null) => unknown
+
+/**
+ * Web Locks の最小モック。`available` が true なら callback に lock を渡し、
+ * false なら null を渡す (= `ifAvailable` で取れなかった)。
+ * callback の戻り値 (握り続けるための resolve しない Promise) はそのまま返す。
+ */
+function installLocks(available: () => boolean, opts: { reject?: boolean } = {}) {
+  const callbacks: Array<{ lock: object | null; returned: unknown }> = []
+  const request = vi.fn(async (_name: string, _opts: unknown, cb: LockCallback) => {
+    if (opts.reject) throw new DOMException('locks unavailable', 'InvalidStateError')
+    const lock = available() ? { name: _name, mode: 'exclusive' } : null
+    const returned = cb(lock)
+    callbacks.push({ lock, returned })
+    return returned
+  })
+  Object.defineProperty(navigator, 'locks', { configurable: true, value: { request } })
+  return { request, callbacks }
+}
+
+function installDisplayMode(standalone: boolean) {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: vi.fn((query: string) => ({ matches: standalone, media: query })),
+  })
+}
+
+function installHistoryLength(length: number) {
+  Object.defineProperty(window, 'history', { configurable: true, value: { length } })
+}
+
+/** onMounted → 最初の request (同期) → microtask を流す */
+async function flush() {
+  await vi.advanceTimersByTimeAsync(0)
+}
+
+/** 再試行を全部使い切る (7 回分の待ち + 余裕) */
+async function exhaustRetries() {
+  await vi.advanceTimersByTimeAsync(SINGLE_INSTANCE_RETRY_MS * SINGLE_INSTANCE_MAX_TRIES)
+}
+
+describe('useSingleInstance', () => {
+  let close: ReturnType<typeof vi.fn>
+  const savedHistory = Object.getOwnPropertyDescriptor(window, 'history')
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    close = vi.fn()
+    Object.defineProperty(window, 'close', { configurable: true, writable: true, value: close })
+    installDisplayMode(false)
+    installHistoryLength(2)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    delete (navigator as { locks?: unknown }).locks
+    if (savedHistory) Object.defineProperty(window, 'history', savedHistory)
+    else delete (window as { history?: unknown }).history
+  })
+
+  it('ロック名は alc-pwa:<role>', () => {
+    expect(singleInstanceLockName('driver')).toBe('alc-pwa:driver')
+    expect(singleInstanceLockName('manager')).toBe('alc-pwa:manager')
+  })
+
+  it('navigator.locks が無い環境では何もしない (素通し)', async () => {
+    const [result, app] = withSetup(() => useSingleInstance('driver'))
+    await flush()
+    await exhaustRetries()
+    expect(result.duplicate.value).toBe(false)
+    expect(close).not.toHaveBeenCalled()
+    app.unmount()
+  })
+
+  it('取れる → duplicate=false。ifAvailable で 1 回だけ要求し、callback は resolve しない Promise を返して握り続ける', async () => {
+    const { request, callbacks } = installLocks(() => true)
+    const [result, app] = withSetup(() => useSingleInstance('driver'))
+    await flush()
+    await exhaustRetries()
+
+    expect(result.duplicate.value).toBe(false)
+    expect(request).toHaveBeenCalledTimes(1)
+    expect(request).toHaveBeenCalledWith('alc-pwa:driver', { ifAvailable: true }, expect.any(Function))
+    expect(callbacks[0]!.lock).not.toBeNull()
+    // 握り続ける = callback の戻りは pending の Promise
+    let settled = false
+    void (callbacks[0]!.returned as Promise<void>).then(() => { settled = true })
+    await flush()
+    expect(settled).toBe(false)
+    expect(close).not.toHaveBeenCalled()
+    app.unmount()
+  })
+
+  it('role は ref / computed でも受け、mount 時点の値でロック名を決める', async () => {
+    const role = ref<'driver' | 'manager'>('manager')
+    const { request } = installLocks(() => true)
+    const [, app] = withSetup(() => useSingleInstance(computed(() => role.value)))
+    await flush()
+    expect(request).toHaveBeenCalledWith('alc-pwa:manager', { ifAvailable: true }, expect.any(Function))
+    app.unmount()
+  })
+
+  it('8 回とも取れない → duplicate=true。通常タブでは close を自動では呼ばない', async () => {
+    const { request, callbacks } = installLocks(() => false)
+    const [result, app] = withSetup(() => useSingleInstance('driver'))
+    await flush()
+    expect(request).toHaveBeenCalledTimes(1)
+    expect(result.duplicate.value).toBe(false)
+
+    // 7 回目までは判定しない
+    await vi.advanceTimersByTimeAsync(SINGLE_INSTANCE_RETRY_MS * (SINGLE_INSTANCE_MAX_TRIES - 2))
+    expect(request).toHaveBeenCalledTimes(SINGLE_INSTANCE_MAX_TRIES - 1)
+    expect(result.duplicate.value).toBe(false)
+
+    await vi.advanceTimersByTimeAsync(SINGLE_INSTANCE_RETRY_MS)
+    expect(request).toHaveBeenCalledTimes(SINGLE_INSTANCE_MAX_TRIES)
+    expect(result.duplicate.value).toBe(true)
+    expect(callbacks.every((c) => c.lock === null)).toBe(true)
+    expect(close).not.toHaveBeenCalled()
+
+    // ボタンを押したときだけ閉じる
+    result.closeWindow()
+    expect(close).toHaveBeenCalledTimes(1)
+    app.unmount()
+  })
+
+  it('8 回とも取れない + PWA ウィンドウ (standalone) + history.length===1 → 自動で close', async () => {
+    installDisplayMode(true)
+    installHistoryLength(1)
+    installLocks(() => false)
+    const [result, app] = withSetup(() => useSingleInstance('driver'))
+    await flush()
+    await exhaustRetries()
+    expect(result.duplicate.value).toBe(true)
+    expect(window.matchMedia).toHaveBeenCalledWith('(display-mode: standalone)')
+    expect(close).toHaveBeenCalledTimes(1)
+    app.unmount()
+  })
+
+  it('standalone でも history.length が 2 以上なら自動では閉じない (window.close は無視される)', async () => {
+    installDisplayMode(true)
+    installHistoryLength(2)
+    installLocks(() => false)
+    const [result, app] = withSetup(() => useSingleInstance('driver'))
+    await flush()
+    await exhaustRetries()
+    expect(result.duplicate.value).toBe(true)
+    expect(close).not.toHaveBeenCalled()
+    app.unmount()
+  })
+
+  it('3 回目で取れる → duplicate=false (reload で旧ページの解放が遅れる競合に耐える)', async () => {
+    let calls = 0
+    const { request } = installLocks(() => ++calls >= 3)
+    const [result, app] = withSetup(() => useSingleInstance('driver'))
+    await flush()
+    expect(request).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(SINGLE_INSTANCE_RETRY_MS)
+    expect(request).toHaveBeenCalledTimes(2)
+    await vi.advanceTimersByTimeAsync(SINGLE_INSTANCE_RETRY_MS)
+    expect(request).toHaveBeenCalledTimes(3)
+    await exhaustRetries()
+    expect(request).toHaveBeenCalledTimes(3)
+    expect(result.duplicate.value).toBe(false)
+    expect(close).not.toHaveBeenCalled()
+    app.unmount()
+  })
+
+  it('request が reject する環境では判定不能なので案内を出さない (fail-open)', async () => {
+    const { request } = installLocks(() => false, { reject: true })
+    const [result, app] = withSetup(() => useSingleInstance('driver'))
+    await flush()
+    await exhaustRetries()
+    expect(request).toHaveBeenCalledTimes(1)
+    expect(result.duplicate.value).toBe(false)
+    expect(close).not.toHaveBeenCalled()
+    app.unmount()
+  })
+})

--- a/web/tests/public/manifests.test.ts
+++ b/web/tests/public/manifests.test.ts
@@ -53,6 +53,12 @@ describe('public/manifest-*.webmanifest', () => {
     }
   })
 
+  it('launch_handler focus-existing — OS からの起動は既存ウィンドウにフォーカスし 2 つ目を開かない (Refs #204)', () => {
+    for (const m of [driver, manager]) {
+      expect(m.launch_handler).toEqual({ client_mode: 'focus-existing' })
+    }
+  })
+
   it('theme_color が useRoleManifest の定数と一致する', () => {
     expect(driver.theme_color).toBe(DRIVER_MANIFEST.themeColor)
     expect(manager.theme_color).toBe(MANAGER_MANIFEST.themeColor)


### PR DESCRIPTION
## 何を
PWA の二重起動を防ぐ。

1. **manifest** (`manifest-driver.webmanifest` / `manifest-manager.webmanifest`) に `"launch_handler": { "client_mode": "focus-existing" }`。OS から PWA を起動したとき、既に開いているウィンドウがあればそれにフォーカスし、新しいウィンドウを開かない
2. **`useSingleInstance(role)`** (新規): Web Locks で `alc-pwa:<role>` (role は `useRoleManifest` の `manifestRole`。運行者と運行管理者は別ロック) を取る。`ifAvailable` を 250 ms 間隔で最大 8 回 (2 秒) 再試行し、reload (F5 / chunk 復旧の自動 reload) で旧ページの解放が遅れる競合に耐える。取れた側は unload まで握る。8 回とも取れなければ `duplicate` (fail-open: 自動で閉じるのは PWA ウィンドウ (`display-mode: standalone`) かつ履歴 1 のときだけ。通常タブは案内カード + 「このウィンドウを閉じる」ボタン)。`navigator.locks` が無い環境は素通し
3. `app.vue`: `duplicate` なら案内カードを出し本体を描画しない。既存の pagehide / beforeunload / `[RELOAD-DETECT]` は不変

## なぜ
ユーザー要望「二重起動の場合 閉じるようにしたい」。同じ PC で同じ PWA が 2 つ開くと、CoreS3 / 警告デバイスのシリアルポートは片方しか握れず、もう片方が未接続や誤った警告を出す。

## テスト
- `tests/composables/useSingleInstance.test.ts` 新規 9 本 (fake timers): 取れる / 3 回目で取れる / 8 回失敗 → duplicate / standalone + 履歴 1 で close / 通常タブでは close しない / locks 無し・reject は素通し
- `tests/public/manifests.test.ts` に launch_handler の検査
- `tsc --noEmit` 0 / `vitest run` 55 files 1381 passed 2 skipped / coverage 100% (`useSingleInstance.ts` を branches=true で登録)

## 実機確認 (マージ後)
- PWA を 2 回起動しても 1 つにフォーカスされる
- ブラウザで同じ URL を 2 タブ開くと 2 つ目に案内が出る
- PWA で F5 / 自動 reload しても案内が出ない
- PWA ウィンドウの 2 つ目が実際に閉じるか (閉じなければ案内のみで運用、別 issue)

Closes #204
Refs ippoan/alc-app-s3#135, #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)
