### PR TITLE
fix(timecard): NFC 表示を CoreS3 直結でも「接続中」にする — 打刻経路は変えない (Closes #216)

### DIFF
--- a/web/app/components/TimePunchKiosk.vue
+++ b/web/app/components/TimePunchKiosk.vue
@@ -9,6 +9,7 @@ const props = defineProps<{
 }>()
 
 const nfc = useNfcWebSocket()
+const coreS3 = useCoreS3Serial()
 const { accessToken } = useAuth()
 const { deviceModel } = useFingerprint()
 const KYOCERA_MODELS = ['KC-T305CN', 'KC-305CN', 'KYT35', 'A404KC', 'KC-T306']
@@ -54,6 +55,13 @@ const watch$ = useTimecardWatch({
   getToken: () => accessToken.value ?? getDeviceJwt(),
   onChange: () => { void loadTodayPunches() },
 })
+
+/**
+ * NFC 待機表示の 3 状態 (Refs ippoan/alc-app#216)。
+ * CoreS3 が USB 直結されていれば最優先 (打刻は CoreS3 firmware 自身が行う)、
+ * 次に PC の NFC ブリッジ、どちらも無ければ未接続。
+ */
+const nfcState = computed(() => coreS3.isConnected.value ? 'core' : nfc.isConnected.value ? 'bridge' : 'none')
 
 const isLargeScreen = ref(false)
 function updateScreenSize() {
@@ -110,6 +118,8 @@ onMounted(async () => {
   await loadTodayPunches()
   void watch$.connect()
 
+  // CoreS3 直結の読み取りは購読しない — 打刻は CoreS3 firmware 自身が `kind=timecard` で
+  // 送る (alc-app-s3 hub-drivers/timecard.rs)。ここで useNfcReader() に切り替えると 1 タップが 2 行になる
   nfc.connect()
   nfc.onRead(async (event) => {
     if (processing.value) return
@@ -198,10 +208,12 @@ function formatTime(iso: string): string {
         <div class="mt-4 flex items-center justify-center gap-2 text-sm">
           <span
             class="w-2 h-2 rounded-full"
-            :class="nfc.isConnected.value ? 'bg-green-500' : 'bg-red-500'"
+            :class="nfcState !== 'none' ? 'bg-green-500' : 'bg-red-500'"
           />
           <span class="text-gray-500">
-            {{ nfc.isConnected.value ? 'NFC ブリッジ接続中' : 'NFC ブリッジ未接続' }}
+            {{ nfcState === 'core' ? 'NFC 端末接続中 (端末が打刻します)'
+              : nfcState === 'bridge' ? 'NFC ブリッジ接続中'
+                : 'NFC リーダー未接続' }}
           </span>
         </div>
         <!-- インラインエラー -->

--- a/web/tests/components/TimePunchKiosk.test.ts
+++ b/web/tests/components/TimePunchKiosk.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ref, readonly } from 'vue'
+import { mountSuspended, mockNuxtImport } from '@nuxt/test-utils/runtime'
+import TimePunchKiosk from '~/components/TimePunchKiosk.vue'
+
+// --- API のモック (NFC 表示だけを見るので中身は空で足りる) ---
+
+vi.mock('~/utils/api', () => ({
+  punchTimecard: vi.fn(async () => {}),
+  listTimePunches: vi.fn(async () => ({ punches: [] })),
+  getEmployees: vi.fn(async () => []),
+}))
+
+// --- composable のモック (NFC 接続表示 3 状態だけを動かす) ---
+
+const nfcConnected = ref(false)
+const nfcOnReadMock = vi.fn()
+mockNuxtImport('useNfcWebSocket', () => () => ({
+  isConnected: readonly(nfcConnected),
+  connect: vi.fn(),
+  onRead: nfcOnReadMock,
+}))
+
+const coreS3Connected = ref(false)
+mockNuxtImport('useCoreS3Serial', () => () => ({
+  isConnected: readonly(coreS3Connected),
+}))
+
+mockNuxtImport('useAuth', () => () => ({
+  accessToken: ref(null),
+}))
+
+mockNuxtImport('useFingerprint', () => () => ({
+  deviceModel: ref(null),
+}))
+
+mockNuxtImport('useDeviceToken', () => () => ({
+  getDeviceJwt: vi.fn(() => null),
+}))
+
+mockNuxtImport('useHubClaim', () => () => ({
+  lastError: ref(null),
+}))
+
+mockNuxtImport('useTimecardWatch', () => () => ({
+  connect: vi.fn(async () => {}),
+}))
+
+describe('TimePunchKiosk — NFC 接続表示の 3 状態 (Refs ippoan/alc-app#216)', () => {
+  beforeEach(() => {
+    nfcConnected.value = false
+    coreS3Connected.value = false
+  })
+
+  it('CoreS3 直結が繋がっていれば緑で「NFC 端末接続中」を出す', async () => {
+    coreS3Connected.value = true
+    const wrapper = await mountSuspended(TimePunchKiosk)
+
+    expect(wrapper.text()).toContain('NFC 端末接続中 (端末が打刻します)')
+    expect(wrapper.find('.bg-green-500').exists()).toBe(true)
+    expect(wrapper.find('.bg-red-500').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('CoreS3 は未接続で PC の NFC ブリッジだけ繋がっていれば緑で「NFC ブリッジ接続中」を出す', async () => {
+    nfcConnected.value = true
+    const wrapper = await mountSuspended(TimePunchKiosk)
+
+    expect(wrapper.text()).toContain('NFC ブリッジ接続中')
+    expect(wrapper.find('.bg-green-500').exists()).toBe(true)
+    expect(wrapper.find('.bg-red-500').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('どちらも未接続なら赤で「NFC リーダー未接続」を出す', async () => {
+    const wrapper = await mountSuspended(TimePunchKiosk)
+
+    expect(wrapper.text()).toContain('NFC リーダー未接続')
+    expect(wrapper.find('.bg-red-500').exists()).toBe(true)
+    expect(wrapper.find('.bg-green-500').exists()).toBe(false)
+    wrapper.unmount()
+  })
+})


### PR DESCRIPTION
## 何を
運行者 PWA の「タイムカード」タブの NFC 表示を 3 状態にする: CoreS3 直結 → 「NFC 端末接続中 (端末が打刻します)」緑 / PC の NFC ブリッジ → 「NFC ブリッジ接続中」緑 / どちらも無し → 「NFC リーダー未接続」赤。

## なぜ
2026-09-10 のユーザー報告: PWA 起動時は CoreS3 と繋がり「通常点呼」は「NFC 待機中」なのに、「タイムカード」へ切り替えると「NFC ブリッジ未接続」(赤) になる。`TimePunchKiosk.vue` だけが PC ブリッジ専用の `useNfcWebSocket()` の接続状態しか見ておらず、CoreS3 直結を表示に反映していなかった (`useCoreS3Serial` は module singleton でタブ切替では切れない)。

**打刻経路は変えない。** タイムカードの打刻は CoreS3 firmware 自身が `kind=timecard` で送る (alc-app-s3 `hub-drivers/src/timecard.rs`)。ここで `useNfcReader()` に差し替えると CoreS3 の読み取りが PWA にも流れて 1 タップが 2 打刻になるため、`nfc.connect()` / `nfc.onRead → punchTimecard` (PC ブリッジ経路) はそのままにし、その旨をコメントで残した。

## 変更
- `web/app/components/TimePunchKiosk.vue`: `useCoreS3Serial()` を足し、表示状態を `core / bridge / none` の computed に。文言 3 種 (「NFC リーダー未接続」は `NfcStatus.vue` と同じ)
- `web/tests/components/TimePunchKiosk.test.ts` (新規): 既存の component テストと同じ `mountSuspended` + `mockNuxtImport` で 3 状態の文言と色クラスだけを検査

## 検証
- `npx nuxi typecheck` エラー無し / `npx vitest run` 1415 passed / `check_coverage_100.mjs` 44 files 100%
- `useNfcWebSocket.ts` / `useNfcReader.ts` / `useCoreS3Serial.ts` / `TimecardManager.vue` / `coverage_100.toml` は不変

## マージ後 (実機)
運行者 PWA で CoreS3 を USB 直結のまま「タイムカード」タブへ → 緑「NFC 端末接続中 (端末が打刻します)」。警告音は PWA の HB が続く限り鳴らない (設計どおり)。

Closes #216
Refs ippoan/alc-app-s3#135

🤖 Generated with [Claude Code](https://claude.com/claude-code)
