### PR TITLE
fix(kiosk): 運行者タブに端末未登録のバナーを出す (device JWT も管理者 JWT も無いとき) (Closes #206)

### DIFF
--- a/web/app/components/DeviceUnregisteredBanner.vue
+++ b/web/app/components/DeviceUnregisteredBanner.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+/**
+ * 運行者タブの入口に出す「端末未登録」の案内 (Refs #206)。
+ *
+ * 端末登録 (device JWT) も管理者ログイン (access token) も無いと、`api.ts` の request() は
+ * テナント無しの直 fetch に落ちる。すると by-nfc は 404 になり打刻一覧は空になるが、画面には
+ * 「乗務員に登録されていません」「本日の打刻はまだありません」としか出ず原因が分からない。
+ * 原因をここで 1 か所だけ出す (fallback 自体と各 catch の文言は触らない)。
+ */
+import { deviceUnregisteredMessage } from '~/utils/employee-lookup-messages'
+
+const { isAuthenticated, isDeviceActivated } = useAuth()
+</script>
+
+<template>
+  <div
+    v-if="!isAuthenticated && !isDeviceActivated"
+    data-testid="device-unregistered-banner"
+    class="w-full max-w-lg mx-auto px-4 mt-2"
+  >
+    <div class="bg-red-50 border border-red-200 rounded-xl p-3 text-sm text-red-700">
+      {{ deviceUnregisteredMessage }}。メニュー →「端末登録」で QR を読み取ってください。登録するまで免許証の照合と打刻一覧は動きません
+    </div>
+  </div>
+</template>

--- a/web/app/components/TimePunchKiosk.vue
+++ b/web/app/components/TimePunchKiosk.vue
@@ -2,6 +2,7 @@
 import type { ApiEmployee, TimePunchWithDevice } from '~/types'
 import { punchTimecard, listTimePunches, getEmployees } from '~/utils/api'
 import { jstTodayStartIso } from '~/utils/jst'
+import { deviceUnregisteredMessage } from '~/utils/employee-lookup-messages'
 
 const props = defineProps<{
   landscape?: boolean
@@ -143,7 +144,7 @@ onUnmounted(() => {
  */
 function punchFailureMessage(e: unknown): string {
   const err = e as { punchFailure?: string, status?: number } | undefined
-  if (err?.punchFailure === 'unpaired') return 'この端末は登録されていません (ペアリングが必要です)'
+  if (err?.punchFailure === 'unpaired') return deviceUnregisteredMessage
   if (err?.punchFailure === 'forbidden') return 'この端末では打刻できません (ペアリングの種別を確認してください)'
   return err?.status ? `打刻に失敗しました (${err.status})` : '打刻に失敗しました'
 }

--- a/web/app/pages/index.vue
+++ b/web/app/pages/index.vue
@@ -249,6 +249,9 @@ function onRoleTabClick(role: RoleTab) {
 
     <!-- 運行者タブ -->
     <template v-if="activeRole === 'driver'">
+      <!-- 端末未登録 (device JWT も管理者 JWT も無い) の案内 (Refs #206) -->
+      <DeviceUnregisteredBanner />
+
       <!-- 通常点呼 / 自動点呼 サブタブ + ハンバーガーメニュー (縦画面時のみ) -->
       <div v-if="!isAndroidLandscape" class="w-full max-w-lg mx-auto px-4 mt-2 flex items-center gap-2">
         <div class="flex-1 flex gap-1 bg-blue-100 rounded-lg p-1">

--- a/web/app/utils/employee-lookup-messages.ts
+++ b/web/app/utils/employee-lookup-messages.ts
@@ -14,3 +14,9 @@ export function employeeNotFoundByCode(code: string): string {
 export function noPendingSchedule(): string {
   return '未消費の点呼予定がありません。点呼予定を作成してから読み取り直してください'
 }
+
+/**
+ * 端末がペアリングされていない (device JWT が無い) とき。
+ * 打刻の失敗表示 (TimePunchKiosk) と運行者タブの入口バナーで同じ文言を使う (Refs #206)
+ */
+export const deviceUnregisteredMessage = 'この端末は登録されていません (ペアリングが必要です)'

--- a/web/tests/components/DeviceUnregisteredBanner.test.ts
+++ b/web/tests/components/DeviceUnregisteredBanner.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { ref, computed } from 'vue'
+import { mountSuspended, mockNuxtImport } from '@nuxt/test-utils/runtime'
+import DeviceUnregisteredBanner from '~/components/DeviceUnregisteredBanner.vue'
+import { deviceUnregisteredMessage } from '~/utils/employee-lookup-messages'
+
+// useAuth と同じ式 (useAuth.ts:48-49) をモック側でも保つ
+const accessToken = ref<string | null>(null)
+const deviceTenantId = ref<string | null>(null)
+
+mockNuxtImport('useAuth', () => () => ({
+  accessToken,
+  deviceTenantId,
+  isAuthenticated: computed(() => !!accessToken.value),
+  isDeviceActivated: computed(() => !!deviceTenantId.value),
+}))
+
+describe('DeviceUnregisteredBanner', () => {
+  beforeEach(() => {
+    accessToken.value = null
+    deviceTenantId.value = null
+  })
+
+  it('端末未登録かつ未ログインなら赤枠で原因と次の操作を出す', async () => {
+    const wrapper = await mountSuspended(DeviceUnregisteredBanner)
+
+    const banner = wrapper.find('[data-testid="device-unregistered-banner"]')
+    expect(banner.exists()).toBe(true)
+    expect(banner.text()).toContain(deviceUnregisteredMessage)
+    expect(banner.text()).toContain('「端末登録」で QR を読み取ってください')
+    expect(banner.text()).toContain('登録するまで免許証の照合と打刻一覧は動きません')
+    expect(wrapper.find('.border-red-200').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('端末登録済み / 管理者ログイン済みのどちらでも出さない', async () => {
+    deviceTenantId.value = 'tenant-x'
+    const activated = await mountSuspended(DeviceUnregisteredBanner)
+    expect(activated.find('[data-testid="device-unregistered-banner"]').exists()).toBe(false)
+    activated.unmount()
+
+    deviceTenantId.value = null
+    accessToken.value = 'jwt'
+    const loggedIn = await mountSuspended(DeviceUnregisteredBanner)
+    expect(loggedIn.find('[data-testid="device-unregistered-banner"]').exists()).toBe(false)
+    loggedIn.unmount()
+  })
+
+  it('登録が済んだ時点で消える', async () => {
+    const wrapper = await mountSuspended(DeviceUnregisteredBanner)
+    expect(wrapper.find('[data-testid="device-unregistered-banner"]').exists()).toBe(true)
+
+    deviceTenantId.value = 'tenant-x'
+    await wrapper.vm.$nextTick()
+    expect(wrapper.find('[data-testid="device-unregistered-banner"]').exists()).toBe(false)
+    wrapper.unmount()
+  })
+})

--- a/web/tests/utils/employee-lookup-messages.test.ts
+++ b/web/tests/utils/employee-lookup-messages.test.ts
@@ -3,6 +3,7 @@ import {
   employeeNotFoundByNfc,
   employeeNotFoundByCode,
   noPendingSchedule,
+  deviceUnregisteredMessage,
 } from '~/utils/employee-lookup-messages'
 
 describe('employee-lookup-messages', () => {
@@ -22,5 +23,10 @@ describe('employee-lookup-messages', () => {
     const msg = noPendingSchedule()
     expect(msg).toContain('未消費の点呼予定がありません')
     expect(msg).toContain('点呼予定を作成')
+  })
+
+  it('deviceUnregisteredMessage は未登録であることとペアリングが要ることを言う', () => {
+    expect(deviceUnregisteredMessage).toContain('登録されていません')
+    expect(deviceUnregisteredMessage).toContain('ペアリング')
   })
 })


### PR DESCRIPTION
## 何を
運行者タブの先頭に **端末未登録のバナー** (`DeviceUnregisteredBanner.vue`、新規) を置く。端末登録の device JWT も管理者ログインも無いとき (`!isAuthenticated && !isDeviceActivated`、`useAuth` の既存 ref) だけ赤枠で「この端末は登録されていません (ペアリングが必要です)。メニュー →「端末登録」で QR を読み取ってください。登録するまで免許証の照合と打刻一覧は動きません」を出す。文言の 1 文目は `TimePunchKiosk.vue` にあったものを `employee-lookup-messages.ts` の定数に移して 2 か所で共有。`api.ts` の 3 段 fallback と各 catch は触らない (認可は緩めない)。

## なぜ
実機 (2026-09-09、FE v0.0.84) で、Windows の運行者 PWA が「免許証は乗務員に未登録」「本日の打刻はまだありません」を出したが、**サーバには CoreS3 からの打刻が入っていて乗務員にも解決済み**だった (本番 API を `verify_eval` で実測)。この PC の運行者 PWA は端末登録されておらず管理者 JWT も無いため、`api.ts:97-116` の 3 段目 (テナント無しの直 fetch) に落ちて by-nfc が 404、一覧が空になり、画面がその原因をどこにも出していなかった。

simplify-reviewer の指摘で、新 composable と 4 か所の catch 文言分岐は撤回し、バナー 1 つに削った (判定式は `useFaceSync.ts:101` と同じ、文言は `TimePunchKiosk.vue:146` の流用)。

## テスト
- `tests/components/DeviceUnregisteredBanner.test.ts` 新規 3 本 (未登録かつ未ログイン → 出る / 登録済み → 出ない / ログイン済み → 出ない)、`employee-lookup-messages.test.ts` +1
- `tsc --noEmit` 0 / `vitest run` 55 files 1375 passed 2 skipped / coverage 100% (`coverage_100.toml` 無変更)

## 実機確認 (マージ後)
端末未登録の PC で運行者 PWA を開くと赤枠の案内が出る。メニュー →「端末登録」を済ませると案内が消え、免許証で点呼が進み、タイムカードに当日の打刻が出る。

Closes #206
Refs #202, ippoan/alc-app-s3#188, ippoan/alc-app-s3#135

🤖 Generated with [Claude Code](https://claude.com/claude-code)
