### PR TITLE
feat(serial): シリアルの診断ログを localStorage に常時貯め、CoreS3 の get_log に中継で返す (Closes #223)

### DIFF
--- a/web/app/composables/useCoreS3Serial.ts
+++ b/web/app/composables/useCoreS3Serial.ts
@@ -29,11 +29,18 @@
  * 意図した reload の直前だけ `HB OK grace=45` を 1 行送り、その 1 回の沈黙の猶予を
  * 広げてもらう (sendGrace、呼び口は useAlarmDevice.notifyIntentionalReload。
  * Refs ippoan/alc-app-s3#192)。
+ *
+ * CoreS3 が遠隔から `get_log` を受けると、`EVT WS_COMMAND <id> {"action":"get_log",…}` を
+ * 1 行流して PWA に問い合わせる。PWA はシリアル診断ログの置き場 (utils/serialDiagLog) の
+ * 新しい行を `PWALOG <id> <行>` で返し、`PWALOG END <id> <送った行数>` で閉じる。CoreS3 は
+ * それを `get_log` の応答の `pwa_log` に載せる (Refs ippoan/alc-app#223)。古い firmware は
+ * `PWALOG` を知らず `ERR` を 1 行返すだけ (害なし)。
  */
 
 import type { SerialClaimant } from '~/composables/useSerialArbiter'
 import { HEARTBEAT_INTERVAL, RELOAD_GRACE_SEC } from '~/composables/useAlarmDevice'
 import { writeLine } from '~/composables/useSerialArbiter'
+import { readDiag } from '~/utils/serialDiagLog'
 
 /** arbiter に登録する名前 */
 const CLAIMANT_NAME = 'cores3'
@@ -45,6 +52,14 @@ const CLAIMANT_NAME = 'cores3'
  * 受け取ったあとでも isConnected / onOpen で接続を知れる。
  */
 const CLAIM_TIMEOUT = 3000
+
+/** CoreS3 が下り command を中継する行の接頭辞 (`EVT WS_COMMAND <id> <payload>`) */
+const WS_COMMAND_PREFIX = 'EVT WS_COMMAND '
+/** `get_log` に返す上限。CoreS3 の応答 1 通に収めるため */
+const LOG_REPLY_MAX_LINES = 40
+const LOG_REPLY_MAX_BYTES = 1200
+/** `PWALOG` の行を送る間隔 (CoreS3 の受信を溢れさせない。40 行で約 0.4 秒) */
+const LOG_REPLY_INTERVAL = 10
 
 /** 行の素性。CoreS3 のものか、警告デバイスのものか、どちらとも言えないか */
 type LineKind = 'json' | 'status' | 'event' | 'alarm' | 'unknown'
@@ -65,6 +80,9 @@ let held: WritableStreamDefaultWriter<Uint8Array> | null = null
 /** 走っている heartbeat のタイマー (未接続なら null) */
 let heartbeatTimer: ReturnType<typeof setInterval> | null = null
 
+/** いちばん新しい `get_log` の返信の番号。上がったら古い返信は打ち切る */
+let logReplyGeneration = 0
+
 /**
  * 行の接頭辞から素性を決める。
  *
@@ -76,6 +94,39 @@ function classify(line: string): LineKind {
   if (line.startsWith('STATUS ') && line.includes('BOARD=cores3')) return 'status'
   if (line.startsWith('EVT ')) return 'event'
   return 'unknown'
+}
+
+/** `EVT WS_COMMAND <id> <payload>` の action が `get_log` なら `<id>`、それ以外は null */
+function logQueryId(line: string): string | null {
+  if (!line.startsWith(WS_COMMAND_PREFIX)) return null
+  const rest = line.slice(WS_COMMAND_PREFIX.length)
+  const sep = rest.indexOf(' ')
+  if (sep <= 0) return null
+  try {
+    const payload = JSON.parse(rest.slice(sep + 1)) as { action?: unknown } | null
+    return payload?.action === 'get_log' ? rest.slice(0, sep) : null
+  }
+  catch {
+    return null
+  }
+}
+
+/**
+ * 置き場の新しい行から、`LOG_REPLY_MAX_LINES` 行・`LOG_REPLY_MAX_BYTES` バイト (UTF-8) に
+ * 収まる分を選び、古い順に並べて返す
+ */
+function pickLogLines(lines: string[]): string[] {
+  const encoder = new TextEncoder()
+  const picked: string[] = []
+  let bytes = 0
+  for (const line of [...lines].reverse()) {
+    if (picked.length >= LOG_REPLY_MAX_LINES) break
+    const size = encoder.encode(line).length
+    if (bytes + size > LOG_REPLY_MAX_BYTES) break
+    bytes += size
+    picked.push(line)
+  }
+  return picked.reverse()
 }
 
 export function useCoreS3Serial() {
@@ -110,8 +161,34 @@ export function useCoreS3Serial() {
   function handleLine(line: string): void {
     const kind = classify(line)
     if (kind === 'json') dispatchJson(line)
-    else if (kind === 'event') dispatchEvent(line)
+    else if (kind === 'event') {
+      dispatchEvent(line)
+      const queryId = logQueryId(line)
+      if (queryId !== null) void replyLog(queryId)
+    }
     // 'status' (名乗りそのもの) / 'alarm' / 'unknown' は捨てる
+  }
+
+  // --- get_log への返信 ---
+
+  /**
+   * `PWALOG <id> <行>` を 10 ms 間隔で送り、`PWALOG END <id> <n>` で閉じる。
+   *
+   * 書き込みは `write()` ではなく arbiter の `writeLine` を直に使う — 診断の返信の失敗で
+   * ポートを返して (release して) 掴み直しを起こさないため。1 行でも失敗したら残りは
+   * 打ち切る。返信中に次の `get_log` が来た・ポートを失った・掴み直した、のいずれでも
+   * 古い返信はそこで止める。
+   */
+  async function replyLog(id: string): Promise<void> {
+    const generation = ++logReplyGeneration
+    const writer = held
+    const lines = pickLogLines(readDiag()).map(line => `PWALOG ${id} ${line}`)
+    lines.push(`PWALOG END ${id} ${lines.length}`)
+    for (const [i, line] of lines.entries()) {
+      if (i > 0) await new Promise(resolve => setTimeout(resolve, LOG_REPLY_INTERVAL))
+      if (generation !== logReplyGeneration || held !== writer || !writer) return
+      if (!await writeLine(writer, line)) return
+    }
   }
 
   // --- heartbeat ---
@@ -213,7 +290,7 @@ export function useCoreS3Serial() {
   async function write(line: string): Promise<boolean> {
     if (!held) return false
     const ok = await writeLine(held, line)
-    if (!ok) await arbiter.release(CLAIMANT_NAME)
+    if (!ok) await arbiter.release(CLAIMANT_NAME, 'write_failed')
     return ok
   }
 

--- a/web/app/composables/useSerialArbiter.ts
+++ b/web/app/composables/useSerialArbiter.ts
@@ -22,11 +22,14 @@
  * 叩かない)。
  *
  * 診断ログ (`[SERIAL]`、Refs ippoan/alc-app#197): scan の開始 / セッションを閉じた理由 /
- * 60 秒再訪は常時。候補ごとの claim・見送り・open 失敗は本番のノイズになるので
- * `localStorage.alc_debug_serial=1` の端末だけ。
+ * 60 秒再訪 / connect イベント / close 失敗はコンソールに常時。候補ごとの claim・見送り・
+ * open 失敗は本番のノイズになるので、コンソールへは `localStorage.alc_debug_serial=1` の
+ * 端末だけ。どちらも診断ログの置き場 (utils/serialDiagLog) へは常に貯め、遠隔からは
+ * CoreS3 の `get_log` 経由で読む (Refs ippoan/alc-app#223)。
  */
 
 import { isWebSerialSupported } from '~/utils/webserial'
+import { appendDiag } from '~/utils/serialDiagLog'
 import { onPortConnected } from '~/composables/useSerialDeviceManager'
 
 /**
@@ -83,13 +86,28 @@ export function msSinceLoad(): number {
   return Math.round(performance.now())
 }
 
-function log(message: string): void {
+function print(message: string): void {
   console.log(`[SERIAL] ${message} (+${msSinceLoad()}ms)`)
 }
 
-/** 候補ごとの行。`localStorage.alc_debug_serial=1` のときだけ出す */
+/** 常時の行。コンソールと診断ログの置き場の両方へ */
+function log(message: string): void {
+  appendDiag(message)
+  print(message)
+}
+
+/**
+ * 候補ごとの行。置き場へは常に貯め、コンソールへは `localStorage.alc_debug_serial=1`
+ * のときだけ出す (Refs ippoan/alc-app#223)
+ */
 function debug(message: string): void {
-  if (localStorage.getItem(DEBUG_KEY) === '1') log(message)
+  appendDiag(message)
+  if (localStorage.getItem(DEBUG_KEY) === '1') print(message)
+}
+
+/** 例外の名前だけ (message は環境ごとの文言が入りうるので記録しない) */
+function errorName(e: unknown): string {
+  return e instanceof Error ? e.name : 'unknown'
 }
 
 /**
@@ -234,6 +252,7 @@ export function useSerialArbiter() {
    * 即予約する。
    */
   function handlePortConnected(port: SerialPort): void {
+    log('connect event')
     passedOver.delete(toRaw(port))
     if (scanning) {
       rescanRequested = true
@@ -263,7 +282,11 @@ export function useSerialArbiter() {
     try { s.writer.releaseLock() } catch {}
     try { await s.reader.cancel() } catch {}
     try { s.reader.releaseLock() } catch {}
-    try { await closePortQuietly(s.port) } catch {}
+    try { await closePortQuietly(s.port) }
+    catch (e) {
+      // 失敗するとポートが管理外に残りうる (掴み直さない症状の有力候補)。直す前にまず記録する
+      log(`close failed name=${errorName(e)}`)
+    }
     if (owner) owner.claimant.onClose()
   }
 
@@ -293,7 +316,7 @@ export function useSerialArbiter() {
       s.active = false
       s.buffer = ''
       // 預けたあとに終わった = 抜線・クラッシュ → 返させて掴み直しへ
-      if (s.owner) await release(s.owner.name)
+      if (s.owner) await release(s.owner.name, 'read_end')
     }
   }
 
@@ -376,9 +399,9 @@ export function useSerialArbiter() {
     try {
       await candidate.open(SERIAL_OPTIONS)
     }
-    catch {
+    catch (e) {
       // InvalidStateError = 他の探索者が使用中 → 印を残さず次の候補へ
-      debug('open failed (in use by another explorer?) -> next candidate')
+      debug(`open failed name=${errorName(e)}`)
       return
     }
 
@@ -494,12 +517,15 @@ export function useSerialArbiter() {
     }
   }
 
-  /** 預かったポートを返す (抜線・書き込み失敗など) → 掴み直しへ */
-  async function release(name: string): Promise<void> {
+  /**
+   * 預かったポートを返す (抜線・書き込み失敗など) → 掴み直しへ。
+   * `reason` (`read_end` / `write_failed` 等) は診断ログに残すだけ
+   */
+  async function release(name: string, reason?: string): Promise<void> {
     const s = held.get(name)
     if (!s) return
     held.delete(name)
-    await closeSession(s, `release(${name})`)
+    await closeSession(s, reason ? `release(${name}) reason=${reason}` : `release(${name})`)
     scheduleScan(RESCAN_INTERVAL)
   }
 

--- a/web/app/pages/maintenance.vue
+++ b/web/app/pages/maintenance.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { readDiag } from '~/utils/serialDiagLog'
+
 const {
   isConnected,
   state,
@@ -47,6 +49,27 @@ function formatSeconds(totalSeconds: number): string {
   const minutes = Math.floor((totalSeconds % 3600) / 60)
   return `${hours}時間${minutes}分`
 }
+
+// シリアル診断ログ (CoreS3 が繋がらず get_log で読めないときの逃げ道、Refs ippoan/alc-app#223)
+const diagLines = ref<string[]>([])
+const diagCopyResult = ref<'ok' | 'ng' | null>(null)
+
+function reloadDiag() {
+  diagLines.value = readDiag()
+  diagCopyResult.value = null
+}
+
+async function copyDiag() {
+  try {
+    await navigator.clipboard.writeText(diagLines.value.join('\n'))
+    diagCopyResult.value = 'ok'
+  }
+  catch {
+    diagCopyResult.value = 'ng'
+  }
+}
+
+onMounted(reloadDiag)
 </script>
 
 <template>
@@ -232,6 +255,40 @@ function formatSeconds(totalSeconds: number): string {
             </button>
           </div>
         </div>
+      </div>
+    </div>
+
+    <!-- シリアル診断ログ -->
+    <div class="w-full max-w-lg mt-4">
+      <div class="bg-white rounded-2xl p-6 shadow-sm">
+        <div class="flex items-center justify-between mb-3">
+          <h2 class="text-lg font-semibold text-gray-700">シリアル診断ログ</h2>
+          <div class="flex gap-2">
+            <button
+              class="px-3 py-1 bg-gray-100 text-gray-600 rounded-lg text-sm hover:bg-gray-200 transition-colors"
+              @click="reloadDiag"
+            >
+              再読み込み
+            </button>
+            <button
+              class="px-3 py-1 bg-gray-100 text-gray-600 rounded-lg text-sm hover:bg-gray-200 transition-colors"
+              :disabled="diagLines.length === 0"
+              @click="copyDiag"
+            >
+              コピー
+            </button>
+          </div>
+        </div>
+        <p class="text-sm text-gray-500 mb-2">
+          USB シリアルの接続・切断の記録 (最新 {{ diagLines.length }} 行)
+          <span v-if="diagCopyResult === 'ok'" class="text-green-600 ml-2">コピーしました</span>
+          <span v-else-if="diagCopyResult === 'ng'" class="text-red-600 ml-2">コピーできませんでした</span>
+        </p>
+        <pre
+          v-if="diagLines.length > 0"
+          class="max-h-64 overflow-y-auto bg-gray-50 rounded-lg p-3 text-xs font-mono text-gray-700 whitespace-pre-wrap break-all"
+        >{{ diagLines.join('\n') }}</pre>
+        <p v-else class="text-sm text-gray-400">記録はまだありません</p>
       </div>
     </div>
 

--- a/web/app/utils/serialDiagLog.ts
+++ b/web/app/utils/serialDiagLog.ts
@@ -1,0 +1,49 @@
+/**
+ * シリアル診断ログの置き場 (localStorage のリング、Refs ippoan/alc-app#223)。
+ *
+ * arbiter の `[SERIAL]` の行はコンソールにしか出ず、遠隔では読めない。ここへ**常に**
+ * 貯めておき (再読み込みをまたいで残る)、CoreS3 の `get_log` の問い合わせ
+ * (useCoreS3Serial) とメンテナンス画面から読む。
+ *
+ * 入れるのは arbiter の診断の行だけ。券・nonce・ERR の行・利用者の情報は入れない。
+ *
+ * localStorage が使えない (SSR・例外・容量超過) ときは何もしない / 空を返す — 診断の
+ * 置き場が本処理 (ポートの調停) を落としてはいけないため、例外は外へ出さない。
+ */
+
+const STORAGE_KEY = 'alc_serial_diag'
+/** 保持する最大行数。超えたら古い行から捨てる */
+const MAX_LINES = 200
+/** 1 行の最大文字数 (時刻込み) */
+const MAX_LINE_LENGTH = 160
+
+/** `HH:MM:SS.mmm` (PWA のローカル時刻) */
+function timestamp(d: Date): string {
+  const pad = (n: number, width = 2): string => String(n).padStart(width, '0')
+  return `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}.${pad(d.getMilliseconds(), 3)}`
+}
+
+/** 貯めた行を古い順に返す */
+export function readDiag(): string[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return []
+    const parsed: unknown = JSON.parse(raw)
+    return Array.isArray(parsed) ? parsed : []
+  }
+  catch {
+    return []
+  }
+}
+
+/** 1 行貯める (`HH:MM:SS.mmm <msg>`、改行は空白に、160 文字で切る) */
+export function appendDiag(msg: string): void {
+  try {
+    const line = `${timestamp(new Date())} ${msg.replace(/[\r\n]/g, ' ')}`.slice(0, MAX_LINE_LENGTH)
+    const lines = [...readDiag(), line].slice(-MAX_LINES)
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(lines))
+  }
+  catch {
+    // 容量超過など。診断が本処理を止めないよう黙って捨てる
+  }
+}

--- a/web/coverage_100.toml
+++ b/web/coverage_100.toml
@@ -195,3 +195,7 @@ branches = true
 [[files]]
 path = "app/utils/reload-reason.ts"
 branches = true
+
+[[files]]
+path = "app/utils/serialDiagLog.ts"
+branches = true

--- a/web/tests/composables/useCoreS3Serial.test.ts
+++ b/web/tests/composables/useCoreS3Serial.test.ts
@@ -358,6 +358,178 @@ describe('useCoreS3Serial', () => {
       expect(core.isConnected.value).toBe(false)
       expect(dev.port.close).toHaveBeenCalledTimes(1)
     })
+
+    it('書き込み失敗で返したときは診断ログに reason=write_failed を残す', async () => {
+      const dev = createMockPort()
+      await connectWithJson(dev)
+      dev.setWriteError(true)
+
+      await core.write('{"cmd":"reset"}')
+
+      const { readDiag } = await import('~/utils/serialDiagLog')
+      expect(readDiag().some(line => line.endsWith('close port of cores3: release(cores3) reason=write_failed'))).toBe(true)
+    })
+  })
+
+  // ---------- get_log の問い合わせ (Refs ippoan/alc-app#223) ----------
+
+  /**
+   * CoreS3 は遠隔の `get_log` を `EVT WS_COMMAND <id> <payload>` で PWA に問い合わせる。
+   * PWA は置き場 (alc_serial_diag) の行を `PWALOG <id> <行>` で返し `PWALOG END <id> <n>` で閉じる。
+   */
+  describe('get_log', () => {
+    const DIAG_KEY = 'alc_serial_diag'
+
+    function setDiag(lines: string[]): void {
+      localStorage.setItem(DIAG_KEY, JSON.stringify(lines))
+    }
+
+    function getLog(id: string): string {
+      return `EVT WS_COMMAND ${id} {"action":"get_log","lines":40}\n`
+    }
+
+    function replies(dev: MockPortHandle): string[] {
+      return dev.writes.filter(line => line.startsWith('PWALOG '))
+    }
+
+    beforeEach(() => {
+      localStorage.removeItem(DIAG_KEY)
+    })
+
+    afterEach(() => {
+      localStorage.removeItem(DIAG_KEY)
+    })
+
+    it('PWALOG <id> <行> を古い順に 10 ms 間隔で送り、PWALOG END <id> <n> で閉じる', async () => {
+      const dev = createMockPort()
+      await connectWithJson(dev)
+      const events: string[] = []
+      core.onEvent(name => events.push(name))
+      setDiag(['a', 'b', 'c'])
+
+      dev.emit(getLog('42'))
+      await vi.advanceTimersByTimeAsync(0)
+      expect(replies(dev)).toEqual(['PWALOG 42 a\n'])
+
+      await vi.advanceTimersByTimeAsync(10)
+      expect(replies(dev)).toEqual(['PWALOG 42 a\n', 'PWALOG 42 b\n'])
+
+      await vi.advanceTimersByTimeAsync(20)
+      expect(replies(dev)).toEqual(['PWALOG 42 a\n', 'PWALOG 42 b\n', 'PWALOG 42 c\n', 'PWALOG END 42 3\n'])
+      // 既存の EVT の配送は変えない
+      expect(events).toEqual(['WS_COMMAND'])
+    })
+
+    it('置き場が空なら PWALOG END <id> 0 だけ', async () => {
+      const dev = createMockPort()
+      await connectWithJson(dev)
+      localStorage.removeItem(DIAG_KEY)
+
+      dev.emit(getLog('7'))
+      await vi.advanceTimersByTimeAsync(100)
+
+      expect(replies(dev)).toEqual(['PWALOG END 7 0\n'])
+    })
+
+    it('最大 40 行 (新しい行を優先し、送る順は古い順)', async () => {
+      const dev = createMockPort()
+      await connectWithJson(dev)
+      setDiag(Array.from({ length: 50 }, (_, i) => `l${i}`))
+
+      dev.emit(getLog('1'))
+      await vi.advanceTimersByTimeAsync(1000)
+
+      const sent = replies(dev)
+      expect(sent).toHaveLength(41)
+      expect(sent[0]).toBe('PWALOG 1 l10\n')
+      expect(sent[39]).toBe('PWALOG 1 l49\n')
+      expect(sent[40]).toBe('PWALOG END 1 40\n')
+    })
+
+    it('合計 1200 バイト (UTF-8) に収まる分だけ (新しい行を優先)', async () => {
+      const dev = createMockPort()
+      await connectWithJson(dev)
+      // 1 行 = 3 + 3×49 = 150 バイト (52 文字)。8 行でちょうど 1200 バイト
+      setDiag(Array.from({ length: 10 }, (_, i) => `${String(i).padStart(3, '0')}${'あ'.repeat(49)}`))
+
+      dev.emit(getLog('9'))
+      await vi.advanceTimersByTimeAsync(1000)
+
+      const sent = replies(dev)
+      expect(sent).toHaveLength(9)
+      expect(sent[0]!.startsWith('PWALOG 9 002')).toBe(true)
+      expect(sent[7]!.startsWith('PWALOG 9 009')).toBe(true)
+      expect(sent[8]).toBe('PWALOG END 9 8\n')
+    })
+
+    it.each([
+      ['他の action', 'EVT WS_COMMAND 1 {"action":"measure"}\n'],
+      ['JSON でない payload', 'EVT WS_COMMAND 1 get_log\n'],
+      ['payload が null', 'EVT WS_COMMAND 1 null\n'],
+      ['payload が無い', 'EVT WS_COMMAND 1\n'],
+      ['id が空', 'EVT WS_COMMAND  {"action":"get_log"}\n'],
+      ['WS_COMMAND 以外の EVT', 'EVT OTHER 1 {"action":"get_log"}\n'],
+    ])('%s では何も送らない', async (_label, line) => {
+      const dev = createMockPort()
+      await connectWithJson(dev)
+      setDiag(['a'])
+
+      dev.emit(line)
+      await vi.advanceTimersByTimeAsync(100)
+
+      expect(dev.writes).toEqual(['STATUS\n', 'HB OK\n'])
+    })
+
+    it('送信に失敗したら残りを打ち切り、ポートは返さない (release しない)', async () => {
+      const dev = createMockPort()
+      await connectWithJson(dev)
+      setDiag(['a', 'b', 'c'])
+      dev.port.writable.getWriter().write.mockRejectedValueOnce(new Error('write failed'))
+
+      dev.emit(getLog('5'))
+      await vi.advanceTimersByTimeAsync(100)
+
+      // 1 行目で失敗 → 残り (b, c, END) は送らない
+      expect(replies(dev)).toEqual([])
+      expect(core.isConnected.value).toBe(true)
+      expect(dev.port.close).not.toHaveBeenCalled()
+
+      // 接続は生きている (heartbeat が続く)
+      await vi.advanceTimersByTimeAsync(3000)
+      expect(dev.writes.at(-1)).toBe('HB OK\n')
+    })
+
+    it('返信の途中で別の id が来たら、古い返信を打ち切って新しい方に答える', async () => {
+      const dev = createMockPort()
+      await connectWithJson(dev)
+      setDiag(['a', 'b', 'c'])
+
+      dev.emit(getLog('1'))
+      await vi.advanceTimersByTimeAsync(0)
+      dev.emit(getLog('2'))
+      await vi.advanceTimersByTimeAsync(100)
+
+      expect(replies(dev)).toEqual([
+        'PWALOG 1 a\n',
+        'PWALOG 2 a\n',
+        'PWALOG 2 b\n',
+        'PWALOG 2 c\n',
+        'PWALOG END 2 3\n',
+      ])
+    })
+
+    it('返信の途中でポートを失ったら止める', async () => {
+      const dev = createMockPort()
+      await connectWithJson(dev)
+      setDiag(['a', 'b', 'c'])
+
+      dev.emit(getLog('3'))
+      await vi.advanceTimersByTimeAsync(0)
+      await core.release()
+      await vi.advanceTimersByTimeAsync(100)
+
+      expect(replies(dev)).toEqual(['PWALOG 3 a\n'])
+    })
   })
 
   // ---------- heartbeat ----------

--- a/web/tests/composables/useSerialArbiter.test.ts
+++ b/web/tests/composables/useSerialArbiter.test.ts
@@ -1102,8 +1102,117 @@ describe('useSerialArbiter 診断ログ', () => {
       arbiter.register('alarm', claimant)
       await vi.advanceTimersByTimeAsync(0)
 
-      expect(serialLogs()).toContain('open failed (in use by another explorer?) -> next candidate')
+      expect(serialLogs()).toContain('open failed name=InvalidStateError')
       expect(serialLogs()).toContain('no readable/writable stream -> close')
+    })
+  })
+
+  // ---------- 置き場 (alc_serial_diag、Refs ippoan/alc-app#223) ----------
+
+  describe('診断ログの置き場', () => {
+    beforeEach(() => {
+      localStorage.removeItem('alc_serial_diag')
+    })
+
+    afterEach(() => {
+      localStorage.removeItem('alc_serial_diag')
+    })
+
+    /** 置き場の行 (先頭の `HH:MM:SS.mmm ` を落とした本文) */
+    async function diag(): Promise<string[]> {
+      const { readDiag } = await import('~/utils/serialDiagLog')
+      return readDiag().map(line => line.replace(/^\d\d:\d\d:\d\d\.\d{3} /, ''))
+    }
+
+    it('alc_debug_serial が無くても debug の行は置き場に入る (コンソールには出ない)', async () => {
+      const dev = createMockPort()
+      dev.emit('ALARM state=idle\n')
+      installSerialMock({ getPorts: vi.fn(async () => [dev.port]) })
+      await load()
+      const { claimant } = createClaimant('ALARM', 'CORE')
+      arbiter.register('alarm', claimant)
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(await diag()).toEqual([
+        'scan start: candidates=1 pending=alarm',
+        'claimed by alarm (probe lines=1)',
+      ])
+      // コンソールへの debug 出力は今までどおりフラグ次第
+      expect(serialLogs()).not.toContain('claimed by alarm (probe lines=1)')
+    })
+
+    it.each([
+      [new DOMException('busy', 'InvalidStateError'), 'open failed name=InvalidStateError'],
+      ['not an error', 'open failed name=unknown'],
+    ])('open 失敗はエラー名だけ残す (%s)', async (openError, expected) => {
+      const busy = createMockPort({ openError: openError as Error })
+      installSerialMock({ getPorts: vi.fn(async () => [busy.port]) })
+      await load()
+      const { claimant } = createClaimant('ALARM', 'CORE')
+      arbiter.register('alarm', claimant)
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(await diag()).toContain(expected)
+    })
+
+    it('connect イベントを残す (コンソールにも出す)', async () => {
+      installSerialMock({ getPorts: vi.fn(async () => []) })
+      await load()
+      const { claimant } = createClaimant('ALARM', 'CORE')
+      arbiter.register('alarm', claimant)
+      await vi.advanceTimersByTimeAsync(0)
+
+      emitConnect(createMockPort().port)
+
+      expect(await diag()).toContain('connect event')
+      expect(serialLogs()).toContain('connect event')
+    })
+
+    it('close の失敗はエラー名を残す (握りつぶさない)', async () => {
+      const dev = createMockPort()
+      dev.emit('ALARM state=idle\n')
+      dev.port.close.mockRejectedValueOnce(new DOMException('gone', 'NetworkError'))
+      installSerialMock({ getPorts: vi.fn(async () => [dev.port]) })
+      await load()
+      const { claimant, seen } = createClaimant('ALARM', 'CORE')
+      arbiter.register('alarm', claimant)
+      await vi.advanceTimersByTimeAsync(0)
+
+      await arbiter.release('alarm')
+
+      expect(await diag()).toContain('close failed name=NetworkError')
+      // 後始末 (onClose) は続ける
+      expect(seen.closed).toBe(1)
+    })
+
+    it('受信ループが終わった (抜線) release は reason=read_end を残す', async () => {
+      const dev = createMockPort()
+      dev.emit('ALARM state=idle\n')
+      installSerialMock({ getPorts: vi.fn(async () => [dev.port]) })
+      await load()
+      const { claimant } = createClaimant('ALARM', 'CORE')
+      arbiter.register('alarm', claimant)
+      await vi.advanceTimersByTimeAsync(0)
+
+      dev.push({ value: undefined, done: true })
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(await diag()).toContain('close port of alarm: release(alarm) reason=read_end')
+    })
+
+    it('release に渡した理由を残す (理由なしは今までの行のまま)', async () => {
+      const dev = createMockPort()
+      dev.emit('ALARM state=idle\n')
+      installSerialMock({ getPorts: vi.fn(async () => [dev.port]) })
+      await load()
+      const { claimant } = createClaimant('ALARM', 'CORE')
+      arbiter.register('alarm', claimant)
+      await vi.advanceTimersByTimeAsync(0)
+
+      await arbiter.release('alarm', 'write_failed')
+
+      expect(await diag()).toContain('close port of alarm: release(alarm) reason=write_failed')
+      expect(serialLogs()).toContain('close port of alarm: release(alarm) reason=write_failed')
     })
   })
 })

--- a/web/tests/utils/serialDiagLog.test.ts
+++ b/web/tests/utils/serialDiagLog.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { appendDiag, readDiag } from '~/utils/serialDiagLog'
+
+const KEY = 'alc_serial_diag'
+
+describe('serialDiagLog', () => {
+  beforeEach(() => {
+    localStorage.removeItem(KEY)
+    vi.useFakeTimers({ toFake: ['Date'] })
+    // ローカル時刻 09:05:07.042
+    vi.setSystemTime(new Date(2026, 8, 10, 9, 5, 7, 42))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+    localStorage.removeItem(KEY)
+  })
+
+  it('1 行 = `HH:MM:SS.mmm <msg>` (ローカル時刻) で、古い順に読める', () => {
+    appendDiag('scan start: candidates=1')
+    vi.setSystemTime(new Date(2026, 8, 10, 23, 59, 58, 7))
+    appendDiag('connect event')
+
+    expect(readDiag()).toEqual([
+      '09:05:07.042 scan start: candidates=1',
+      '23:59:58.007 connect event',
+    ])
+    // JSON の文字列配列として置く (他の読み手が同じキーを読めるように)
+    expect(JSON.parse(localStorage.getItem(KEY)!)).toEqual(readDiag())
+  })
+
+  it('\\r \\n は空白に置き換える', () => {
+    appendDiag('a\r\nb\nc')
+    expect(readDiag()).toEqual(['09:05:07.042 a  b c'])
+  })
+
+  it('160 文字 (時刻込み) で切る', () => {
+    appendDiag('x'.repeat(300))
+    const [line] = readDiag()
+    expect(line).toHaveLength(160)
+    expect(line!.startsWith('09:05:07.042 xxx')).toBe(true)
+  })
+
+  it('200 行を超えたら古い行から捨てる', () => {
+    for (let i = 0; i < 205; i++) appendDiag(`m${i}`)
+    const lines = readDiag()
+    expect(lines).toHaveLength(200)
+    expect(lines[0]).toBe('09:05:07.042 m5')
+    expect(lines.at(-1)).toBe('09:05:07.042 m204')
+  })
+
+  it('何も無ければ空配列', () => {
+    expect(readDiag()).toEqual([])
+  })
+
+  it.each([
+    ['壊れた JSON', '{not json'],
+    ['配列でない JSON', '{"a":1}'],
+  ])('%s は空配列として読み、追記で置き直す', (_label, raw) => {
+    localStorage.setItem(KEY, raw)
+    expect(readDiag()).toEqual([])
+
+    appendDiag('after')
+    expect(readDiag()).toEqual(['09:05:07.042 after'])
+  })
+
+  // happy-dom の localStorage は Storage.prototype を経由しないので、spyOn ではなく差し替える
+
+  it('localStorage が例外を投げても落ちない (読めない端末の設定)', () => {
+    const getItem = vi.fn(() => {
+      throw new DOMException('denied', 'SecurityError')
+    })
+    const setItem = vi.fn()
+    vi.stubGlobal('localStorage', { getItem, setItem })
+
+    expect(readDiag()).toEqual([])
+    expect(() => appendDiag('x')).not.toThrow()
+    expect(getItem).toHaveBeenCalled()
+  })
+
+  it('容量超過 (setItem が投げる) でも落ちない', () => {
+    const stored = JSON.stringify(['09:05:07.042 before'])
+    const setItem = vi.fn(() => {
+      throw new DOMException('full', 'QuotaExceededError')
+    })
+    vi.stubGlobal('localStorage', { getItem: vi.fn(() => stored), setItem })
+
+    expect(() => appendDiag('x')).not.toThrow()
+    expect(setItem).toHaveBeenCalledTimes(1)
+    expect(readDiag()).toEqual(['09:05:07.042 before'])
+  })
+
+  it('localStorage が無い (SSR) でも落ちない', () => {
+    vi.stubGlobal('localStorage', undefined)
+
+    expect(readDiag()).toEqual([])
+    expect(() => appendDiag('x')).not.toThrow()
+  })
+})


### PR DESCRIPTION
## 何を直したか

キオスクの PWA のシリアルの記録 (`[SERIAL]`、ポートの開け閉め・掴み直し) は、ブラウザのコンソールにしか出ていませんでした。詳細は `alc_debug_serial` を立てたときだけです。そのため、USB の抜き挿しで「掴み直さない」「ときどき CoreS3 がリセットする」が起きても、何が起きたかを後から追えませんでした (#223)。

## 直し方

| 箇所 | 変更 |
|---|---|
| `web/app/utils/serialDiagLog.ts` (新規) | localStorage (`alc_serial_diag`) に上限 200 行のリングで診断の行を**常に**貯める。1 行 `HH:MM:SS.mmm <msg>`、160 文字で切る。localStorage が使えないときは何もしない |
| `web/app/composables/useSerialArbiter.ts` | log / debug の行を、フラグに関係なく置き場へ。記録点を 4 つ追加: `open failed name=<name>` / `connect event` / `close failed name=<name>` / `release(<name>) reason=read_end\|write_failed` |
| `web/app/composables/useCoreS3Serial.ts` | CoreS3 から `EVT WS_COMMAND <id> {"action":"get_log"…}` が来たら、置き場の新しい行から最大 40 行・1200 B を古い順に `PWALOG <id> <行>` で返し、`PWALOG END <id> <n>` で閉じる (10 ms 間隔、失敗しても release しない、別 id が来たら打ち切り) |
| `web/app/pages/maintenance.vue` | 「シリアル診断ログ」のカード (最新 200 行・再読み込み・コピー) |

- CoreS3 はこの返事を `get_log` の応答の `pwa_log` に載せます (firmware 側は ippoan/alc-app-s3#215)。古い firmware では `PWALOG` を知らないので、何も起きません
- 置き場に入るのは arbiter の診断の行だけです (利用側の名前・理由・件数・エラー名)。券・nonce・ERR の行・STATUS の応答は入れていません
- 「掴み直さない」の有力候補 (close 失敗時にポートが管理外になる) は、今回は記録点を足すだけで直していません。次に起きたときにログで確かめてから直します

## 検証

| 項目 | 結果 |
|---|---|
| `npx nuxi typecheck` | exit 0 |
| `npx vitest run` | 60 files / 1469 passed, 2 skipped |
| `npm run test:coverage` | exit 0 (`serialDiagLog.ts` 100%) |
| `node scripts/check_coverage_100.mjs` | 47 files すべて 100% |

既存テストの期待値の変更は 1 か所 (open 失敗の行の文言を `open failed name=InvalidStateError` に)。

## 実機確認 (マージ後)

メンテナンス画面のカードに行が出ることを確かめます。firmware 側 (#215) も本番に出たら、`get_device_log` の `pwa_log` に PWA の行が返ることを確かめます。

Closes #223
Refs ippoan/alc-app-s3#135 ippoan/alc-app-s3#215

🤖 Generated with [Claude Code](https://claude.com/claude-code)
