### PR TITLE
feat(kiosk): CoreS3 が USB で繋がっていれば管理者ログイン無しで自動的に端末登録する (AUTH TICKET → /device/pair/token) (Refs #213)

### DIFF
--- a/web/app/app.vue
+++ b/web/app/app.vue
@@ -4,6 +4,11 @@ import { RELOAD_REASON_KEY } from '~/utils/reload-reason'
 
 const { init, isLoading } = useAuth()
 const { isAndroidApp } = useFingerprint()
+// CoreS3 が USB で繋がっていれば管理者ログイン無しで端末登録する (#213)。
+// タブ・ロールに関わらず常時アクティブにするため app.vue で 1 回だけ呼ぶ (listener は
+// module 内で 1 度しか登録されない — 詳細は useHubClaim.ts)。TimePunchKiosk はこことは
+// 別に自分でも呼び、失敗理由 (lastError) だけを読んでバナーに出す。
+useHubClaim()
 const config = useRuntimeConfig()
 const apiBase = config.public.apiBase as string
 const stagingTenantId = config.public.stagingTenantId as string

--- a/web/app/components/TimePunchKiosk.vue
+++ b/web/app/components/TimePunchKiosk.vue
@@ -37,6 +37,13 @@ let highlightTimer: ReturnType<typeof setTimeout> | null = null
 const { getDeviceJwt } = useDeviceToken()
 
 /**
+ * CoreS3 経由の自動端末登録 (#213) の失敗理由。成功 / 未実行なら null。
+ * 登録の実行自体は app.vue が常時アクティブにしている (ここでは呼ぶ理由が useHubClaim.ts
+ * の listener 二重登録ガードに書いてあるとおり、lastError を読むためだけに呼ぶ)。
+ */
+const { lastError: hubClaimError } = useHubClaim()
+
+/**
  * 打刻更新の購読 (Refs ippoan/alc-app-s3#134)。**管理画面と同じ composable。**
  * 他の端末 (NFC タイムカード端末や別のキオスク) で打たれた打刻も、この画面の
  * 「本日の打刻履歴」に出したいので購読する。トークンはキオスクの device JWT、
@@ -164,6 +171,14 @@ function formatTime(iso: string): string {
       <header :class="['w-full text-center', landscape ? 'py-2' : 'max-w-md py-6']">
         <h1 :class="['font-bold text-gray-800', landscape ? 'text-lg' : 'text-2xl']">タイムカード</h1>
       </header>
+
+      <!-- CoreS3 経由の自動端末登録 (#213) の失敗バナー -->
+      <div
+        v-if="hubClaimError"
+        :class="['w-full mb-3 px-4 py-2 bg-red-50 text-red-600 text-sm font-medium rounded-lg text-center', landscape ? '' : 'max-w-md']"
+      >
+        {{ hubClaimError }}
+      </div>
 
       <!-- NFC 待機カード -->
       <div :class="['w-full bg-white rounded-2xl shadow-sm border p-6 text-center', landscape ? '' : 'max-w-md']">

--- a/web/app/composables/useCoreS3Serial.ts
+++ b/web/app/composables/useCoreS3Serial.ts
@@ -246,6 +246,14 @@ export function useCoreS3Serial() {
     await arbiter.unregister(CLAIMANT_NAME)
   }
 
+  /**
+   * 1 行送って応答 1 つを待つ (#213 の自動端末登録、後続の VoiceS3R 認証でも使用予定)。
+   * 実体は arbiter 側 (useSerialArbiter.request) — CoreS3 が預かっているポートに送る。
+   */
+  function request(line: string, matchPrefix: string, timeoutMs: number): Promise<string> {
+    return arbiter.request(CLAIMANT_NAME, line, matchPrefix, timeoutMs)
+  }
+
   return {
     isSupported,
     isConnected: readonly(isConnected),
@@ -259,5 +267,6 @@ export function useCoreS3Serial() {
     requestPort,
     release,
     disconnect,
+    request,
   }
 }

--- a/web/app/composables/useHubClaim.ts
+++ b/web/app/composables/useHubClaim.ts
@@ -33,8 +33,8 @@ const TICKET_MATCH_PREFIX = 'AUTH TICKET '
 
 /** `AUTH TICKET <ticket> EXPIRES=<秒>` を解く。マッチしなければ null */
 function parseTicketLine(line: string): { ticket: string } | null {
-  const m = line.match(/^AUTH TICKET (\S+) EXPIRES=\d+$/)
-  return m ? { ticket: m[1] } : null
+  const ticket = line.match(/^AUTH TICKET (\S+) EXPIRES=\d+$/)?.[1]
+  return ticket ? { ticket } : null
 }
 
 /** 直近の失敗理由 (画面表示用)。成功 / 未実行なら null */

--- a/web/app/composables/useHubClaim.ts
+++ b/web/app/composables/useHubClaim.ts
@@ -1,0 +1,118 @@
+/**
+ * CoreS3 が USB で繋がっていれば、管理者ログイン無しで自動的に端末登録する (#213)。
+ *
+ * 運行者タブの `TimePunchKiosk` は端末登録 (device-kiosk credential、`useDeviceToken`)
+ * が無いと打刻一覧が空になる。端末登録 (`device-claim.vue`) には本来、管理者の Google
+ * ログインが要るが、CoreS3 が USB で繋がっている PC はそれ自体が「その場に居る」証拠に
+ * なるので、firmware 経由で 1 回限りの登録トークンを取り、無人で端末登録まで済ませる。
+ *
+ * プロトコル (firmware は ippoan/alc-app-s3#204、auth-worker は ippoan/auth-worker#519):
+ *   host → dev  `AUTH TICKET`
+ *   dev  → host `AUTH TICKET <ticket> EXPIRES=<秒>`  … 成功
+ *   dev  → host `ERR AUTH TICKET: <理由>`            … 失敗
+ * ticket を既存の `POST <authWorkerUrl>/device/pair/token` (body `{device_code}`) に
+ * 渡すと `{device_id, device_secret, tenant_id, label}` が 1 回だけ返る。
+ *
+ * 保存は **device-claim.vue と同じ漏斗** (`useAuth().activateFromRegistration`) を使う —
+ * kiosk credential の保存経路をここで新設しない。`device_id`/`device_secret` は
+ * auth-worker の device-kiosk credential (`auth_device_id`/`device_secret` として渡す)。
+ * rust-alc-api 側の device 行 id は CoreS3 auto-claim には無いので渡さない
+ * (`activateDevice` の `devId` は省略可)。
+ *
+ * ここは CoreS3 の接続を自分で確立しない — `register`/`unregister` は呼ばない。
+ * NFC (`useNfcReader`) 側が unregister すると BLE ゲートウェイ (体温計・血圧計) まで
+ * 切れる実害があったため、既存の接続状態 (`useCoreS3Serial().isConnected`) と
+ * 書き込み口 (`request`) だけを使う (Refs ippoan/alc-app#182)。
+ */
+import { autoClaimFailedMessage } from '~/utils/employee-lookup-messages'
+
+/** firmware の `AUTH TICKET` 応答を待つ上限 (USB 記述子どおり 10 秒、契約は issue #213 参照) */
+const TICKET_TIMEOUT_MS = 10_000
+const TICKET_COMMAND = 'AUTH TICKET'
+const TICKET_MATCH_PREFIX = 'AUTH TICKET '
+
+/** `AUTH TICKET <ticket> EXPIRES=<秒>` を解く。マッチしなければ null */
+function parseTicketLine(line: string): { ticket: string } | null {
+  const m = line.match(/^AUTH TICKET (\S+) EXPIRES=\d+$/)
+  return m ? { ticket: m[1] } : null
+}
+
+/** 直近の失敗理由 (画面表示用)。成功 / 未実行なら null */
+const lastError = ref<string | null>(null)
+/** 二重起動防止 (同時に 1 回だけ) */
+let claiming = false
+/** CoreS3 の再接続ごとに 1 回だけ試すための onOpen 登録 (module 内で 1 度だけ) */
+let listenerInstalled = false
+
+export function useHubClaim() {
+  const { isDeviceActivated, activateFromRegistration } = useAuth()
+  const coreS3 = useCoreS3Serial()
+  const config = useRuntimeConfig()
+
+  /**
+   * `!isDeviceActivated && coreS3.isConnected` の条件が揃った瞬間に呼ばれる想定。
+   * 既に端末登録済み、または同時実行中なら何もしない。
+   */
+  async function attemptClaim(): Promise<void> {
+    if (claiming) return
+    if (isDeviceActivated.value) return
+    if (!coreS3.isConnected.value) return
+
+    claiming = true
+    lastError.value = null
+    try {
+      const line = await coreS3.request(TICKET_COMMAND, TICKET_MATCH_PREFIX, TICKET_TIMEOUT_MS)
+      const parsed = parseTicketLine(line)
+      if (!parsed) {
+        lastError.value = autoClaimFailedMessage(`予期しない応答: ${line}`)
+        return
+      }
+
+      // nuxt.config.ts が public.authWorkerUrl に既定値を持つので、ここでの fallback は
+      // 不要 (useAuth.ts の authWorkerUrl 参照と同じ流儀 — 到達不能な分岐を作らない)
+      const authWorkerUrl = (config.public.authWorkerUrl as string).replace(/\/$/, '')
+      const res = await fetch(`${authWorkerUrl}/device/pair/token`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ device_code: parsed.ticket }),
+      })
+      if (!res.ok) {
+        lastError.value = autoClaimFailedMessage(`http ${res.status}`)
+        return
+      }
+
+      const data = await res.json() as { device_id?: string, device_secret?: string, tenant_id?: string }
+      if (!data.tenant_id || !data.device_id || !data.device_secret) {
+        lastError.value = autoClaimFailedMessage('応答が不完全です')
+        return
+      }
+
+      // device-claim.vue と同じ漏斗。auth_device_id/device_secret が kiosk credential
+      activateFromRegistration({
+        tenant_id: data.tenant_id,
+        auth_device_id: data.device_id,
+        device_secret: data.device_secret,
+      })
+    }
+    catch (e) {
+      // request() の ERR/タイムアウト、または fetch の通信エラー
+      lastError.value = autoClaimFailedMessage(e instanceof Error ? e.message : String(e))
+    }
+    finally {
+      claiming = false
+    }
+  }
+
+  // CoreS3 の接続 (再接続含む) のたびに 1 回試す。listenerInstalled で二重登録を避ける
+  // (useHubClaim() は app.vue と TimePunchKiosk.vue の双方から呼ばれる想定)
+  if (!listenerInstalled) {
+    listenerInstalled = true
+    coreS3.onOpen(() => { void attemptClaim() })
+  }
+
+  return {
+    /** 直近の失敗理由。成功 / 未実行なら null */
+    lastError: readonly(lastError),
+    attemptClaim,
+  }
+}

--- a/web/app/composables/useSerialArbiter.ts
+++ b/web/app/composables/useSerialArbiter.ts
@@ -479,9 +479,13 @@ export function useSerialArbiter() {
    * (`useCoreS3Serial.write` の `HB` heartbeat 等、無関係な書き込みは通る)。
    */
   function request(name: string, line: string, matchPrefix: string, timeoutMs: number): Promise<string> {
-    const s = held.get(name)
-    if (!s) return Promise.reject(new Error(`request(${name}): ポートを預かっていません`))
-    if (pendingRequests.has(s)) return Promise.reject(new Error(`request(${name}): 既に応答待ちです`))
+    const held_ = held.get(name)
+    if (!held_) return Promise.reject(new Error(`request(${name}): ポートを預かっていません`))
+    if (pendingRequests.has(held_)) return Promise.reject(new Error(`request(${name}): 既に応答待ちです`))
+    // ↑ の narrowing はネストした function 宣言 (下の doResolve/doReject) の中までは
+    // 効かない (TS が閉包越しに const の絞り込みを保持しない) ので、常に非 undefined な
+    // 別の const に積み直す
+    const s: PortSession = held_
 
     return new Promise<string>((resolve, reject) => {
       const timer = setTimeout(() => {

--- a/web/app/composables/useSerialArbiter.ts
+++ b/web/app/composables/useSerialArbiter.ts
@@ -138,6 +138,22 @@ const passedOver = new Map<SerialPort, number>()
 let scanning = false
 let scanTimer: ReturnType<typeof setTimeout> | null = null
 
+/**
+ * `request()` が待っている応答 (session ごとに高々 1 件)。
+ *
+ * CoreS3 の自動端末登録 (#213) や後続の VoiceS3R 認証など、「1 行送って応答 1 つを
+ * 待つ」型のやり取りに使う。既存の行配送 (`owner.claimant.onLine`) はそのまま動かし
+ * 続け、これはそれに割り込んで見るだけ (二重配送だが、対象外の行は利用側で無視される)。
+ */
+interface PendingRequest {
+  matchPrefix: string
+  /** これで始まる行が来たら失敗として reject する (`ERR <送った行>`) */
+  errPrefix: string
+  resolve: (line: string) => void
+  reject: (err: Error) => void
+}
+const pendingRequests = new Map<PortSession, PendingRequest>()
+
 /** いま arbiter が握っているポートか (他の探索者がこれを掴まないための口) */
 export function isArbitratedPort(port: SerialPort): boolean {
   for (const s of sessions) {
@@ -204,6 +220,10 @@ export function useSerialArbiter() {
   // --- ストリーム ---
 
   async function closeSession(s: PortSession, reason: string): Promise<void> {
+    // 待っている request() があれば、応答が来ないまま宙に浮かせず reject する
+    // (reject 自体が pendingRequests から自分を消すので、ここでの delete は不要)
+    const pendingRequest = pendingRequests.get(s)
+    if (pendingRequest) pendingRequest.reject(new Error(`request: port closed (${reason})`))
     // 受信ループの finally が二重に release を呼ばないよう、先に持ち主を落とす
     const owner = s.owner
     s.owner = null
@@ -286,6 +306,13 @@ export function useSerialArbiter() {
       void pump(s, (line) => {
         // 採用後は利用側へ生のまま流す
         if (s.owner) {
+          // request() が待っていれば先に判定する (行の配送そのものは変えない。
+          // resolve/reject 自体が pendingRequests から自分を消すので delete は不要)
+          const pendingRequest = pendingRequests.get(s)
+          if (pendingRequest) {
+            if (line.startsWith(pendingRequest.matchPrefix)) pendingRequest.resolve(line)
+            else if (line.startsWith(pendingRequest.errPrefix)) pendingRequest.reject(new Error(line))
+          }
           s.owner.claimant.onLine(line)
           return
         }
@@ -438,12 +465,55 @@ export function useSerialArbiter() {
     scheduleScan(RESCAN_INTERVAL)
   }
 
+  /**
+   * 1 行送って、応答 1 つを待つ (CoreS3 の自動端末登録 #213 / 後続の VoiceS3R 認証で使用)。
+   *
+   * `line` を書き、その後に届く行のうち `matchPrefix` で始まる最初の行で resolve する。
+   * `ERR <line>` で始まる行が先に来たら、それを reject する (firmware がコマンドを
+   * 認識しつつ失敗を返したとき用)。`timeoutMs` 経過しても届かなければ reject する。
+   *
+   * 同時に 1 件しか待てない (2 件目を呼ぶと 1 件目は sessionの入れ替えで上書きされ、
+   * 待ち続けたまま応答を受け取れなくなる) — 呼び出し側は await してから次を呼ぶこと。
+   * 既存の行配送 (`onLine` / `onEvent` 等) は変えない。
+   */
+  function request(name: string, line: string, matchPrefix: string, timeoutMs: number): Promise<string> {
+    const s = held.get(name)
+    if (!s) return Promise.reject(new Error(`request(${name}): ポートを預かっていません`))
+
+    return new Promise<string>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        doReject(new Error(`request(${name}): timeout waiting for "${matchPrefix}"`))
+      }, timeoutMs)
+
+      // resolve/reject は必ずこの 2 つ経由で呼ぶ。Promise は 2 度目以降の settle が
+      // 無害な no-op になる (ネイティブの仕様) ので、「まだ待っているか」を呼び出し側で
+      // 確かめる防御コードを書かずに済む — 二重の delete/timer 解除も安全に重ねられる。
+      function doResolve(l: string): void {
+        clearTimeout(timer)
+        pendingRequests.delete(s)
+        resolve(l)
+      }
+      function doReject(e: Error): void {
+        clearTimeout(timer)
+        pendingRequests.delete(s)
+        reject(e)
+      }
+
+      pendingRequests.set(s, { matchPrefix, errPrefix: `ERR ${line}`, resolve: doResolve, reject: doReject })
+
+      void writeLine(s.writer, line).then((ok) => {
+        if (!ok) doReject(new Error(`request(${name}): write failed`))
+      })
+    })
+  }
+
   return {
     isSupported,
     isArbitratedPort,
     register,
     unregister,
     release,
+    request,
     /** `delay` ミリ秒後に探索を始める。以後は見つかるまで 10 秒ごと */
     start: scheduleScan,
     /** WebSerial の初回許可 (ユーザー操作が要る) */

--- a/web/app/composables/useSerialArbiter.ts
+++ b/web/app/composables/useSerialArbiter.ts
@@ -472,13 +472,16 @@ export function useSerialArbiter() {
    * `ERR <line>` で始まる行が先に来たら、それを reject する (firmware がコマンドを
    * 認識しつつ失敗を返したとき用)。`timeoutMs` 経過しても届かなければ reject する。
    *
-   * 同時に 1 件しか待てない (2 件目を呼ぶと 1 件目は sessionの入れ替えで上書きされ、
-   * 待ち続けたまま応答を受け取れなくなる) — 呼び出し側は await してから次を呼ぶこと。
-   * 既存の行配送 (`onLine` / `onEvent` 等) は変えない。
+   * **同時に 1 件しか待てない。** 1 件目が待っている間に 2 件目を呼ぶと、2 件目は
+   * 書かずに即 reject する (1 件目の完了 or タイムアウトまで待ってから呼び直すこと)。
+   * `matchPrefix`/`errPrefix` のどちらにも当てはまらない行は横取りせず、判定だけして
+   * そのまま `onLine` へ流す。**待っている間も `writeLine` 自体は塞がない**
+   * (`useCoreS3Serial.write` の `HB` heartbeat 等、無関係な書き込みは通る)。
    */
   function request(name: string, line: string, matchPrefix: string, timeoutMs: number): Promise<string> {
     const s = held.get(name)
     if (!s) return Promise.reject(new Error(`request(${name}): ポートを預かっていません`))
+    if (pendingRequests.has(s)) return Promise.reject(new Error(`request(${name}): 既に応答待ちです`))
 
     return new Promise<string>((resolve, reject) => {
       const timer = setTimeout(() => {

--- a/web/app/utils/employee-lookup-messages.ts
+++ b/web/app/utils/employee-lookup-messages.ts
@@ -20,3 +20,12 @@ export function noPendingSchedule(): string {
  * 打刻の失敗表示 (TimePunchKiosk) と運行者タブの入口バナーで同じ文言を使う (Refs #206)
  */
 export const deviceUnregisteredMessage = 'この端末は登録されていません (ペアリングが必要です)'
+
+/**
+ * CoreS3 経由の自動端末登録 (#213) が失敗したとき。理由 (AUTH TICKET の ERR / タイムアウト /
+ * auth-worker の HTTP エラー) を添えて、現地の人が次の一手 (管理者に連絡する等) を選べるように
+ * する。文言だけを出す — 端末登録は依然として管理者の Google ログイン (device-claim) で可能
+ */
+export function autoClaimFailedMessage(reason: string): string {
+  return `CoreS3 経由の端末登録に失敗しました: ${reason}`
+}

--- a/web/coverage_100.toml
+++ b/web/coverage_100.toml
@@ -126,6 +126,10 @@ branches = true
 path = "app/composables/useCoreS3Serial.ts"
 branches = true
 
+[[files]]
+path = "app/composables/useHubClaim.ts"
+branches = true
+
 # --- plugins ---
 
 [[files]]

--- a/web/tests/composables/useCoreS3Serial.test.ts
+++ b/web/tests/composables/useCoreS3Serial.test.ts
@@ -499,6 +499,33 @@ describe('useCoreS3Serial', () => {
     })
   })
 
+  // ---------- request (#213 CoreS3 自動端末登録) ----------
+
+  describe('request', () => {
+    it('行を書いて matchPrefix の応答で resolve する (arbiter.request を CLAIMANT_NAME で呼ぶ)', async () => {
+      const dev = createMockPort()
+      installSerialMock({ getPorts: vi.fn(async () => [dev.port]) })
+      await load()
+      dev.emit('{"type":"ready"}\n')
+      await connect()
+
+      const p = core.request('AUTH TICKET', 'AUTH TICKET ', 10_000)
+      await vi.advanceTimersByTimeAsync(0)
+      expect(dev.writes.at(-1)).toBe('AUTH TICKET\n')
+
+      dev.emit('AUTH TICKET tkt-1 EXPIRES=300\n')
+      await vi.advanceTimersByTimeAsync(0)
+      await expect(p).resolves.toBe('AUTH TICKET tkt-1 EXPIRES=300')
+    })
+
+    it('未接続なら reject する (ポートを預かっていない)', async () => {
+      installSerialMock({ getPorts: vi.fn(async () => []) })
+      await load()
+
+      await expect(core.request('AUTH TICKET', 'AUTH TICKET ', 10_000)).rejects.toThrow()
+    })
+  })
+
   // ---------- 公開 API の形 ----------
 
   it('navigator.serial は直接触らない (列挙は arbiter 経由)', async () => {

--- a/web/tests/composables/useHubClaim.test.ts
+++ b/web/tests/composables/useHubClaim.test.ts
@@ -1,0 +1,288 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+/**
+ * useHubClaim (#213 CoreS3 経由の自動端末登録) のテスト。
+ *
+ * useCoreS3Serial / useSerialArbiter は実体を使う (mock しない) — CoreS3 の
+ * 接続そのものは useCoreS3Serial.test.ts / useSerialArbiter.test.ts が担保済みなので、
+ * ここでは「接続イベントを受けて何をするか」だけを見る。
+ *
+ * **navigator.serial は load() より前に installSerialMock で用意すること。**
+ * `useCoreS3Serial()` (→ `useSerialArbiter()`) は呼ばれた瞬間に
+ * `isWebSerialSupported()` を評価して `isSupported` に固定するため、後から
+ * navigator.serial を生やしても遅い (useCoreS3Serial.test.ts と同じ制約)。
+ */
+
+// --- Mock SerialPort (useCoreS3Serial.test.ts と同型) ---
+function createMockPort(options?: { vid?: number }) {
+  const queue: Array<{ value?: Uint8Array; done: boolean }> = []
+  let pending: ((chunk: { value?: Uint8Array; done: boolean }) => void) | null = null
+
+  const reader = {
+    read: vi.fn(() => {
+      const next = queue.shift()
+      if (next) return Promise.resolve(next)
+      return new Promise<{ value?: Uint8Array; done: boolean }>((resolve) => { pending = resolve })
+    }),
+    cancel: vi.fn(async () => {
+      if (pending) { pending({ value: undefined, done: true }); pending = null }
+    }),
+    releaseLock: vi.fn(),
+  }
+
+  function push(chunk: { value?: Uint8Array; done: boolean }) {
+    if (pending) { pending(chunk); pending = null }
+    else queue.push(chunk)
+  }
+
+  const writes: string[] = []
+  const writer = {
+    write: vi.fn(async (data: Uint8Array) => { writes.push(new TextDecoder().decode(data)) }),
+    releaseLock: vi.fn(),
+  }
+
+  const port = {
+    open: vi.fn(async () => {}),
+    close: vi.fn(async () => {}),
+    readable: { getReader: vi.fn(() => reader) },
+    writable: { getWriter: vi.fn(() => writer) },
+    getInfo: vi.fn(() => ({ usbVendorId: options?.vid ?? 0x303A, usbProductId: 0x1001 })),
+  }
+
+  return { port, writes, emit: (text: string) => push({ value: new TextEncoder().encode(text), done: false }) }
+}
+
+function installSerialMock(getPorts: ReturnType<typeof vi.fn>) {
+  Object.defineProperty(navigator, 'serial', {
+    value: { requestPort: vi.fn(), getPorts },
+    configurable: true,
+    writable: true,
+  })
+}
+
+/** dev port を作り、CoreS3 として見つかるように navigator.serial へ仕込む (load() より前に呼ぶこと) */
+function prepareSerial() {
+  const dev = createMockPort()
+  installSerialMock(vi.fn(async () => [dev.port]))
+  return dev
+}
+
+describe('useHubClaim', () => {
+  let hubMod: typeof import('~/composables/useHubClaim')
+  let authMod: typeof import('~/composables/useAuth')
+  let coreMod: typeof import('~/composables/useCoreS3Serial')
+  let hub: ReturnType<typeof hubMod.useHubClaim>
+  let auth: ReturnType<typeof authMod.useAuth>
+  let core: ReturnType<typeof coreMod.useCoreS3Serial>
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  /** 3 つのモジュールを新しい singleton state で読み込む。navigator.serial は先に用意しておくこと */
+  async function load() {
+    vi.resetModules()
+    authMod = await import('~/composables/useAuth')
+    coreMod = await import('~/composables/useCoreS3Serial')
+    hubMod = await import('~/composables/useHubClaim')
+    auth = authMod.useAuth()
+    core = coreMod.useCoreS3Serial()
+    hub = hubMod.useHubClaim()
+  }
+
+  /** JSON ready 行を先着させて claim させる (onOpen が発火し、登録済みリスナーが attemptClaim を走らせる) */
+  async function claim(dev: ReturnType<typeof createMockPort>) {
+    dev.emit('{"type":"ready"}\n')
+    const p = core.connect(0)
+    await vi.advanceTimersByTimeAsync(0)
+    await p
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+    vi.useFakeTimers({ toFake: ['setTimeout', 'setInterval', 'clearTimeout', 'clearInterval', 'Date'] })
+    delete (navigator as any).serial
+    fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  afterEach(async () => {
+    await core?.disconnect()
+    delete (navigator as any).serial
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it('未登録 + CoreS3 接続 → AUTH TICKET → pair/token 成功で端末登録される (device-claim と同じ保存関数)', async () => {
+    const dev = prepareSerial()
+    await load()
+    expect(auth.isDeviceActivated.value).toBe(false)
+
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ device_id: 'dev-1', device_secret: 'sec-1', tenant_id: 'tenant-1', label: 'CoreS3' }),
+    })
+
+    await claim(dev)
+    await vi.advanceTimersByTimeAsync(0)
+    expect(dev.writes).toContain('AUTH TICKET\n')
+
+    dev.emit('AUTH TICKET tkt-xyz EXPIRES=300\n')
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('/device/pair/token'),
+      expect.objectContaining({ method: 'POST', body: JSON.stringify({ device_code: 'tkt-xyz' }) }),
+    )
+    expect(auth.isDeviceActivated.value).toBe(true)
+    expect(localStorage.getItem('alc_kiosk_device_id')).toBe('dev-1')
+    expect(localStorage.getItem('alc_kiosk_device_secret')).toBe('sec-1')
+    expect(hub.lastError.value).toBeNull()
+  })
+
+  it('既に端末登録済みなら CoreS3 が繋がっても何もしない (fetch しない)', async () => {
+    const dev = prepareSerial()
+    localStorage.setItem('alc_device_tenant_id', 'existing-tenant')
+    await load()
+    expect(auth.isDeviceActivated.value).toBe(true)
+
+    await claim(dev)
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('CoreS3 未接続なら attemptClaim は何もしない', async () => {
+    await load()
+    await hub.attemptClaim()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('同時に 2 回走らせても 1 回しか実行しない (claiming ガード)', async () => {
+    const dev = prepareSerial()
+    await load()
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ device_id: 'dev-1', device_secret: 'sec-1', tenant_id: 'tenant-1' }),
+    })
+    await claim(dev)
+    await vi.advanceTimersByTimeAsync(0)
+
+    // 1 本目の request() が pending (ticket 未応答) のうちにもう一度呼ぶ
+    void hub.attemptClaim()
+    await vi.advanceTimersByTimeAsync(0)
+
+    // AUTH TICKET は 1 回しか送られない
+    expect(dev.writes.filter(w => w === 'AUTH TICKET\n')).toHaveLength(1)
+  })
+
+  it('リスナーは二重登録されない (useHubClaim を複数回呼んでも接続ごとに 1 回)', async () => {
+    const dev = prepareSerial()
+    await load()
+    hubMod.useHubClaim()
+    hubMod.useHubClaim()
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ device_id: 'dev-1', device_secret: 'sec-1', tenant_id: 'tenant-1' }),
+    })
+
+    await claim(dev)
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(dev.writes.filter(w => w === 'AUTH TICKET\n')).toHaveLength(1)
+  })
+
+  it('AUTH TICKET の応答が予期しない形なら lastError に出す', async () => {
+    const dev = prepareSerial()
+    await load()
+    await claim(dev)
+    await vi.advanceTimersByTimeAsync(0)
+
+    dev.emit('AUTH TICKET malformed\n')
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(hub.lastError.value).toContain('CoreS3')
+    expect(hub.lastError.value).toContain('予期しない応答')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('pair/token が非 2xx なら http status を lastError に出す', async () => {
+    const dev = prepareSerial()
+    await load()
+    fetchMock.mockResolvedValue({ ok: false, status: 404 })
+    await claim(dev)
+    await vi.advanceTimersByTimeAsync(0)
+
+    dev.emit('AUTH TICKET tkt-1 EXPIRES=300\n')
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(hub.lastError.value).toContain('http 404')
+    expect(auth.isDeviceActivated.value).toBe(false)
+  })
+
+  it('pair/token の応答が不完全なら lastError に出す', async () => {
+    const dev = prepareSerial()
+    await load()
+    fetchMock.mockResolvedValue({ ok: true, json: () => Promise.resolve({ tenant_id: 'tenant-1' }) })
+    await claim(dev)
+    await vi.advanceTimersByTimeAsync(0)
+
+    dev.emit('AUTH TICKET tkt-1 EXPIRES=300\n')
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(hub.lastError.value).toContain('応答が不完全です')
+    expect(auth.isDeviceActivated.value).toBe(false)
+  })
+
+  it('ERR AUTH TICKET は理由を lastError に出す (Error 経由の catch)', async () => {
+    const dev = prepareSerial()
+    await load()
+    await claim(dev)
+    await vi.advanceTimersByTimeAsync(0)
+
+    dev.emit('ERR AUTH TICKET: not ready\n')
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(hub.lastError.value).toContain('ERR AUTH TICKET: not ready')
+  })
+
+  it('タイムアウトは理由を lastError に出す', async () => {
+    const dev = prepareSerial()
+    await load()
+    await claim(dev)
+    await vi.advanceTimersByTimeAsync(0)
+
+    await vi.advanceTimersByTimeAsync(10_000)
+
+    expect(hub.lastError.value).toContain('timeout')
+  })
+
+  it('fetch が Error でない値で reject しても lastError に出す (String(e) 経由の catch)', async () => {
+    const dev = prepareSerial()
+    await load()
+    fetchMock.mockRejectedValue('boom')
+    await claim(dev)
+    await vi.advanceTimersByTimeAsync(0)
+
+    dev.emit('AUTH TICKET tkt-1 EXPIRES=300\n')
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(hub.lastError.value).toContain('boom')
+  })
+
+  it('CoreS3 再接続のたびに 1 回試す', async () => {
+    const dev = prepareSerial()
+    await load()
+    fetchMock.mockResolvedValue({ ok: false, status: 500 })
+    await claim(dev)
+    await vi.advanceTimersByTimeAsync(0)
+    dev.emit('AUTH TICKET tkt-1 EXPIRES=300\n')
+    await vi.advanceTimersByTimeAsync(0)
+    expect(hub.lastError.value).toContain('http 500')
+
+    await core.disconnect()
+    const dev2 = createMockPort()
+    installSerialMock(vi.fn(async () => [dev2.port]))
+    await claim(dev2)
+    await vi.advanceTimersByTimeAsync(0)
+    expect(dev2.writes).toContain('AUTH TICKET\n')
+  })
+})

--- a/web/tests/composables/useSerialArbiter.test.ts
+++ b/web/tests/composables/useSerialArbiter.test.ts
@@ -747,6 +747,94 @@ describe('useSerialArbiter', () => {
       expect(await mod.writeLine(ngWriter, 'HB OK')).toBe(false)
     })
   })
+
+  // ---------- request (#213 CoreS3 自動端末登録 / 後続の VoiceS3R 認証) ----------
+
+  describe('request', () => {
+    /** 'core' を claim させてから返す (writer への直アクセス用に seen も返す) */
+    async function claimAsCore() {
+      const dev = createMockPort()
+      dev.emit('CORE hello\n')
+      installSerialMock({ getPorts: vi.fn(async () => [dev.port]) })
+      await load()
+
+      const { claimant, seen } = createClaimant('CORE', 'ZZZ')
+      arbiter.register('core', claimant)
+      await vi.advanceTimersByTimeAsync(0)
+      expect(seen.opened).toBe(1)
+      return { dev, seen }
+    }
+
+    it('行を書いて matchPrefix で始まる応答で resolve する (onLine への配送は壊さない)', async () => {
+      const { dev, seen } = await claimAsCore()
+
+      const p = arbiter.request('core', 'AUTH TICKET', 'AUTH TICKET ', 10_000)
+      await vi.advanceTimersByTimeAsync(0)
+      expect(dev.writes.at(-1)).toBe('AUTH TICKET\n')
+
+      dev.emit('AUTH TICKET abc123 EXPIRES=300\n')
+      await vi.advanceTimersByTimeAsync(0)
+
+      await expect(p).resolves.toBe('AUTH TICKET abc123 EXPIRES=300')
+      // 既存の行配送 (onLine) は変えない — claimant にも同じ行が届く
+      expect(seen.lines).toContain('AUTH TICKET abc123 EXPIRES=300')
+    })
+
+    it('`ERR <送った行>` で始まる応答は reject する', async () => {
+      const { dev } = await claimAsCore()
+
+      const p = arbiter.request('core', 'AUTH TICKET', 'AUTH TICKET ', 10_000)
+      // reject より前に handler を付けておく (付ける前に settle すると
+      // vitest が "Unhandled Rejection" として拾ってしまうため)
+      const assertion = expect(p).rejects.toThrow('ERR AUTH TICKET: not ready')
+      await vi.advanceTimersByTimeAsync(0)
+
+      dev.emit('ERR AUTH TICKET: not ready\n')
+      await vi.advanceTimersByTimeAsync(0)
+
+      await assertion
+    })
+
+    it('無関係な行では resolve も reject もせず、timeoutMs で reject する', async () => {
+      const { dev } = await claimAsCore()
+
+      const p = arbiter.request('core', 'AUTH TICKET', 'AUTH TICKET ', 10_000)
+      const assertion = expect(p).rejects.toThrow(/timeout/)
+      await vi.advanceTimersByTimeAsync(0)
+      dev.emit('EVT SOMETHING else\n')
+      await vi.advanceTimersByTimeAsync(0)
+
+      await vi.advanceTimersByTimeAsync(10_000)
+      await assertion
+    })
+
+    it('書き込みに失敗したら reject する', async () => {
+      const { seen } = await claimAsCore()
+      ;(seen.writer as unknown as { write: ReturnType<typeof vi.fn> }).write
+        = vi.fn().mockRejectedValueOnce(new Error('write failed'))
+
+      const p = arbiter.request('core', 'AUTH TICKET', 'AUTH TICKET ', 10_000)
+      await expect(p).rejects.toThrow('write failed')
+    })
+
+    it('その名前でポートを預かっていなければ書かずに即 reject する', async () => {
+      await load()
+      await expect(arbiter.request('core', 'AUTH TICKET', 'AUTH TICKET ', 10_000))
+        .rejects.toThrow('ポートを預かっていません')
+    })
+
+    it('待っている間にポートを失ったら reject する (抜線・release)', async () => {
+      await claimAsCore()
+
+      const p = arbiter.request('core', 'AUTH TICKET', 'AUTH TICKET ', 10_000)
+      const assertion = expect(p).rejects.toThrow(/port closed/)
+      await vi.advanceTimersByTimeAsync(0)
+
+      await arbiter.release('core')
+
+      await assertion
+    })
+  })
 })
 
 // ---------- 診断ログ (#197) ----------

--- a/web/tests/composables/useSerialArbiter.test.ts
+++ b/web/tests/composables/useSerialArbiter.test.ts
@@ -780,6 +780,27 @@ describe('useSerialArbiter', () => {
       expect(seen.lines).toContain('AUTH TICKET abc123 EXPIRES=300')
     })
 
+    it('応答待ち中に 2 件目を呼ぶと書かずに即 reject する (同時に 1 件しか待てない)', async () => {
+      const { dev } = await claimAsCore()
+
+      const p1 = arbiter.request('core', 'AUTH TICKET', 'AUTH TICKET ', 10_000)
+      await vi.advanceTimersByTimeAsync(0)
+      expect(dev.writes.filter(w => w === 'AUTH TICKET\n')).toHaveLength(1)
+
+      await expect(arbiter.request('core', 'AUTH SIGN', 'AUTH SIGN ', 10_000))
+        .rejects.toThrow('既に応答待ちです')
+      // 2 件目は書かれていない (1 件目の応答待ちのみ)
+      expect(dev.writes).not.toContain('AUTH SIGN\n')
+
+      // 1 件目は生きたまま — 待っている間も他の writeLine (HB 等) は塞がない
+      expect(await mod.writeLine(dev.port.writable.getWriter(), 'HB OK')).toBe(true)
+      expect(dev.writes).toContain('HB OK\n')
+
+      dev.emit('AUTH TICKET abc123 EXPIRES=300\n')
+      await vi.advanceTimersByTimeAsync(0)
+      await expect(p1).resolves.toBe('AUTH TICKET abc123 EXPIRES=300')
+    })
+
     it('`ERR <送った行>` で始まる応答は reject する', async () => {
       const { dev } = await claimAsCore()
 

--- a/web/tests/utils/employee-lookup-messages.test.ts
+++ b/web/tests/utils/employee-lookup-messages.test.ts
@@ -4,6 +4,7 @@ import {
   employeeNotFoundByCode,
   noPendingSchedule,
   deviceUnregisteredMessage,
+  autoClaimFailedMessage,
 } from '~/utils/employee-lookup-messages'
 
 describe('employee-lookup-messages', () => {
@@ -28,5 +29,11 @@ describe('employee-lookup-messages', () => {
   it('deviceUnregisteredMessage は未登録であることとペアリングが要ることを言う', () => {
     expect(deviceUnregisteredMessage).toContain('登録されていません')
     expect(deviceUnregisteredMessage).toContain('ペアリング')
+  })
+
+  it('autoClaimFailedMessage は CoreS3 経由であることと理由を含む', () => {
+    const msg = autoClaimFailedMessage('http 404')
+    expect(msg).toContain('CoreS3')
+    expect(msg).toContain('http 404')
   })
 })


### PR DESCRIPTION
## 何を

**CoreS3 が USB で繋がっていれば、管理者ログイン無しで自動的に端末登録する。** 運行者タブのタイムカードは端末登録 (device-kiosk 資格情報) が無いと打刻一覧が空になり、端末登録には管理者の Google ログインが要った。

- `useSerialArbiter.request(name, line, matchPrefix, timeoutMs)`: 1 行送って応答 1 つを待つ口 (matchPrefix で始まる最初の行で resolve、`ERR …` かタイムアウトで reject。他の行は既存の `onLine` 配送のまま)。`useCoreS3Serial` から薄いラッパで export (後続の VoiceS3R 認証 #214 も同じ口を使う)
- `useHubClaim` (新規、`app.vue` で常時アクティブ): `!isDeviceActivated && coreS3.isConnected` になったら接続ごとに 1 回、`AUTH TICKET` を送り (firmware ippoan/alc-app-s3#206)、`AUTH TICKET <ticket> EXPIRES=<秒>` を既存の `POST /device/pair/token` (auth-worker、一回券 = ippoan/auth-worker#520) で引き換え、`device-claim.vue` と同じ保存関数に渡す。以後 `TimePunchKiosk` は既存の device JWT 経路で動く
- 失敗 (`ERR AUTH TICKET: …` / タイムアウト / HTTP) は `TimePunchKiosk` 上部に 1 行 (`employee-lookup-messages.ts` に定数化)
- `api.ts` / `RoleAuthGate.vue` / `device-claim.vue` は不変

## なぜ

ユーザー要望 (2026-09-10)「ログインしていないとタイムカードが表示されない。S3 と通信して出せるようにできないか」。CoreS3 に物理的に繋がった PC だけが登録でき、secret も JWT も USB に出ない (券だけ)。

## テスト

`tsc` OK / `vitest` 1411 passed / `check_coverage_100.mjs` 44 files 100/100 (`useHubClaim.ts` 登録)。

## 実機確認 (マージ後、ユーザー。CoreS3 は firmware main 7a595bb 以降を OTA)

端末未登録の運行者 PC に CoreS3 を USB で繋ぐ → 数秒で端末登録され、タイムカードの一覧が出る。管理者ログインは不要。

Refs #213, ippoan/alc-app-s3#204, ippoan/auth-worker#519, ippoan/alc-app-s3#135

🤖 Generated with [Claude Code](https://claude.com/claude-code)
