### PR TITLE
fix(nfc): useNfcReader の sync watch に immediate を付け、タブを戻しても CoreS3 直結が「接続中」のまま出るようにする (Closes #219)

### DIFF
--- a/web/app/composables/useNfcReader.ts
+++ b/web/app/composables/useNfcReader.ts
@@ -162,7 +162,9 @@ export function useNfcReader() {
     else if (wantConnected) ws.connect()
   })
 
-  watch([core.isConnected, ws.isConnected, ws.error, ws.readers, ws.bridgeVersion], sync)
+  // immediate: 既に接続済みの CoreS3 / ブリッジへ再 mount した時点で local ref に
+  // 反映する (タブを戻すたびに local isConnected が false から作り直されるため)。
+  watch([core.isConnected, ws.isConnected, ws.error, ws.readers, ws.bridgeVersion], sync, { immediate: true })
 
   function connect(): void {
     wantConnected = true

--- a/web/tests/composables/useNfcReader.test.ts
+++ b/web/tests/composables/useNfcReader.test.ts
@@ -349,6 +349,16 @@ describe('useNfcReader', () => {
     expect(wsMock.connect).not.toHaveBeenCalled()
   })
 
+  it('core.isConnected が既に true の状態で新しく呼ぶと、connect() を呼ばなくても isConnected が即 true になる', async () => {
+    // タブを戻して component が再 mount されたときの再現 (Refs ippoan/alc-app#219)
+    coreState.isConnected.value = true
+    const reader = await load()
+
+    expect(reader.isConnected.value).toBe(true)
+    expect(reader.readers.value).toEqual(['CoreS3'])
+    expect(coreMock.connect).not.toHaveBeenCalled()
+  })
+
   it('直結したらブリッジを切り、readers は CoreS3 になる', async () => {
     const reader = await load()
     reader.connect()


### PR DESCRIPTION
## 何を
`useNfcReader` の `sync` を起動する watch に `{ immediate: true }` を足し、component が再 mount されたときに「既に繋がっている CoreS3」が local の `isConnected` / `readers` に即反映されるようにする。

## なぜ
2026-09-10 のユーザー報告 (v0.0.92): 運行者 PWA で通常点呼 → タイムカード → 通常点呼 とタブを戻すと、CoreS3 は USB で繋がったままなのに「NFC リーダー未接続」+「USB デバイスを選択」が出て復旧しない。`useNfcReader()` は呼ぶたびに local ref を false で作り、`sync` の watch に `immediate` が無く、`core.connect()` は接続済みだと即 return するので、再 mount 後は一度も同期されなかった。ポートは閉じていない (表示だけの不整合)。

`immediate` を付けるのは `sync` の watch 1 本だけ。1 本目 (`core.isConnected` で `ws.disconnect()` / `ws.connect()` を切り替える watch) に付けると、mount のたびに singleton の ws を切る副作用と到達不能分岐が生まれる (simplify-reviewer の指摘、issue のコメント)。

## 変更
- `web/app/composables/useNfcReader.ts`: `watch([core.isConnected, ws.isConnected, …], sync, { immediate: true })` (`useAlarmDevice.ts` の先例に合わせた書式)
- `web/tests/composables/useNfcReader.test.ts`: 「`core.isConnected` が既に true の状態で新しく `useNfcReader()` を呼ぶと、`connect()` 無しで `isConnected` が即 true、`readers` が `['CoreS3']`」を 1 本追加。既存 20 本は無変更で緑

## 検証
- `npx nuxi typecheck` exit 0 / `npx vitest run` 1432 passed / `useNfcReader.ts` 100% (branches 含む) / `check_coverage_100.mjs` gate green
- `useSerialArbiter.ts` / `useCoreS3Serial.ts` / `NfcStatus.vue` / `TimePunchKiosk.vue` は不変

## マージ後 (実機)
運行者 PWA で通常点呼 → タイムカード → 通常点呼 と戻し、CoreS3 直結のまま「NFC 待機中」(緑) のまま。

Closes #219
Refs ippoan/alc-app-s3#135、#216

🤖 Generated with [Claude Code](https://claude.com/claude-code)
