### PR TITLE
feat(login): 端末登録済みブラウザの /login に「Google のアカウント選択に残った名前は『アカウントの削除』で消す」の注意文 (Refs #193)

### DIFF
--- a/web/app/pages/login.vue
+++ b/web/app/pages/login.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-const { loginWithGoogleRedirect, isAuthenticated, isLoading } = useAuth()
+const { loginWithGoogleRedirect, isAuthenticated, isLoading, isDeviceActivated } = useAuth()
 const route = useRoute()
 
 // 認証済みならリダイレクト (redirect クエリがあればそちらへ、なければ admin タブ)
@@ -44,6 +44,13 @@ function handleLogin() {
           </svg>
           Google でログイン
         </button>
+
+        <p
+          v-if="isDeviceActivated"
+          class="mt-4 text-left text-xs text-amber-800 bg-amber-50 border border-amber-200 rounded-lg p-3"
+        >
+          共用端末です。Google の「アカウントを選択」に前の利用者の名前が残っているときは、その名前の右のメニューから「アカウントの削除」を選んで消してください。ログアウトだけでは一覧から消えません。
+        </p>
       </template>
 
       <NuxtLink to="/" class="block mt-6 text-sm text-blue-600 hover:underline">


### PR DESCRIPTION
## 何を

`/login` の Google ボタンの直下に、端末登録済みブラウザ (共用の運行者端末) のときだけ注意文を出す:

> 共用端末です。Google の「アカウントを選択」に前の利用者の名前が残っているときは、その名前の右のメニューから「アカウントの削除」を選んで消してください。ログアウトだけでは一覧から消えません。

`web/app/pages/login.vue` の 1 ファイル。`useAuth()` から `isDeviceActivated` を取り、`v-if` で出し分ける。管理者 PC (端末未登録) には出ない。

## なぜ

共用端末で管理者がログアウトしても、Google の「アカウントを選択」に前の利用者の名前が「ログアウト済み」で残る。アプリからは消せない (`RemoveLocalAccount?email=` は 400、実測)。ユーザー決定 (2026-09-10) は「その画面の『アカウントの削除』を手動でやる」なので、ログアウト後に次の人が見る `/login` にその手順を出す。詳細は #193 の最後のコメント。

## 触っていないもの

`useAuth.logout()` (`window.open` の同 tick 制約) / `AdminDashboard.vue` / `DeviceUnregisteredBanner.vue` (表示条件が逆)。

## テスト

`npx tsc --noEmit` / `npx vitest run` (56 files, 1390 passed) / `npm run test:coverage` / `node scripts/check_coverage_100.mjs` (43 files 100%) すべて green。`pages/` は gate 未登録なのでテスト追加なし。

## 実機確認 (マージ後、ユーザー)

運行者端末で管理者がログアウト → `/login` に注意文が出る。管理者 PC の `/login` には出ない。

Refs #193, ippoan/alc-app-s3#135

🤖 Generated with [Claude Code](https://claude.com/claude-code)
