### PR TITLE
feat(tenko): 通常点呼から顔認証ステップを外す — NFC → 体温・血圧へ直結、顔承認 gate と指紋入口も通常点呼だけ外す (Closes #210)

### DIFF
--- a/web/app/components/NormalMeasurement.vue
+++ b/web/app/components/NormalMeasurement.vue
@@ -1,9 +1,8 @@
 <script setup lang="ts">
-import type { FaceAuthResult, MeasurementResult } from '~/types'
-import { getEmployeeByNfcId, getEmployeeByCode, startMeasurement, updateMeasurement, uploadFacePhoto, uploadBlowVideo } from '~/utils/api'
+import type { MeasurementResult } from '~/types'
+import { getEmployeeByNfcId, getEmployeeByCode, startMeasurement, updateMeasurement, uploadBlowVideo } from '~/utils/api'
 import { saveVideo, markVideoUploaded, getPendingVideos, cleanupOldVideos } from '~/utils/video-store'
 import { checkLicenseExpiry, formatExpiryDate, type LicenseExpiryStatus } from '~/utils/license'
-import { checkFaceApproval } from '~/utils/face-approval'
 import { employeeNotFoundByNfc, employeeNotFoundByCode } from '~/utils/employee-lookup-messages'
 
 const { isDemoMode: isDemoModeFromUrl } = useDemoMode()
@@ -15,11 +14,9 @@ const props = defineProps<{
 
 const isDemoMode = computed(() => props.demoMode || isDemoModeFromUrl.value)
 
-const step = ref<'nfc' | 'face_auth' | 'medical' | 'measuring' | 'result'>('nfc')
+const step = ref<'nfc' | 'medical' | 'measuring' | 'result'>('nfc')
 const employeeId = ref('')
-const authResult = ref<FaceAuthResult | null>(null)
 const measurementResult = ref<MeasurementResult | null>(null)
-const faceSnapshot = ref<Blob | null>(null)
 
 const saveError = ref<string | null>(null)
 const isSaving = ref(false)
@@ -42,8 +39,6 @@ const useManualInput = ref(false)
 
 // 測定レコード早期作成
 const activeMeasurementId = ref<string | null>(null)
-const facePhotoUploaded = ref(false)
-const faceVerified = ref<boolean | null>(null)
 
 // 録画 (measuring ステップ用)
 const {
@@ -83,13 +78,11 @@ async function onNfcRead(nfcId: string, expiryDate?: Date) {
   }
   try {
     const emp = await getEmployeeByNfcId(nfcId)
-    const err = checkFaceApproval(emp)
-    if (err) { approvalError.value = err; return }
     employeeId.value = emp.id
     employeeName.value = emp.name
     await tryStartMeasurement(emp.id)
     await faceSync()
-    step.value = 'face_auth'
+    step.value = 'medical'
   } catch {
     const msg = employeeNotFoundByNfc(nfcId)
     console.error(msg)
@@ -106,13 +99,11 @@ async function onManualSubmit() {
   approvalError.value = null
   try {
     const emp = await getEmployeeByCode(input)
-    const err = checkFaceApproval(emp)
-    if (err) { approvalError.value = err; return }
     employeeId.value = emp.id
     employeeName.value = emp.name
     await tryStartMeasurement(emp.id)
     await faceSync()
-    step.value = 'face_auth'
+    step.value = 'medical'
   } catch {
     manualError.value = employeeNotFoundByCode(input)
   }
@@ -134,81 +125,7 @@ watch(isDemoMode, (v) => {
 const manualMedicalData = ref<import('~/types').SubmitMedicalData | null>(null)
 const medicalInputSource = ref<'ble' | 'manual' | null>(null)
 
-// 顔認証結果
-function onFaceAuthResult(result: FaceAuthResult) {
-  authResult.value = result
-  if (result.verified) {
-    faceVerified.value = true
-    if (result.snapshot) {
-      faceSnapshot.value = result.snapshot
-    }
-    // 顔認証成功 → この端末と社員を紐付け（次回から指紋認証可能に）
-    if (employeeId.value) authorizeEmployee(employeeId.value)
-    step.value = 'medical'
-
-    // 顔写真 + face_verified を started レコードに記録（best-effort）
-    console.log('[Measurement] onFaceAuth: activeMeasurementId:', activeMeasurementId.value, 'hasSnapshot:', !!result.snapshot)
-    if (activeMeasurementId.value) {
-      if (result.snapshot) {
-        uploadFacePhoto(result.snapshot)
-          .then(url => {
-            console.log('[Measurement] face photo uploaded:', url)
-            facePhotoUploaded.value = true
-            return updateMeasurement(activeMeasurementId.value!, { face_photo_url: url, face_verified: true })
-          })
-          .then(() => console.log('[Measurement] face photo + face_verified saved to record'))
-          .catch(e => console.error('[Measurement] face photo upload/save failed:', e))
-      } else {
-        updateMeasurement(activeMeasurementId.value, { face_verified: true })
-          .catch(e => console.error('[Measurement] face_verified update failed:', e))
-      }
-    }
-  }
-}
-
-// 顔認証スキップ
-function onFaceAuthSkip() {
-  faceVerified.value = false
-  step.value = 'medical'
-
-  // face_verified = false を started レコードに記録（best-effort）
-  if (activeMeasurementId.value) {
-    updateMeasurement(activeMeasurementId.value, { face_verified: false })
-      .catch(e => console.error('[Measurement] face_verified skip update failed:', e))
-  }
-}
-
-// 指紋認証 (Android Bridge)
-const {
-  isFingerprintAvailable,
-  isEmployeeAuthorized,
-  authorizeEmployee,
-  requestFingerprint: triggerFingerprint,
-} = useFingerprint()
-
-const canUseFingerprint = computed(() =>
-  isFingerprintAvailable.value && employeeId.value && isEmployeeAuthorized(employeeId.value),
-)
-
-function requestFingerprint() {
-  triggerFingerprint()
-}
-
 onMounted(() => {
-  const handler = (e: Event) => {
-    const detail = (e as CustomEvent).detail
-    if (detail?.success) {
-      faceVerified.value = true
-      step.value = 'medical'
-      if (activeMeasurementId.value) {
-        updateMeasurement(activeMeasurementId.value, { face_verified: true })
-          .catch(e => console.error('[Measurement] fingerprint face_verified update failed:', e))
-      }
-    }
-  }
-  window.addEventListener('fingerprint-result', handler)
-  onUnmounted(() => window.removeEventListener('fingerprint-result', handler))
-
   // 録画: 7日超のローカル録画を削除 + 未アップロード分をリトライ
   cleanupOldVideos(7).catch(() => {})
   getPendingVideos().then(pending => {
@@ -350,23 +267,19 @@ async function onMeasurementResult(result: MeasurementResult) {
     console.log('[Measurement] activeMeasurementId:', activeMeasurementId.value, 'isOnline:', isOnline.value)
     if (activeMeasurementId.value && isOnline.value) {
       // started レコードを completed に更新
-      let facePhotoUrl: string | undefined
-      if (faceSnapshot.value && !facePhotoUploaded.value) {
-        facePhotoUrl = await uploadFacePhoto(faceSnapshot.value)
-      }
       const updateData = {
         status: 'completed',
         alcohol_value: result.alcoholValue,
         result_type: result.resultType,
         device_use_count: result.deviceUseCount,
-        face_photo_url: facePhotoUrl || result.facePhotoUrl,
+        face_photo_url: result.facePhotoUrl,
         measured_at: result.measuredAt.toISOString(),
         temperature: result.temperature,
         systolic: result.systolic,
         diastolic: result.diastolic,
         pulse: result.pulse,
         medical_measured_at: result.medicalMeasuredAt?.toISOString(),
-        face_verified: faceVerified.value,
+        face_verified: null,
         medical_manual_input: medicalInputSource.value === 'manual' ? true : undefined,
       }
       console.log('[Measurement] updateMeasurement PUT data:', JSON.stringify(updateData))
@@ -396,14 +309,14 @@ async function onMeasurementResult(result: MeasurementResult) {
     } else {
       // オフラインまたは activeMeasurementId なし → 従来のフロー
       console.log('[Measurement] fallback to offlineSave')
-      saveStatus.value = await offlineSave(result, faceSnapshot.value || undefined, activeMeasurementId.value || undefined, videoStoreId.value || undefined)
+      saveStatus.value = await offlineSave(result, undefined, activeMeasurementId.value || undefined, videoStoreId.value || undefined)
       if (recordedVideoBlob.value) videoUploadStatus.value = 'pending'
     }
   } catch (e) {
     // 更新失敗時はオフラインキューにフォールバック
     console.error('[Measurement] updateMeasurement failed:', e)
     try {
-      saveStatus.value = await offlineSave(result, faceSnapshot.value || undefined, activeMeasurementId.value || undefined, videoStoreId.value || undefined)
+      saveStatus.value = await offlineSave(result, undefined, activeMeasurementId.value || undefined, videoStoreId.value || undefined)
       if (recordedVideoBlob.value) videoUploadStatus.value = 'pending'
     } catch (e2) {
       saveError.value = e2 instanceof Error ? e2.message : '保存エラー'
@@ -422,17 +335,13 @@ function reset() {
   manualIdInput.value = ''
   manualError.value = null
   useManualInput.value = false
-  authResult.value = null
   measurementResult.value = null
-  faceSnapshot.value = null
   saveError.value = null
   saveStatus.value = null
   isSaving.value = false
   licenseExpiryDate.value = null
   licenseExpiryStatus.value = null
   activeMeasurementId.value = null
-  facePhotoUploaded.value = false
-  faceVerified.value = null
   manualMedicalData.value = null
   medicalInputSource.value = null
   recordedVideoBlob.value = null
@@ -441,8 +350,8 @@ function reset() {
   stopMeasuringCamera()
 }
 
-const steps = ['NFC', '顔認証', '体温・血圧', '測定', '結果'] as const
-const stepKeys = ['nfc', 'face_auth', 'medical', 'measuring', 'result'] as const
+const steps = ['NFC', '体温・血圧', '測定', '結果'] as const
+const stepKeys = ['nfc', 'medical', 'measuring', 'result'] as const
 const currentStepIndex = computed(() => stepKeys.indexOf(step.value))
 </script>
 
@@ -608,46 +517,7 @@ const currentStepIndex = computed(() => stepKeys.indexOf(step.value))
         </div>
       </div>
 
-      <!-- Step 2: 顔認証 (フルスクリーンオーバーレイ) -->
-      <Teleport to="body">
-        <div v-if="step === 'face_auth'" class="fixed inset-0 z-50 bg-black flex flex-col">
-          <!-- ヘッダー -->
-          <div class="flex items-center justify-between px-4 py-2 bg-black/80 text-white">
-            <div>
-              <h2 class="text-base font-semibold">顔認証</h2>
-              <p class="text-xs text-gray-300">{{ employeeName }}</p>
-            </div>
-            <button
-              v-if="!isDemoMode"
-              class="px-3 py-1.5 text-xs bg-gray-700 hover:bg-gray-600 text-white rounded-lg"
-              @click="onFaceAuthSkip"
-            >
-              スキップ
-            </button>
-          </div>
-          <!-- カメラ (残り全体を使用) -->
-          <div class="flex-1 min-h-0">
-            <FaceAuth
-              :employee-id="employeeId"
-              mode="verify"
-              :demo-mode="isDemoMode"
-              @result="onFaceAuthResult"
-            />
-          </div>
-          <!-- フッター: 指紋認証 -->
-          <div v-if="canUseFingerprint" class="px-4 py-3 bg-black/80">
-            <button
-              class="w-full px-4 py-3 bg-indigo-600 text-white rounded-xl font-medium hover:bg-indigo-700 transition-colors flex items-center justify-center gap-2"
-              @click="requestFingerprint"
-            >
-              <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 11c0-1.1.9-2 2-2s2 .9 2 2v3c0 1.66-1.34 3-3 3"/><path d="M8 15V11c0-2.21 1.79-4 4-4s4 1.79 4 4"/><path d="M2 11c0-5.52 4.48-10 10-10s10 4.48 10 10v3c0 3.31-2.69 6-6 6"/><path d="M12 11v4c0 .55-.45 1-1 1"/><path d="M6 11c0-3.31 2.69-6 6-6s6 2.69 6 6v2"/></svg>
-              指紋認証で本人確認
-            </button>
-          </div>
-        </div>
-      </Teleport>
-
-      <!-- Step 3: 体温・血圧 (BLE Medical Gateway / 手動入力) -->
+      <!-- Step 2: 体温・血圧 (BLE Medical Gateway / 手動入力) -->
       <div v-if="step === 'medical'" class="flex flex-col gap-4">
         <div class="bg-white rounded-2xl p-6 shadow-sm">
           <h2 class="text-lg font-semibold text-gray-700 mb-2">体温・血圧</h2>
@@ -684,7 +554,7 @@ const currentStepIndex = computed(() => stepKeys.indexOf(step.value))
         </div>
       </div>
 
-      <!-- Step 4: FC-1200 測定 -->
+      <!-- Step 3: FC-1200 測定 -->
       <div v-if="step === 'measuring'" class="flex flex-col gap-4">
         <div class="bg-white rounded-2xl p-6 shadow-sm">
           <h2 class="text-lg font-semibold text-gray-700 mb-4">アルコール測定</h2>
@@ -717,11 +587,10 @@ const currentStepIndex = computed(() => stepKeys.indexOf(step.value))
         </div>
       </div>
 
-      <!-- Step 5: 結果表示 -->
+      <!-- Step 4: 結果表示 -->
       <div v-if="step === 'result' && measurementResult" class="flex flex-col gap-4">
         <ResultCard
           :result="measurementResult"
-          :face-photo-blob="faceSnapshot"
           :employee-name="employeeName"
           @reset="reset"
         />

--- a/web/tests/components/NormalMeasurement.test.ts
+++ b/web/tests/components/NormalMeasurement.test.ts
@@ -7,14 +7,19 @@ import { employeeNotFoundByNfc } from '~/utils/employee-lookup-messages'
 // --- API のモック (NFC → 乗務員照合だけを動かす) ---
 
 const getEmployeeByNfcIdMock = vi.fn()
+const checkFaceApprovalMock = vi.fn(() => null)
 
 vi.mock('~/utils/api', () => ({
   getEmployeeByNfcId: (nfcId: string) => getEmployeeByNfcIdMock(nfcId),
   getEmployeeByCode: vi.fn(),
   startMeasurement: vi.fn(async () => ({ id: 'measurement-1' })),
   updateMeasurement: vi.fn(async () => ({})),
-  uploadFacePhoto: vi.fn(async () => 'https://example.com/face.jpg'),
   uploadBlowVideo: vi.fn(async () => 'https://example.com/blow.webm'),
+}))
+
+// 通常点呼は顔承認 gate を通さない (呼ばれないことを assert するためにモックする)
+vi.mock('~/utils/face-approval', () => ({
+  checkFaceApproval: (emp: unknown) => checkFaceApprovalMock(emp),
 }))
 
 vi.mock('~/utils/video-store', () => ({
@@ -67,13 +72,6 @@ mockNuxtImport('useBleGateway', () => () => ({
   latestBloodPressure: readonly(ref(null)),
 }))
 
-mockNuxtImport('useFingerprint', () => () => ({
-  isFingerprintAvailable: ref(false),
-  isEmployeeAuthorized: () => false,
-  authorizeEmployee: vi.fn(),
-  requestFingerprint: vi.fn(),
-}))
-
 // NfcStatus は表示と emit('read') だけなので、read を直接投げられるスタブに差し替える
 const NfcStatusStub = defineComponent({
   name: 'NfcStatus',
@@ -85,7 +83,7 @@ const APPROVED_EMPLOYEE = { id: 'emp-1', name: '山田太郎', face_approval_sta
 
 async function mountNfcStep() {
   const wrapper = await mountSuspended(NormalMeasurement, {
-    global: { stubs: { NfcStatus: NfcStatusStub, ClientOnly: false, Teleport: true } },
+    global: { stubs: { NfcStatus: NfcStatusStub, BleStatus: true, ClientOnly: false, Teleport: true } },
   })
   return wrapper
 }
@@ -111,7 +109,7 @@ describe('NormalMeasurement — NFC ステップの乗務員照合', () => {
     const alert = wrapper.find('.bg-red-50')
     expect(alert.exists()).toBe(true)
     expect(alert.text()).toBe(employeeNotFoundByNfc('2601012901010'))
-    // 進まない (顔認証の見出しは出ない)
+    // 進まない
     expect(wrapper.text()).toContain('乗務員ID')
     wrapper.unmount()
   })
@@ -127,6 +125,39 @@ describe('NormalMeasurement — NFC ステップの乗務員照合', () => {
     // NFC ステップを抜けている
     expect(wrapper.findComponent(NfcStatusStub).exists()).toBe(false)
     expect(faceSyncMock).toHaveBeenCalledTimes(1)
+    wrapper.unmount()
+  })
+
+  it('乗務員が引ければ顔認証を経ずに体温・血圧ステップへ進む', async () => {
+    getEmployeeByNfcIdMock.mockResolvedValue(APPROVED_EMPLOYEE)
+    const wrapper = await mountNfcStep()
+
+    await touch(wrapper, '2601012901010')
+
+    // 現在ステップのパンくず (青) が「体温・血圧」
+    const active = wrapper.findAll('div.rounded-full').filter(d => d.classes('bg-blue-600'))
+    expect(active).toHaveLength(1)
+    expect(active[0]!.text()).toBe('体温・血圧')
+    expect(wrapper.text()).toContain('体温・血圧')
+    wrapper.unmount()
+  })
+
+  it('通常点呼では顔データの承認 gate を通さない', async () => {
+    getEmployeeByNfcIdMock.mockResolvedValue({ ...APPROVED_EMPLOYEE, face_approval_status: 'pending' })
+    const wrapper = await mountNfcStep()
+
+    await touch(wrapper, '2601012901010')
+
+    expect(checkFaceApprovalMock).not.toHaveBeenCalled()
+    expect(wrapper.find('.bg-red-50').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('パンくずに「顔認証」が無い', async () => {
+    const wrapper = await mountNfcStep()
+
+    const labels = wrapper.findAll('div.rounded-full').map(d => d.text())
+    expect(labels).toEqual(['NFC', '体温・血圧', '測定', '結果'])
     wrapper.unmount()
   })
 


### PR DESCRIPTION
## 何を
運行者タブ「通常点呼」(`NormalMeasurement.vue`) のステップを **NFC → 体温・血圧 → 測定 → 結果** にする (顔認証ステップを外す)。

- 顔認証のフルスクリーンオーバーレイ (`<FaceAuth mode="verify">`) と、その中にあった指紋認証の入口 (顔認証の代替経路で単独では入口が無い) を削除
- NFC 直後の顔データ承認 gate (`checkFaceApproval`) を**通常点呼だけ**外す (残すと承認待ち / 未登録の乗務員が NFC の時点で止まり、顔認証を外した意味が無い。ユーザー承認済み)
- 保存する測定は `face_verified: null` (履歴では「-」。工程自体が無いので false の「スキップ」より実態に合う)、`face_photo_url` は測定結果の写真 (`result.facePhotoUrl`) のみ
- 残骸 (`authResult` / `facePhotoUploaded` / `faceSnapshot` / `faceVerified` / `authorizeEmployee` / 関連 import) を掃除。顔データ同期 (`faceSync` / `isFaceSyncing`) は他画面が使う singleton なので存置
- 点呼予定あり (`TenkoKiosk.vue`) / 認証ゲート / 顔登録 / 共有 component は不変。純減 −100 行

## なぜ
ユーザー要望 (2026-09-09)「通常点呼から顔認証を外して」。設定フラグは既存に無く、新設もしない (コードから外す)。

## テスト
`NormalMeasurement.test.ts` +3: NFC 成功 → `step` が `medical` / `checkFaceApproval` が呼ばれない / パンくずに「顔認証」が無い。既存 3 本 (赤枠 / 成功 / 次のタッチで消える) は不変。medical ステップが描画されるようになったため `BleStatus` を stub に (このテストの対象外)。`tsc --noEmit` 0 / `vitest run` 56 files 1390 passed 2 skipped / coverage 100% (`coverage_100.toml` 無変更)。

## 実機確認 (マージ後)
通常点呼で免許証をタッチ → 顔認証を挟まず体温・血圧へ。パンくずは 4 段。点呼予定あり (TenkoKiosk) の顔認証は従来どおり。

Closes #210
Refs ippoan/alc-app-s3#135, #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)
