### PR TITLE
fix(alarm): ロールタブを切り替えても警告デバイスを切らない — unmount で disconnect せず、設定 off と unload だけで切る (Closes #205)

### DIFF
--- a/web/app/components/ManagerAlarmBar.vue
+++ b/web/app/components/ManagerAlarmBar.vue
@@ -3,9 +3,15 @@
  * 据置警告デバイス (Atom VoiceS3R / USB) の heartbeat と着信購読。
  *
  * 運行管理者の PC は普段、トップ画面「運行管理者」タブの認証ゲートのまま置かれる。
- * 見張る対象は「そのタブがブラウザで開いているか」であって認証の有無ではないので、
+ * 見張る対象は「その PWA がブラウザで開いているか」であって認証の有無ではないので、
  * このバーは認証ゲートの外 (タブに入った時点) に置く。
- * バーが mount しているあいだだけ heartbeat が出る = タブを離れるとデバイスが鳴る (#135)
+ *
+ * 止める (= デバイスが鳴る) のは次の 3 つだけ:
+ *   PWA を閉じる / reload (app.vue の pagehide → grace=45) / デバイス設定を off にする
+ * **SPA 内のロールタブ切替 (このバーの unmount) では切らない** — 運行管理者から
+ * システム管理者へ移っただけで鳴るのは誤報だった (#205)。useAlarmDevice / useActiveRooms は
+ * singleton なので、mount 中に始めた heartbeat と着信購読は unmount 後もそのまま続く。
+ * どのロールタブに居ても着信 (`call=1`) は鳴る — これは望ましい副作用 (#135)
  */
 const alarm = useAlarmDevice()
 // Web Serial の無いブラウザでは購読も heartbeat も立てない
@@ -16,26 +22,31 @@ const { enabled, setEnabled } = useAlarmDeviceSetting()
 const { isWatching, activeRooms, joinedRoomId, start, stop } = useActiveRooms()
 
 if (isSupported && enabled.value !== false) {
+  // この instance が「使う」状態か。unmount では下ろさない (singleton は動いたまま)
   let started = false
   const startWatching = () => {
     started = true
-    start()
+    // 別のロールタブから戻ってきた再 mount では singleton が既に動いている。start() は
+    // 参照カウント (対になる stop が無いと下がらない)、connect() も no-op ではない
+    // (installNgWatch / arbiter.register / 再接続の印の削除) ので、二重に呼ばない
+    if (!isWatching.value) start()
     // BLE ゲートウェイと同居しない PC なので、ポートの取り合いを待つ必要が無い
-    alarm.connect(0)
+    if (!alarm.isConnected.value) alarm.connect(0)
   }
   onMounted(() => {
     // 探索は「使う」と決まってから。未設定のあいだは問いかけカードだけを出す
     if (enabled.value === true) startWatching()
   })
-  // 問いかけカードで [つなぐ] を選んだ瞬間に探索を始める
   watch(enabled, (v) => {
+    // 問いかけカードで [つなぐ] を選んだ瞬間に探索を始める
     if (v === true && !started) startWatching()
-  })
-  onUnmounted(() => {
-    if (!started) return
-    void alarm.disconnect()
-    // 参照カウントなので、遠隔点呼タブの子が先に stop していても WebSocket は残る
-    stop()
+    // 設定を off にしたときだけ切る (unmount では切らない = ロールタブ切替で鳴らさない)
+    if (v === false && started) {
+      started = false
+      void alarm.disconnect()
+      // 参照カウントなので、遠隔点呼タブの子が先に stop していても WebSocket は残る
+      stop()
+    }
   })
 }
 

--- a/web/tests/components/ManagerAlarmBar.test.ts
+++ b/web/tests/components/ManagerAlarmBar.test.ts
@@ -68,9 +68,46 @@ describe('ManagerAlarmBar', () => {
     settingState.enabled.value = true
   })
 
-  it('mount で購読 → heartbeat の順に始め、unmount で heartbeat → 購読の順に止める', async () => {
+  it('mount で購読 → heartbeat の順に始め、unmount では止めない (ロールタブ切替で鳴らさない)', async () => {
+    // まだ購読していない状態から mount する
+    roomsState.isWatching.value = false
     const wrapper = await mountSuspended(ManagerAlarmBar)
     expect(calls).toEqual(['start', 'connect(0)'])
+
+    // 運行管理者タブを離れても singleton は動いたまま — disconnect / stop は入らない (#205)
+    wrapper.unmount()
+    expect(calls).toEqual(['start', 'connect(0)'])
+  })
+
+  it('ロールタブを往復して再 mount しても購読も探索も二重に始めず、設定 off では切れる', async () => {
+    roomsState.isWatching.value = false
+    const wrapper = await mountSuspended(ManagerAlarmBar)
+    expect(calls).toEqual(['start', 'connect(0)'])
+    wrapper.unmount()
+
+    // singleton は動き続けている (購読中・デバイス接続済み) ので、戻ってきても呼び直さない
+    roomsState.isWatching.value = true
+    alarmState.isConnected.value = true
+    const again = await mountSuspended(ManagerAlarmBar)
+    expect(calls).toEqual(['start', 'connect(0)'])
+
+    // 呼び直していない再 mount 側でも、設定 off なら切れる
+    settingState.enabled.value = false
+    await again.vm.$nextTick()
+    expect(calls).toEqual(['start', 'connect(0)', 'disconnect', 'stop'])
+
+    again.unmount()
+    expect(calls).toEqual(['start', 'connect(0)', 'disconnect', 'stop'])
+  })
+
+  it('デバイス設定を off にしたときだけ切る (切った後の unmount では二重に切らない)', async () => {
+    roomsState.isWatching.value = false
+    const wrapper = await mountSuspended(ManagerAlarmBar)
+    expect(calls).toEqual(['start', 'connect(0)'])
+
+    settingState.enabled.value = false
+    await wrapper.vm.$nextTick()
+    expect(calls).toEqual(['start', 'connect(0)', 'disconnect', 'stop'])
 
     wrapper.unmount()
     expect(calls).toEqual(['start', 'connect(0)', 'disconnect', 'stop'])
@@ -101,6 +138,7 @@ describe('ManagerAlarmBar', () => {
 
   it('未設定 (既存の端末) なら問いかけカードだけを出し、[つなぐ] で保存してから探索を始める', async () => {
     settingState.enabled.value = null
+    roomsState.isWatching.value = false
     const wrapper = await mountSuspended(ManagerAlarmBar)
 
     expect(wrapper.find('[data-testid="manager-alarm-ask"]').exists()).toBe(true)
@@ -116,9 +154,9 @@ describe('ManagerAlarmBar', () => {
     expect(wrapper.find('[data-testid="manager-alarm-bar"]').exists()).toBe(true)
     expect(calls).toEqual(['start', 'connect(0)'])
 
-    // 始めた後の unmount は通常どおり止める
+    // 始めた後にロールタブを離れても止めない
     wrapper.unmount()
-    expect(calls).toEqual(['start', 'connect(0)', 'disconnect', 'stop'])
+    expect(calls).toEqual(['start', 'connect(0)'])
   })
 
   it('未設定で [つながない] を選ぶと保存して非表示になり、unmount でも何も止めない', async () => {


### PR DESCRIPTION
## 何を
`ManagerAlarmBar.vue` の `onUnmounted` で警告デバイスを切る (`alarm.disconnect()` + 着信購読の `stop()`) のをやめる。切るのは **設定 off** (`watch(enabled)` に false 方向の分岐を追加。これまで off で切れていたのは unmount の副作用だった) と **ページの unload** (`app.vue` の pagehide → grace=45、既存) の 2 つだけ。再 mount の `connect(0)` は `isConnected`、`start()` は `isWatching` で guard し、二重接続 / 参照カウントの増加を防ぐ。設計コメントを「ロールタブの切替では切らない」に書き直した。

## なぜ
実機 (2026-09-09、FE v0.0.84) で、運行管理者 PWA のロールタブを「システム管理者」に切り替えると警告デバイスが鳴った (沈黙の 5 秒ごとピピッ)。`index.vue:475` の `<ManagerAlarmBar v-if="activeRole === 'manager'">` が unmount され、その `onUnmounted` がポートを閉じて heartbeat を止めていたため。設計コメントの「タブを離れると鳴る」はブラウザを離れる意味で、SPA 内のロールタブ切替まで含めるつもりではなかった。`useAlarmDevice` / `useActiveRooms` は singleton なので、mount 中に始めた heartbeat と着信購読は unmount 後も続く (どのタブに居ても着信は鳴る)。

既知の穴 (今回は直さない): WS 再接続中 (`isWatching` が一瞬 false) にロールタブへ戻ると `start()` が 1 回余分に入り、購読の参照カウントが +1 される。鳴らない。

## テスト
`ManagerAlarmBar.test.ts`: 既存 2 件の `calls` 期待配列を「unmount では disconnect / stop が入らない」に書き換え、「設定 off で disconnect + stop」「再 mount で connect / start が増えない」を完全一致で追加 (13 passed、+3)。`tsc --noEmit` 0 / `vitest run` 54 files 1373 passed / coverage 100% (gate 変更なし)。

## 実機確認 (マージ後)
運行管理者 PWA でロールタブを「システム管理者」→「運行管理者」と往復しても警告デバイスは鳴らず、状態カードは接続のまま。設定 off で切れる。PWA を閉じると従来どおり 45 秒後に鳴る。

Closes #205
Refs ippoan/alc-app-s3#135, #177

🤖 Generated with [Claude Code](https://claude.com/claude-code)
