### PR TITLE
fix(serial): USB を挿し直したら 1 秒で掴み直す — navigator.serial の connect を購読 (Closes #221)

### DIFF
--- a/web/app/composables/useSerialArbiter.ts
+++ b/web/app/composables/useSerialArbiter.ts
@@ -27,6 +27,7 @@
  */
 
 import { isWebSerialSupported } from '~/utils/webserial'
+import { onPortConnected } from '~/composables/useSerialDeviceManager'
 
 /**
  * BLE ゲートウェイの既知 VID:PID (CH340, CP210x, Espressif, FTDI FT232R)。
@@ -54,6 +55,14 @@ const SERIAL_OPTIONS: SerialOptions = {
 
 /** 見つからなければこの間隔で探し直す */
 const RESCAN_INTERVAL = 10000
+/**
+ * `navigator.serial` の `connect` イベントを受けてから探索するまでの待ち時間。
+ *
+ * 挿した直後は CDC が準備中で `open` が失敗しうるので、10 秒周期より詰めつつも
+ * 即座ではなく 1 秒だけ待つ。失敗しても既存の 10 秒周期に戻るだけなので固定値で足りる
+ * (Refs ippoan/alc-app#221)。
+ */
+const CONNECT_SCAN_DELAY = 1000
 const PROBE_SEND_INTERVAL = 1000
 const PROBE_MAX_SENDS = 8
 /**
@@ -137,6 +146,10 @@ const sessions = new Set<PortSession>()
 const passedOver = new Map<SerialPort, number>()
 let scanning = false
 let scanTimer: ReturnType<typeof setTimeout> | null = null
+/** scan() 実行中に connect が来た → 終わったら CONNECT_SCAN_DELAY で次を予約する */
+let rescanRequested = false
+/** onPortConnected の購読は register() の初回だけ張る (module 単位で 1 本) */
+let connectSubscribed = false
 
 /**
  * `request()` が待っている応答 (session ごとに高々 1 件)。
@@ -210,6 +223,23 @@ export function useSerialArbiter() {
       scanTimer = null
       void scan()
     }, delay)
+  }
+
+  /**
+   * `navigator.serial` の `connect` を受けたときの処理 (Refs ippoan/alc-app#221)。
+   *
+   * 見送り印を消す (挿し直した機種が直前に見送られたポートと同じかもしれないため —
+   * `isRevisitable` の判定 `:397-404` と同じ引き方)。スキャン中に来たら取りこぼさず
+   * 次の周期を早める (`rescanRequested`)、スキャン中でなければ `CONNECT_SCAN_DELAY` で
+   * 即予約する。
+   */
+  function handlePortConnected(port: SerialPort): void {
+    passedOver.delete(toRaw(port))
+    if (scanning) {
+      rescanRequested = true
+      return
+    }
+    scheduleScan(CONNECT_SCAN_DELAY)
   }
 
   /** まだポートを預かっていない利用側 */
@@ -419,13 +449,17 @@ export function useSerialArbiter() {
         if (isArbitratedPort(candidate)) continue
         if (!isRevisitable(candidate)) continue
         await tryPort(candidate)
-        if (pending().length === 0) return
+        if (pending().length === 0) {
+          rescanRequested = false
+          return
+        }
       }
     }
     finally {
       scanning = false
     }
-    scheduleScan(RESCAN_INTERVAL)
+    scheduleScan(rescanRequested ? CONNECT_SCAN_DELAY : RESCAN_INTERVAL)
+    rescanRequested = false
   }
 
   // --- 公開 API ---
@@ -435,6 +469,10 @@ export function useSerialArbiter() {
    * 直前に見送られたばかりのポートがその利用側のものだったときに取りこぼす。
    */
   function register(name: string, claimant: SerialClaimant): void {
+    if (!connectSubscribed) {
+      connectSubscribed = true
+      onPortConnected(handlePortConnected)
+    }
     const isNew = !claimants.has(name)
     claimants.set(name, claimant)
     if (!isNew) return

--- a/web/app/composables/useSerialDeviceManager.ts
+++ b/web/app/composables/useSerialDeviceManager.ts
@@ -5,6 +5,35 @@ export interface PortEntry {
   info: SerialPortInfo
 }
 
+// --- ポートの挿し直し検知 (module 単位、Refs ippoan/alc-app#221) ---
+//
+// navigator.serial の `connect` は挿した瞬間に発火するので、これを購読しておけば
+// 抜き挿し後の掴み直しを RESCAN_INTERVAL (10 秒) の周期に頼らず即座に始められる。
+// 購読者 (useSerialArbiter) は 1 つしか居ないが、増えても addEventListener が
+// 重複しないよう module 単位で 1 回だけ張る。解除はしない (arbiter は張りっぱなし)。
+
+let connectListening = false
+const connectListeners: Array<(port: SerialPort) => void> = []
+
+/**
+ * `navigator.serial` の `connect` イベントを購読する。初回呼び出しでだけ
+ * `addEventListener` を張り (`useSerialDeviceManager()` はシングルトンではなく
+ * 呼ぶたびに新しいインスタンスができるため、本体の中では張らない)、以後は
+ * ここに積んだ購読者へ配る。WebSerial 非対応、または `addEventListener` が
+ * 無い環境では何もしない。
+ */
+export function onPortConnected(cb: (port: SerialPort) => void): void {
+  connectListeners.push(cb)
+  if (connectListening) return
+  if (!isWebSerialSupported()) return
+  if (typeof navigator.serial.addEventListener !== 'function') return
+  connectListening = true
+  navigator.serial.addEventListener('connect', (ev) => {
+    const port = ev.target as SerialPort
+    for (const listener of connectListeners) listener(port)
+  })
+}
+
 export function useSerialDeviceManager() {
   const ports = ref<PortEntry[]>([])
   const isSupported = isWebSerialSupported()

--- a/web/tests/composables/useSerialArbiter.test.ts
+++ b/web/tests/composables/useSerialArbiter.test.ts
@@ -100,14 +100,31 @@ function installSerialMock(serialMock: {
   requestPort?: ReturnType<typeof vi.fn>
   getPorts?: ReturnType<typeof vi.fn>
 }) {
+  // navigator.serial は本物同様 EventTarget にしておく — addEventListener /
+  // dispatchEvent が実際に効く形にすることで、Refs ippoan/alc-app#221 の
+  // connect 購読 (onPortConnected) をそのまま検証できる
   Object.defineProperty(navigator, 'serial', {
-    value: {
+    value: Object.assign(new EventTarget(), {
       requestPort: serialMock.requestPort ?? vi.fn(),
       getPorts: serialMock.getPorts ?? vi.fn(async () => []),
-    },
+    }),
     configurable: true,
     writable: true,
   })
+}
+
+/**
+ * `navigator.serial` へ `connect` イベントを流す (Refs ippoan/alc-app#221)。
+ *
+ * Web Serial の `connect` は SerialPort で発火して navigator.serial へ bubble
+ * するため、本物の `target` は挿されたポート自身になる。plain `EventTarget` に
+ * `dispatchEvent` させると target は dispatch した相手 (navigator.serial) に
+ * なってしまうので、`target` を挿し直したポートへ差し替えてから配る。
+ */
+function emitConnect(port: any): void {
+  const ev = new Event('connect')
+  Object.defineProperty(ev, 'target', { value: port, configurable: true })
+  ;(navigator as any).serial.dispatchEvent(ev)
 }
 
 /** 「自分の機種だ」と名乗り出る印を持つ利用側 */
@@ -361,6 +378,58 @@ describe('useSerialArbiter', () => {
       arbiter.register('alarm', claimant)
       await vi.advanceTimersByTimeAsync(0)
       expect(getPorts).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  // ---------- connect イベント (Refs ippoan/alc-app#221) ----------
+
+  describe('connect イベント', () => {
+    it('connect で 1 秒後にスキャンが走り claim される', async () => {
+      const dev = createMockPort()
+      dev.emit('ALARM state=idle\n')
+      let portsAvailable: any[] = []
+      const getPorts = vi.fn(async () => portsAvailable)
+      installSerialMock({ getPorts })
+      await load()
+
+      const { claimant, seen } = createClaimant('ALARM', 'CORE')
+      arbiter.register('alarm', claimant)
+      await vi.advanceTimersByTimeAsync(0)
+      expect(getPorts).toHaveBeenCalledTimes(1)
+      expect(seen.opened).toBe(0)
+
+      // ここで USB を挿す — getPorts で見えるようになる
+      portsAvailable = [dev.port]
+      emitConnect(dev.port)
+
+      // 1 秒経つ前はまだ探しにいかない
+      await vi.advanceTimersByTimeAsync(999)
+      expect(getPorts).toHaveBeenCalledTimes(1)
+
+      await vi.advanceTimersByTimeAsync(1)
+      expect(getPorts).toHaveBeenCalledTimes(2)
+      expect(seen.opened).toBe(1)
+    })
+
+    it('見送り中 (60 秒 cooldown 中) のポートでも connect なら待たずに再訪する', async () => {
+      const other = createMockPort()
+      other.emit('CORE LAN=up\n')
+      installSerialMock({ getPorts: vi.fn(async () => [other.port]) })
+      await load()
+
+      const { claimant } = createClaimant('ALARM', 'CORE')
+      arbiter.register('alarm', claimant)
+      await vi.advanceTimersByTimeAsync(0)
+      // 全員 reject → 見送り、本来なら 60 秒は再訪しない
+      expect(other.port.open).toHaveBeenCalledTimes(1)
+
+      // cooldown (60 秒) の途中で挿し直しの connect が来る
+      await vi.advanceTimersByTimeAsync(5000)
+      emitConnect(other.port)
+      await vi.advanceTimersByTimeAsync(1000)
+
+      // 60 秒待たずに再訪している
+      expect(other.port.open).toHaveBeenCalledTimes(2)
     })
   })
 
@@ -715,6 +784,36 @@ describe('useSerialArbiter', () => {
       arbiter.start(0)
       await vi.advanceTimersByTimeAsync(30000)
       expect(getPorts).toHaveBeenCalledTimes(1)
+    })
+
+    it('スキャン中に来た connect は取りこぼさず次を 1 秒で予約し、その次の周期は 10 秒に戻る (Refs ippoan/alc-app#221)', async () => {
+      const silent = createMockPort()
+      let portsAvailable: any[] = [silent.port]
+      const getPorts = vi.fn(async () => portsAvailable)
+      installSerialMock({ getPorts })
+      await load()
+
+      const { claimant } = createClaimant('ALARM', 'CORE')
+      arbiter.register('alarm', claimant)
+
+      // 無応答ポートを 8 秒握っている (= scanning 中) 最中に挿し直しの connect が来る
+      await vi.advanceTimersByTimeAsync(3000)
+      portsAvailable = []
+      emitConnect(silent.port)
+
+      // プローブが打ち切られるまで (8 秒) は再入しない
+      await vi.advanceTimersByTimeAsync(5000)
+      expect(getPorts).toHaveBeenCalledTimes(1)
+
+      // 取りこぼさず、通常の 10 秒より早い 1 秒後に次のスキャンが走る
+      await vi.advanceTimersByTimeAsync(1000)
+      expect(getPorts).toHaveBeenCalledTimes(2)
+
+      // その次の周期は通常の 10 秒に戻っている (1 秒では再スキャンしない)
+      await vi.advanceTimersByTimeAsync(9000)
+      expect(getPorts).toHaveBeenCalledTimes(2)
+      await vi.advanceTimersByTimeAsync(1000)
+      expect(getPorts).toHaveBeenCalledTimes(3)
     })
   })
 

--- a/web/tests/composables/useSerialDeviceManager.test.ts
+++ b/web/tests/composables/useSerialDeviceManager.test.ts
@@ -94,4 +94,40 @@ describe('useSerialDeviceManager', () => {
     await forgetPort(mockPort as any)
     expect(mockForget).toHaveBeenCalledOnce()
   })
+
+  // ---------- connect イベント購読 (Refs ippoan/alc-app#221) ----------
+
+  describe('onPortConnected', () => {
+    it('2 回呼んでも addEventListener は 1 回だけ', async () => {
+      const addEventListener = vi.fn()
+      ;(navigator as any).serial = {
+        getPorts: vi.fn().mockResolvedValue([]),
+        requestPort: vi.fn(),
+        addEventListener,
+      }
+
+      const { onPortConnected } = await import('~/composables/useSerialDeviceManager')
+      onPortConnected(vi.fn())
+      onPortConnected(vi.fn())
+
+      expect(addEventListener).toHaveBeenCalledTimes(1)
+      expect(addEventListener).toHaveBeenCalledWith('connect', expect.any(Function))
+    })
+
+    it('addEventListener が無い mock でも落ちない', async () => {
+      ;(navigator as any).serial = {
+        getPorts: vi.fn().mockResolvedValue([]),
+        requestPort: vi.fn(),
+      }
+
+      const { onPortConnected } = await import('~/composables/useSerialDeviceManager')
+      expect(() => onPortConnected(vi.fn())).not.toThrow()
+    })
+
+    it('WebSerial 非対応でも落ちない (addEventListener を張らない)', async () => {
+      // beforeEach で navigator.serial は既に無い
+      const { onPortConnected } = await import('~/composables/useSerialDeviceManager')
+      expect(() => onPortConnected(vi.fn())).not.toThrow()
+    })
+  })
 })


### PR DESCRIPTION
## 何を直したか

キオスクの PWA に繋いだ CoreS3 (や警告デバイス) の USB を抜き挿しすると、PWA が掴み直すまで 10〜20 秒かかっていました (#221)。

原因は、PWA が `navigator.serial` の `connect` イベントを受けていなかったことです。抜いた後の `release()` が 10 秒後のスキャンを予約し、以後 10 秒おきのスキャンで見つけるまで待っていました。

## 直し方

| 箇所 | 変更 |
|---|---|
| `web/app/composables/useSerialDeviceManager.ts` | module 単位で 1 回だけ `navigator.serial` の `connect` を購読する `onPortConnected()` を追加。`addEventListener` が無い環境・WebSerial 非対応では何もしない |
| `web/app/composables/useSerialArbiter.ts` | 最初の `register()` で購読。挿されたポートの見送り印を消し、1 秒後 (`CONNECT_SCAN_DELAY`) にスキャンする。スキャン中に来た connect はフラグで取りこぼさず、次の 1 回だけ 1 秒で予約し、その次は従来の 10 秒に戻る |
| テスト | arbiter 3 本 / device manager 3 本 |

- 探索は arbiter 1 本のままです (#182 の奪い合いに戻していません)
- `release()` の 10 秒、BLE の heartbeat / 再接続、`useFc1200Serial.ts` の自前スキャンは変えていません
- 挿した直後は CDC が準備中で open に失敗しうるので、0 秒ではなく 1 秒待ちます。失敗しても従来の 10 秒周期に戻るだけです

## 検証

| 項目 | 結果 |
|---|---|
| `npx nuxi typecheck` | rc=0 |
| `npx vitest run` | 59 files / 1438 passed, 2 skipped |
| `npm run test:coverage` | 対象 2 ファイルとも lines / branches 100% |
| `node scripts/check_coverage_100.mjs` | 46 files すべて 100% (両ファイルとも登録済み) |

## 実機確認 (マージ後)

本番で運行者 PC の USB を抜き挿しし、PWA が掴み直すまでの時間が 10〜20 秒から数秒になることを確かめます。

Closes #221
Refs ippoan/alc-app-s3#135

🤖 Generated with [Claude Code](https://claude.com/claude-code)
