### PR TITLE
feat(login): /login に「警告デバイスで認証」— VoiceS3R の ed25519 署名で auth-worker の device-login へ (Closes #214)

### DIFF
--- a/web/app/composables/useAlarmDevice.ts
+++ b/web/app/composables/useAlarmDevice.ts
@@ -266,6 +266,15 @@ export function useAlarmDevice() {
     useCoreS3Serial().sendGrace()
   }
 
+  /**
+   * 1 行送って応答 1 つを待つ (#214 の警告デバイス認証で使用)。
+   * 実体は arbiter 側 (useSerialArbiter.request) — 警告デバイスが預かっているポートに送る
+   * (useCoreS3Serial.request と同型)。
+   */
+  function request(line: string, matchPrefix: string, timeoutMs: number): Promise<string> {
+    return arbiter.request(CLAIMANT_NAME, line, matchPrefix, timeoutMs)
+  }
+
   return {
     isSupported,
     isConnected: readonly(isConnected),
@@ -274,5 +283,6 @@ export function useAlarmDevice() {
     disconnect,
     requestPort,
     notifyIntentionalReload,
+    request,
   }
 }

--- a/web/app/composables/useAuth.ts
+++ b/web/app/composables/useAuth.ts
@@ -42,6 +42,15 @@ let initialized = false
 let inactivityTimerId: ReturnType<typeof setTimeout> | null = null
 const INACTIVITY_TIMEOUT_MS = 5 * 60 * 1000 // 5分
 
+/**
+ * Google ログイン (`loginWithGoogleRedirect`) が auth-worker に渡す `redirect_uri` の
+ * 唯一の出どころ。警告デバイス認証 (#214) も同じ文字列を nonce 取得と device-login の
+ * 両方で使う必要があるため、ここから呼ぶ (文字列リテラル `/auth/callback` はここ 1 か所)。
+ */
+export function getAuthCallbackUrl(): string {
+  return `${window.location.origin}/auth/callback`
+}
+
 export function useAuth() {
   const config = useRuntimeConfig()
 
@@ -104,7 +113,7 @@ export function useAuth() {
   /** Google OAuth ログイン (Authorization Code Flow) */
   function loginWithGoogleRedirect(redirectAfterLogin?: string): void {
     if (!isClient) return
-    const callbackUrl = `${window.location.origin}/auth/callback`
+    const callbackUrl = getAuthCallbackUrl()
     if (redirectAfterLogin) {
       sessionStorage.setItem('oauth_redirect', redirectAfterLogin)
     }

--- a/web/app/composables/useDeviceLogin.ts
+++ b/web/app/composables/useDeviceLogin.ts
@@ -1,0 +1,148 @@
+/**
+ * 警告デバイス (VoiceS3R) が USB で繋がっていることを根拠にした管理者ログイン (#214)。
+ *
+ * Google ログインと並ぶ 2 つ目の認証系統。firmware (ippoan/alc-app-s3#205) が
+ * `AUTH SIGN <nonce>` に ed25519 署名で応え、auth-worker (ippoan/auth-worker#521/#522) が
+ * 公開鍵の登録と nonce 発行・検証を持つ。ここはその間を繋ぐだけで、鍵も署名も検証しない。
+ *
+ * 手順:
+ *   1. `redirect_uri` = `getAuthCallbackUrl()` (Google ログインと**同じ文字列**。
+ *      auth-worker は nonce 取得時と device-login 時で完全一致を要求する)
+ *   2. `GET <auth base>/auth/device-nonce?redirect_uri=...` (XHR、cookie 不要) → nonce
+ *   3. `useAlarmDevice().request('AUTH SIGN ' + nonce, 'AUTH SIG ', 10_000)` で
+ *      firmware に署名させる → `AUTH SIG <pubkey> <sig>` を parse
+ *   4. `window.location.href = <auth base>/auth/device-login?...` (top-level navigation)。
+ *      戻りは Google ログイン後と同じ経路 (cookie / lw_callback fragment) なので
+ *      useAuth に新しい取り込みは作らない
+ *
+ * useHubClaim.ts (#213 CoreS3 自動端末登録) と同じ構造 (module-level state + 1 関数)。
+ *
+ * ★ firmware の `ERR AUTH: no key` / `ERR AUTH: bad nonce` は、useSerialArbiter.request の
+ * `errPrefix` (= 送った行そのものを echo し返した行だけを reject 対象にする、
+ * `AUTH TICKET` の `ERR AUTH TICKET: <理由>` 用の仕組み) には一致しない可能性がある
+ * (送った行は `AUTH SIGN <nonce>` だが ERR 行は `ERR AUTH: ...` で nonce を echo しない
+ * ため)。firmware が実際に nonce を echo するかはここでは分からないので、
+ * useAlarmDevice.request の reject 理由をメッセージの内容 (`no key` を含むか) で判定する
+ * ことで、echo の有無どちらでも `no key` だけは拾えるようにしてある。echo が無い場合、
+ * 実機では `no key` も `bad nonce` も 10 秒のタイムアウト経由でしか reject されず
+ * (useSerialArbiter は matchPrefix/errPrefix どちらにも当てはまらない行を黙って捨てる)、
+ * その場合は `deviceLoginTimeoutMessage` に落ちる。この点は親へ [質問] 済み。
+ */
+import { getAuthCallbackUrl } from '~/composables/useAuth'
+import {
+  deviceLoginNoKeyMessage,
+  deviceLoginNonceFailedMessage,
+  deviceLoginParseFailedMessage,
+  deviceLoginTimeoutMessage,
+} from '~/utils/device-login-messages'
+
+/** firmware への `AUTH SIGN <nonce>` 応答を待つ上限 (useHubClaim の AUTH TICKET と同じ 10 秒) */
+const AUTH_SIGN_TIMEOUT_MS = 10_000
+const AUTH_SIGN_MATCH_PREFIX = 'AUTH SIG '
+
+/** 直近の失敗理由 (画面表示用)。成功 / 未実行なら null */
+const lastError = ref<string | null>(null)
+/** login() が進行中か (ボタンの disabled に使う) */
+const busy = ref(false)
+/** 二重起動防止 (同時に 1 回だけ) */
+let loggingIn = false
+
+/**
+ * `GET <authWorkerUrl>/auth/device-nonce?redirect_uri=...` を XHR で叩き nonce を取る。
+ * cookie は不要 (CORS `*`) なので withCredentials は既定の false のまま。
+ */
+function fetchNonce(authWorkerUrl: string, redirectUri: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest()
+    const url = `${authWorkerUrl}/auth/device-nonce?redirect_uri=${encodeURIComponent(redirectUri)}`
+    xhr.open('GET', url, true)
+    xhr.onload = () => {
+      if (xhr.status < 200 || xhr.status >= 300) {
+        reject(new Error(`http ${xhr.status}`))
+        return
+      }
+      let data: { nonce?: string }
+      try {
+        data = JSON.parse(xhr.responseText) as { nonce?: string }
+      }
+      catch {
+        reject(new Error('応答をJSONとして解釈できません'))
+        return
+      }
+      if (!data.nonce) {
+        reject(new Error('応答にnonceが含まれていません'))
+        return
+      }
+      resolve(data.nonce)
+    }
+    xhr.onerror = () => reject(new Error('通信エラー'))
+    xhr.send()
+  })
+}
+
+/** `AUTH SIG <pubkey> <sig>` を空白で分割して parse。形式が合わなければ null */
+function parseAuthSigLine(line: string): { pubkey: string, sig: string } | null {
+  const parts = line.split(' ')
+  if (parts.length !== 4 || parts[0] !== 'AUTH' || parts[1] !== 'SIG') return null
+  return { pubkey: parts[2]!, sig: parts[3]! }
+}
+
+export function useDeviceLogin() {
+  const config = useRuntimeConfig()
+
+  /** 警告デバイスに署名させ、成功すれば auth-worker の device-login へ top-level navigate する */
+  async function login(): Promise<void> {
+    if (loggingIn) return
+    loggingIn = true
+    busy.value = true
+    lastError.value = null
+    try {
+      const authWorkerUrl = (config.public.authWorkerUrl as string).replace(/\/$/, '')
+      // ★ nonce 取得と device-login で同じ変数を 2 回使う (1 文字でも変えると auth-worker が 401)
+      const redirectUri = getAuthCallbackUrl()
+
+      let nonce: string
+      try {
+        nonce = await fetchNonce(authWorkerUrl, redirectUri)
+      }
+      catch (e) {
+        // fetchNonce は必ず Error で reject する (このファイル内で完結する私有関数)。
+        // instanceof の分岐は到達不能になるため付けない (coverage 100% gate、Refs CLAUDE.md)
+        lastError.value = deviceLoginNonceFailedMessage((e as Error).message)
+        return
+      }
+
+      let line: string
+      try {
+        line = await useAlarmDevice().request(`AUTH SIGN ${nonce}`, AUTH_SIGN_MATCH_PREFIX, AUTH_SIGN_TIMEOUT_MS)
+      }
+      catch (e) {
+        const message = e instanceof Error ? e.message : String(e)
+        lastError.value = message.includes('no key') ? deviceLoginNoKeyMessage : deviceLoginTimeoutMessage
+        return
+      }
+
+      const parsed = parseAuthSigLine(line)
+      if (!parsed) {
+        lastError.value = deviceLoginParseFailedMessage
+        return
+      }
+
+      const query = `pubkey=${encodeURIComponent(parsed.pubkey)}&nonce=${encodeURIComponent(nonce)}`
+        + `&sig=${encodeURIComponent(parsed.sig)}&redirect_uri=${encodeURIComponent(redirectUri)}`
+      window.location.href = `${authWorkerUrl}/auth/device-login?${query}`
+    }
+    finally {
+      loggingIn = false
+      busy.value = false
+    }
+  }
+
+  return {
+    /** 直近の失敗理由。成功 / 未実行なら null */
+    lastError: readonly(lastError),
+    /** login() が進行中か */
+    busy: readonly(busy),
+    login,
+  }
+}

--- a/web/app/composables/useSerialArbiter.ts
+++ b/web/app/composables/useSerialArbiter.ts
@@ -147,7 +147,7 @@ let scanTimer: ReturnType<typeof setTimeout> | null = null
  */
 interface PendingRequest {
   matchPrefix: string
-  /** これで始まる行が来たら失敗として reject する (`ERR <送った行>`) */
+  /** これで始まる行が来たら失敗として reject する (`ERR <送った行の先頭トークン>`) */
   errPrefix: string
   resolve: (line: string) => void
   reject: (err: Error) => void
@@ -469,8 +469,12 @@ export function useSerialArbiter() {
    * 1 行送って、応答 1 つを待つ (CoreS3 の自動端末登録 #213 / 後続の VoiceS3R 認証で使用)。
    *
    * `line` を書き、その後に届く行のうち `matchPrefix` で始まる最初の行で resolve する。
-   * `ERR <line>` で始まる行が先に来たら、それを reject する (firmware がコマンドを
-   * 認識しつつ失敗を返したとき用)。`timeoutMs` 経過しても届かなければ reject する。
+   * `ERR <送った行の先頭トークン>` で始まる行が先に来たら、それを reject する (firmware が
+   * コマンドを認識しつつ失敗を返したとき用)。先頭トークンだけを見るのは、`AUTH TICKET`
+   * (`ERR AUTH TICKET: …`、送信行をまるごと echo) と `AUTH SIGN <nonce>`
+   * (`ERR AUTH: no key` / `ERR AUTH: bad nonce`、nonce を echo しない) の両方を拾うため
+   * (Refs ippoan/alc-app#214)。同時に待てる request は 1 本なので、他コマンドの ERR を
+   * 誤って拾うことは無い。`timeoutMs` 経過しても届かなければ reject する。
    *
    * **同時に 1 件しか待てない。** 1 件目が待っている間に 2 件目を呼ぶと、2 件目は
    * 書かずに即 reject する (1 件目の完了 or タイムアウトまで待ってから呼び直すこと)。
@@ -506,7 +510,7 @@ export function useSerialArbiter() {
         reject(e)
       }
 
-      pendingRequests.set(s, { matchPrefix, errPrefix: `ERR ${line}`, resolve: doResolve, reject: doReject })
+      pendingRequests.set(s, { matchPrefix, errPrefix: `ERR ${line.split(' ')[0]}`, resolve: doResolve, reject: doReject })
 
       void writeLine(s.writer, line).then((ok) => {
         if (!ok) doReject(new Error(`request(${name}): write failed`))

--- a/web/app/pages/login.vue
+++ b/web/app/pages/login.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
 const { loginWithGoogleRedirect, isAuthenticated, isLoading, isDeviceActivated } = useAuth()
+const { isConnected: isAlarmDeviceConnected } = useAlarmDevice()
+const { lastError: deviceLoginError, busy: deviceLoginBusy, login: loginWithDevice } = useDeviceLogin()
 const route = useRoute()
 
 // 認証済みならリダイレクト (redirect クエリがあればそちらへ、なければ admin タブ)
@@ -16,6 +18,10 @@ watch(isAuthenticated, (val) => {
 function handleLogin() {
   const redirect = route.query.redirect as string | undefined
   loginWithGoogleRedirect(redirect)
+}
+
+function handleDeviceLogin() {
+  void loginWithDevice()
 }
 </script>
 
@@ -44,6 +50,18 @@ function handleLogin() {
           </svg>
           Google でログイン
         </button>
+
+        <button
+          v-if="isAlarmDeviceConnected"
+          class="w-full mt-3 flex items-center justify-center gap-2 px-6 py-3 border border-gray-300 rounded-xl bg-white hover:bg-gray-50 transition-colors font-medium text-gray-700 disabled:opacity-50 disabled:cursor-not-allowed"
+          :disabled="deviceLoginBusy"
+          @click="handleDeviceLogin"
+        >
+          警告デバイスで認証
+        </button>
+        <p v-if="deviceLoginError" class="mt-2 text-xs text-red-600">
+          {{ deviceLoginError }}
+        </p>
 
         <p
           v-if="isDeviceActivated"

--- a/web/app/utils/device-login-messages.ts
+++ b/web/app/utils/device-login-messages.ts
@@ -1,0 +1,18 @@
+/** 警告デバイス認証 (#214) が失敗したときの文言を 1 か所にまとめる (employee-lookup-messages.ts と同じ流儀) */
+
+/** firmware に警告デバイスの鍵が登録されていないとき (`ERR AUTH: no key`) */
+export const deviceLoginNoKeyMessage = '管理画面の端末一覧で警告デバイスの鍵を登録してください'
+
+/** nonce 取得 (`GET /auth/device-nonce`) が失敗したとき */
+export function deviceLoginNonceFailedMessage(reason: string): string {
+  return `認証用のnonceを取得できませんでした: ${reason}`
+}
+
+/**
+ * 警告デバイスからの応答を待つ間にタイムアウトした、または想定外のエラーで失敗したとき
+ * (`no key` 以外の request() reject 全般。`ERR AUTH: bad nonce` 等の個別文言は持たない)
+ */
+export const deviceLoginTimeoutMessage = '警告デバイスからの応答がありませんでした。デバイスの接続を確認してもう一度お試しください'
+
+/** 警告デバイスの応答が想定した形式 (`AUTH SIG <pubkey> <sig>`) でなかったとき */
+export const deviceLoginParseFailedMessage = '警告デバイスの応答を解釈できませんでした'

--- a/web/coverage_100.toml
+++ b/web/coverage_100.toml
@@ -35,6 +35,10 @@ path = "app/composables/useAuth.ts"
 branches = true
 
 [[files]]
+path = "app/composables/useDeviceLogin.ts"
+branches = true
+
+[[files]]
 path = "app/composables/useDemoMode.ts"
 branches = true
 
@@ -154,6 +158,10 @@ branches = true
 
 [[files]]
 path = "app/utils/employee-lookup-messages.ts"
+branches = true
+
+[[files]]
+path = "app/utils/device-login-messages.ts"
 branches = true
 
 [[files]]

--- a/web/tests/composables/useAlarmDevice.test.ts
+++ b/web/tests/composables/useAlarmDevice.test.ts
@@ -436,6 +436,7 @@ describe('useAlarmDevice', () => {
         'isConnected',
         'isSupported',
         'notifyIntentionalReload',
+        'request',
         'requestPort',
       ])
     })
@@ -833,6 +834,50 @@ describe('useAlarmDevice', () => {
       await alarm.requestPort()
       await vi.advanceTimersByTimeAsync(20000)
       expect(getPorts).not.toHaveBeenCalled()
+    })
+  })
+
+  // ---------- request (#214 警告デバイス認証) ----------
+
+  describe('request', () => {
+    async function connectDevice() {
+      const dev = createMockPort()
+      dev.emit('EVT ALARM state=idle cause=none\n')
+      installSerialMock({ getPorts: vi.fn(async () => [dev.port]) })
+      await load()
+      alarm.connect()
+      await vi.advanceTimersByTimeAsync(5000)
+      return dev
+    }
+
+    it('行を書いて matchPrefix の応答で resolve する (arbiter.request を CLAIMANT_NAME で呼ぶ)', async () => {
+      const dev = await connectDevice()
+
+      const p = alarm.request('AUTH SIGN abc123', 'AUTH SIG ', 10_000)
+      await vi.advanceTimersByTimeAsync(0)
+      expect(dev.writes.at(-1)).toBe('AUTH SIGN abc123\n')
+
+      dev.emit('AUTH SIG pk-1 sig-1\n')
+      await vi.advanceTimersByTimeAsync(0)
+      await expect(p).resolves.toBe('AUTH SIG pk-1 sig-1')
+    })
+
+    it('未接続なら reject する (ポートを預かっていない、arbiter の reject がそのまま伝播する)', async () => {
+      installSerialMock({ getPorts: vi.fn(async () => []) })
+      await load()
+
+      await expect(alarm.request('AUTH SIGN abc123', 'AUTH SIG ', 10_000)).rejects.toThrow()
+    })
+
+    it('タイムアウトで reject する', async () => {
+      const dev = await connectDevice()
+      void dev // 応答を送らない
+
+      const p = alarm.request('AUTH SIGN abc123', 'AUTH SIG ', 10_000)
+      // 先に catch ハンドラを付けてから進める (unhandledRejection を避ける)
+      const assertion = expect(p).rejects.toThrow()
+      await vi.advanceTimersByTimeAsync(10_000)
+      await assertion
     })
   })
 })

--- a/web/tests/composables/useDeviceLogin.test.ts
+++ b/web/tests/composables/useDeviceLogin.test.ts
@@ -1,0 +1,248 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+import {
+  deviceLoginNoKeyMessage,
+  deviceLoginParseFailedMessage,
+  deviceLoginTimeoutMessage,
+} from '~/utils/device-login-messages'
+
+/**
+ * useDeviceLogin (#214 警告デバイス認証) のテスト。
+ *
+ * useAlarmDevice / getAuthCallbackUrl (useAuth) は mock する — 警告デバイスの接続そのもの
+ * は useAlarmDevice.test.ts が担保済みで、ここでは「nonce 取得 → AUTH SIGN → device-login
+ * 遷移」の組み立てだけを見る。redirect_uri の出どころが 1 か所であることも
+ * getAuthCallbackUrl の呼び出し回数で確かめる。
+ */
+
+const authMock = vi.hoisted(() => ({
+  getAuthCallbackUrl: vi.fn(() => 'https://kiosk.example.com/auth/callback'),
+}))
+vi.mock('~/composables/useAuth', () => authMock)
+
+const alarmDeviceMock = vi.hoisted(() => ({
+  request: vi.fn(),
+}))
+mockNuxtImport('useAlarmDevice', () => () => alarmDeviceMock)
+
+/** XMLHttpRequest の最小モック。send() は何もせず、テストから onload/onerror を手動で起こす */
+class MockXHR {
+  static instances: MockXHR[] = []
+  method = ''
+  url = ''
+  status = 0
+  responseText = ''
+  onload: (() => void) | null = null
+  onerror: (() => void) | null = null
+
+  constructor() {
+    MockXHR.instances.push(this)
+  }
+
+  open(method: string, url: string): void {
+    this.method = method
+    this.url = url
+  }
+
+  send(): void { /* テストが respondNonce()/respondNonceError() で手動応答する */ }
+}
+
+function lastXhr(): MockXHR {
+  const xhr = MockXHR.instances.at(-1)
+  if (!xhr) throw new Error('XHR が送られていません')
+  return xhr
+}
+
+function respondNonce(status: number, body: unknown): void {
+  const xhr = lastXhr()
+  xhr.status = status
+  xhr.responseText = typeof body === 'string' ? body : JSON.stringify(body)
+  xhr.onload?.()
+}
+
+function respondNonceError(): void {
+  lastXhr().onerror?.()
+}
+
+describe('useDeviceLogin', () => {
+  let hrefSetter: ReturnType<typeof vi.fn>
+  let originalLocation: Location
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    authMock.getAuthCallbackUrl.mockReturnValue('https://kiosk.example.com/auth/callback')
+    MockXHR.instances = []
+    vi.stubGlobal('XMLHttpRequest', MockXHR as unknown as typeof XMLHttpRequest)
+
+    hrefSetter = vi.fn()
+    originalLocation = window.location
+    Object.defineProperty(window, 'location', {
+      value: {
+        ...originalLocation,
+        origin: 'https://kiosk.example.com',
+        href: '',
+        set href(val: string) { hrefSetter(val) },
+      },
+      writable: true,
+      configurable: true,
+    })
+
+    // module-level state (lastError/busy/loggingIn) を毎回まっさらにする
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    Object.defineProperty(window, 'location', { value: originalLocation, writable: true, configurable: true })
+    vi.unstubAllGlobals()
+  })
+
+  async function loadDeviceLogin() {
+    const mod = await import('~/composables/useDeviceLogin')
+    return mod.useDeviceLogin()
+  }
+
+  // ---------- 成功 ----------
+
+  it('成功: nonce取得 → AUTH SIGN → device-login へ top-level navigate する', async () => {
+    alarmDeviceMock.request.mockResolvedValue('AUTH SIG pub-1 sig-1')
+    const { login, lastError, busy } = await loadDeviceLogin()
+
+    const p = login()
+    expect(busy.value).toBe(true)
+    respondNonce(200, { nonce: 'nonce-abc', expires_in: 60 })
+    await p
+
+    // redirect_uri は 1 回だけ取得して nonce 取得と device-login の両方で使う
+    expect(authMock.getAuthCallbackUrl).toHaveBeenCalledTimes(1)
+
+    expect(lastXhr().method).toBe('GET')
+    expect(lastXhr().url).toContain('/auth/device-nonce?redirect_uri=')
+    expect(lastXhr().url).toContain(encodeURIComponent('https://kiosk.example.com/auth/callback'))
+
+    expect(alarmDeviceMock.request).toHaveBeenCalledWith('AUTH SIGN nonce-abc', 'AUTH SIG ', 10_000)
+
+    const url = hrefSetter.mock.calls[0]?.[0] as string
+    expect(url).toContain('/auth/device-login?')
+    expect(url).toContain('pubkey=pub-1')
+    expect(url).toContain('nonce=nonce-abc')
+    expect(url).toContain('sig=sig-1')
+    expect(url).toContain(`redirect_uri=${encodeURIComponent('https://kiosk.example.com/auth/callback')}`)
+
+    expect(lastError.value).toBeNull()
+    expect(busy.value).toBe(false)
+  })
+
+  it('二重起動を防ぐ (呼び出し中の 2 回目は何もしない)', async () => {
+    alarmDeviceMock.request.mockResolvedValue('AUTH SIG pub-1 sig-1')
+    const { login } = await loadDeviceLogin()
+
+    const p1 = login()
+    const p2 = login()
+    expect(MockXHR.instances.length).toBe(1)
+
+    respondNonce(200, { nonce: 'nonce-abc' })
+    await p1
+    await p2
+  })
+
+  // ---------- nonce 取得失敗 ----------
+
+  describe('nonce 取得失敗', () => {
+    it('http エラー (2xx 以外)', async () => {
+      const { login, lastError } = await loadDeviceLogin()
+      const p = login()
+      respondNonce(500, '')
+      await p
+      expect(lastError.value).toContain('http 500')
+      expect(alarmDeviceMock.request).not.toHaveBeenCalled()
+    })
+
+    it('応答を JSON として解釈できない', async () => {
+      const { login, lastError } = await loadDeviceLogin()
+      const p = login()
+      respondNonce(200, 'not-json{')
+      await p
+      expect(lastError.value).toContain('JSON')
+    })
+
+    it('応答に nonce が含まれない', async () => {
+      const { login, lastError } = await loadDeviceLogin()
+      const p = login()
+      respondNonce(200, { expires_in: 60 })
+      await p
+      expect(lastError.value).toContain('nonce')
+    })
+
+    it('通信エラー (onerror)', async () => {
+      const { login, lastError } = await loadDeviceLogin()
+      const p = login()
+      respondNonceError()
+      await p
+      expect(lastError.value).toContain('通信エラー')
+    })
+  })
+
+  // ---------- ERR AUTH: no key ----------
+
+  it('ERR AUTH: no key → 鍵登録を促す文言', async () => {
+    alarmDeviceMock.request.mockRejectedValue(new Error('ERR AUTH: no key'))
+    const { login, lastError } = await loadDeviceLogin()
+    const p = login()
+    respondNonce(200, { nonce: 'nonce-abc' })
+    await p
+    expect(lastError.value).toBe(deviceLoginNoKeyMessage)
+  })
+
+  // ---------- タイムアウト (no key 以外の reject 理由すべて) ----------
+
+  it('タイムアウト (no key 以外の reject) → 汎用メッセージ', async () => {
+    alarmDeviceMock.request.mockRejectedValue(
+      new Error('request(alarm-device): timeout waiting for "AUTH SIG "'),
+    )
+    const { login, lastError } = await loadDeviceLogin()
+    const p = login()
+    respondNonce(200, { nonce: 'nonce-abc' })
+    await p
+    expect(lastError.value).toBe(deviceLoginTimeoutMessage)
+  })
+
+  it('Error インスタンスでない reject でも落ちない (useHubClaim と同じ防御)', async () => {
+    alarmDeviceMock.request.mockRejectedValue('boom')
+    const { login, lastError } = await loadDeviceLogin()
+    const p = login()
+    respondNonce(200, { nonce: 'nonce-abc' })
+    await p
+    expect(lastError.value).toBe(deviceLoginTimeoutMessage)
+  })
+
+  // ---------- 応答 parse 失敗 ----------
+
+  describe('応答 parse 失敗', () => {
+    it('トークン数が想定 (4) と違う', async () => {
+      alarmDeviceMock.request.mockResolvedValue('AUTH SIG pubonly')
+      const { login, lastError } = await loadDeviceLogin()
+      const p = login()
+      respondNonce(200, { nonce: 'nonce-abc' })
+      await p
+      expect(lastError.value).toBe(deviceLoginParseFailedMessage)
+    })
+
+    it('先頭トークンが AUTH でない', async () => {
+      alarmDeviceMock.request.mockResolvedValue('XXXX SIG pub-1 sig-1')
+      const { login, lastError } = await loadDeviceLogin()
+      const p = login()
+      respondNonce(200, { nonce: 'nonce-abc' })
+      await p
+      expect(lastError.value).toBe(deviceLoginParseFailedMessage)
+    })
+
+    it('2番目のトークンが SIG でない', async () => {
+      alarmDeviceMock.request.mockResolvedValue('AUTH XXX pub-1 sig-1')
+      const { login, lastError } = await loadDeviceLogin()
+      const p = login()
+      respondNonce(200, { nonce: 'nonce-abc' })
+      await p
+      expect(lastError.value).toBe(deviceLoginParseFailedMessage)
+    })
+  })
+})

--- a/web/tests/composables/useSerialArbiter.test.ts
+++ b/web/tests/composables/useSerialArbiter.test.ts
@@ -801,7 +801,7 @@ describe('useSerialArbiter', () => {
       await expect(p1).resolves.toBe('AUTH TICKET abc123 EXPIRES=300')
     })
 
-    it('`ERR <送った行>` で始まる応答は reject する', async () => {
+    it('`ERR <送った行の先頭トークン>` で始まる応答は reject する (送信行をまるごと echo するパターン)', async () => {
       const { dev } = await claimAsCore()
 
       const p = arbiter.request('core', 'AUTH TICKET', 'AUTH TICKET ', 10_000)
@@ -811,6 +811,20 @@ describe('useSerialArbiter', () => {
       await vi.advanceTimersByTimeAsync(0)
 
       dev.emit('ERR AUTH TICKET: not ready\n')
+      await vi.advanceTimersByTimeAsync(0)
+
+      await assertion
+    })
+
+    it('先頭トークンだけ一致する ERR も reject する (nonce を echo しない #214 の AUTH SIGN)', async () => {
+      const { dev } = await claimAsCore()
+
+      const p = arbiter.request('core', 'AUTH SIGN abc123', 'AUTH SIG ', 10_000)
+      const assertion = expect(p).rejects.toThrow('ERR AUTH: no key')
+      await vi.advanceTimersByTimeAsync(0)
+
+      // firmware は送った "AUTH SIGN abc123" を echo せず、先頭トークン (AUTH) だけ一致する
+      dev.emit('ERR AUTH: no key\n')
       await vi.advanceTimersByTimeAsync(0)
 
       await assertion


### PR DESCRIPTION
## 何を
`/login` に「警告デバイスで認証」ボタンを足す。VoiceS3R (警告デバイス) が USB で繋がっているときだけ表示し、押すと auth-worker から nonce を取り、`AUTH SIGN <nonce>` で機体内の ed25519 鍵に署名させ、`GET /auth/device-login?pubkey&nonce&sig&redirect_uri` へ top-level navigation で遷移する。戻りは Google ログインと同じ経路 (cookie)。

## なぜ
管理者の認証を「Google ログイン」と「登録済みの警告デバイスが手元にあること」の 2 系統にする (B 案、Refs ippoan/alc-app-s3#135)。firmware 側 `AUTH KEYGEN / PUBKEY / SIGN` (ippoan/alc-app-s3#207) と auth-worker 側の鍵登録 (ippoan/auth-worker#523) / `device-nonce` + `device-login` (ippoan/auth-worker#524) は本番済みで、これが最後の 1 本。

## 変更
- `useAuth.ts`: `loginWithGoogleRedirect` のローカル `callbackUrl` を `getAuthCallbackUrl()` として export (redirect_uri の唯一の出どころ。auth-worker は nonce 発行時と device-login で完全一致を要求する)
- `useAlarmDevice.ts`: `useCoreS3Serial` と同型の `request(line, matchPrefix, timeoutMs)` wrapper を 1 本 (claimant 名は非公開のまま)
- `useDeviceLogin.ts` (新規): `useHubClaim` と同じ構造。nonce 取得 → `AUTH SIGN` → parse → device-login へ遷移。失敗は `lastError` に載せて再押下できる
- `utils/device-login-messages.ts` (新規): 文言定数 (鍵未登録 / nonce 取得失敗 / タイムアウト / 応答不正)
- `pages/login.vue`: `isConnected` のときだけボタン
- `useSerialArbiter.ts`: `request` の `errPrefix` を「`ERR ` + 送信行の先頭トークン」に。firmware は `AUTH SIGN` の失敗を `ERR AUTH: no key` / `ERR AUTH: bad nonce` で返し送信行を echo しないため、従来の `ERR <送信行>` では一致せず 10 秒 timeout に落ちていた。`ERR AUTH TICKET: …` (自動端末登録) も同じ前置で拾える
- `coverage_100.toml` に新規 2 ファイルを登録、テスト 3 本 (useAlarmDevice / useDeviceLogin / useSerialArbiter)

## 検証
- `npx nuxi typecheck` exit 0 / `npx vitest run` 1428 passed / `check_coverage_100.mjs` 46 files 100%
- `/auth/callback` のリテラルは repo で 1 か所のまま

## マージ後 (実機)
管理画面の端末一覧で VoiceS3R の鍵を登録 → 管理者 PC に VoiceS3R を USB で繋ぎ `/login` の「警告デバイスで認証」→ admin タブ。Google ログインは従来どおり。

Closes #214
Refs ippoan/alc-app-s3#135

🤖 Generated with [Claude Code](https://claude.com/claude-code)
