### PR TITLE
feat(serial): 診断ログに CoreS3 の EVT を残して同じ行をまとめ、EVT ALARM_RESTORED で CoreS3 を見送る誤判定を直す (Closes #225)

### DIFF
--- a/web/app/composables/useCoreS3Serial.ts
+++ b/web/app/composables/useCoreS3Serial.ts
@@ -40,7 +40,7 @@
 import type { SerialClaimant } from '~/composables/useSerialArbiter'
 import { HEARTBEAT_INTERVAL, RELOAD_GRACE_SEC } from '~/composables/useAlarmDevice'
 import { writeLine } from '~/composables/useSerialArbiter'
-import { readDiag } from '~/utils/serialDiagLog'
+import { appendDiag, readDiag } from '~/utils/serialDiagLog'
 
 /** arbiter に登録する名前 */
 const CLAIMANT_NAME = 'cores3'
@@ -60,6 +60,32 @@ const LOG_REPLY_MAX_LINES = 40
 const LOG_REPLY_MAX_BYTES = 1200
 /** `PWALOG` の行を送る間隔 (CoreS3 の受信を溢れさせない。40 行で約 0.4 秒) */
 const LOG_REPLY_INTERVAL = 10
+
+/**
+ * 置き場に `dev <行>` で残す CoreS3 の `EVT` の接頭辞。CoreS3 自身のログは電源断で消えるので、
+ * 落ちる直前の出来事を PC 側に残す (Refs ippoan/alc-app#225)。
+ * 許可リストにするのは、点呼のセッション ID・免許証・カード・資格情報・URL を載せる行 (`TENKO_SESSION` / `NFC_LICENSE` / `LICENSE_EXPIRED` / `TIMECARD` / `AUTH_TOKEN` / `WS_COMMAND` / `OTA_START` / `PRINT_START` / `WIFI_TEST` / `GW_AUTH_FAIL`) と周期的な行 (`BATT` / `HEAP` / `*_PROGRESS`) を入れないため。短い接頭辞 (`EVT WS_` / `EVT ETH`) にしない。
+ */
+const DIAG_EVENT_PREFIXES = [
+  'EVT BOOT',
+  'EVT CRASH',
+  'EVT USB_HOST=',
+  'EVT BUS5V',
+  'EVT ETH_PROBE_OK',
+  'EVT ETH_CONNECTED',
+  'EVT ETH_DISCONNECTED',
+  'EVT ETH NG',
+  'EVT WS_CONNECTED',
+  'EVT WS_DISCONNECTED',
+  'EVT WS_STALE_RESTART',
+  'EVT WS_DROPPED',
+  'EVT WS_REBOOT_CMD',
+  'EVT NFC_INIT_NG',
+  'EVT NFC_READY',
+  'EVT ALARM_RESTORED',
+  'EVT OTA OK',
+  'EVT OTA NG',
+]
 
 /** 行の素性。CoreS3 のものか、警告デバイスのものか、どちらとも言えないか */
 type LineKind = 'json' | 'status' | 'event' | 'alarm' | 'unknown'
@@ -86,10 +112,12 @@ let logReplyGeneration = 0
 /**
  * 行の接頭辞から素性を決める。
  *
- * 警告デバイスの行を先に見る: `EVT ALARM` は `EVT ` にも当てはまるため。
+ * 警告デバイスの行を先に見る: `EVT ALARM` は `EVT ` にも当てはまるため。空白まで見る —
+ * CoreS3 が起動時に出す `EVT ALARM_RESTORED` を警告デバイスの行と取り違えて CoreS3 を
+ * 見送らないため (Refs ippoan/alc-app#225)。
  */
 function classify(line: string): LineKind {
-  if (line.startsWith('STATUS alarm') || line.startsWith('EVT ALARM')) return 'alarm'
+  if (line.startsWith('STATUS alarm') || line === 'EVT ALARM' || line.startsWith('EVT ALARM ')) return 'alarm'
   if (line.startsWith('{')) return 'json'
   if (line.startsWith('STATUS ') && line.includes('BOARD=cores3')) return 'status'
   if (line.startsWith('EVT ')) return 'event'
@@ -162,6 +190,7 @@ export function useCoreS3Serial() {
     const kind = classify(line)
     if (kind === 'json') dispatchJson(line)
     else if (kind === 'event') {
+      if (DIAG_EVENT_PREFIXES.some(prefix => line.startsWith(prefix))) appendDiag(`dev ${line}`)
       dispatchEvent(line)
       const queryId = logQueryId(line)
       if (queryId !== null) void replyLog(queryId)

--- a/web/app/utils/serialDiagLog.ts
+++ b/web/app/utils/serialDiagLog.ts
@@ -5,17 +5,34 @@
  * 貯めておき (再読み込みをまたいで残る)、CoreS3 の `get_log` の問い合わせ
  * (useCoreS3Serial) とメンテナンス画面から読む。
  *
- * 入れるのは arbiter の診断の行だけ。券・nonce・ERR の行・利用者の情報は入れない。
+ * 入れるのは arbiter の診断の行と、CoreS3 の許可リストの `EVT` 行 (`dev ` 接頭辞、
+ * Refs ippoan/alc-app#225)。券・nonce・ERR の行・利用者の情報は入れない。
+ *
+ * 直前と同じ本文が続いたら新しく足さず 1 件にまとめ、回数と最後の時刻を付ける —
+ * CoreS3 が落ちているあいだ arbiter は 10 秒ごとに `scan start` を書くので、まとめないと
+ * 落ちる直前の行が約 33 分で押し出される。
  *
  * localStorage が使えない (SSR・例外・容量超過) ときは何もしない / 空を返す — 診断の
  * 置き場が本処理 (ポートの調停) を落としてはいけないため、例外は外へ出さない。
  */
 
 const STORAGE_KEY = 'alc_serial_diag'
-/** 保持する最大行数。超えたら古い行から捨てる */
+/** 保持する最大件数。超えたら古い件から捨てる */
 const MAX_LINES = 200
-/** 1 行の最大文字数 (時刻込み) */
+/** 1 行の最大文字数 (時刻・まとめた回数の表示込み) */
 const MAX_LINE_LENGTH = 160
+
+/** 置き場の 1 件 */
+interface DiagEntry {
+  /** 最初の時刻 `HH:MM:SS.mmm` */
+  t: string
+  /** 本文 (改行は空白に、時刻込みで 160 文字に切ったもの) */
+  msg: string
+  /** 続いた回数 */
+  n: number
+  /** 最後の時刻 `HH:MM:SS` */
+  last: string
+}
 
 /** `HH:MM:SS.mmm` (PWA のローカル時刻) */
 function timestamp(d: Date): string {
@@ -23,25 +40,52 @@ function timestamp(d: Date): string {
   return `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}.${pad(d.getMilliseconds(), 3)}`
 }
 
-/** 貯めた行を古い順に返す */
-export function readDiag(): string[] {
+/**
+ * 置き場の中身を古い順に。#223 の古い形 (整形済みの文字列) はそのまま `n = 1` の 1 件として
+ * 読む。どちらでもない要素と、読めない置き場は捨てる
+ */
+function load(): Array<string | DiagEntry> {
   try {
     const raw = localStorage.getItem(STORAGE_KEY)
     if (!raw) return []
     const parsed: unknown = JSON.parse(raw)
-    return Array.isArray(parsed) ? parsed : []
+    if (!Array.isArray(parsed)) return []
+    return parsed.filter(e => typeof e === 'string' || typeof e?.msg === 'string')
   }
   catch {
     return []
   }
 }
 
-/** 1 行貯める (`HH:MM:SS.mmm <msg>`、改行は空白に、160 文字で切る) */
+/** `HH:MM:SS.mmm <msg>`、まとめた件は ` (×<n> 最後 HH:MM:SS)` を付ける (本文を削って 160 文字に収める) */
+function format(entry: string | DiagEntry): string {
+  if (typeof entry === 'string') return entry
+  const line = `${entry.t} ${entry.msg}`
+  if (entry.n === 1) return line
+  const tail = ` (×${entry.n} 最後 ${entry.last})`
+  return line.slice(0, MAX_LINE_LENGTH - tail.length) + tail
+}
+
+/** 貯めた行を古い順に返す */
+export function readDiag(): string[] {
+  return load().map(format)
+}
+
+/** 1 行貯める (改行は空白に、時刻込みで 160 文字に切る)。直前と同じ本文ならその件にまとめる */
 export function appendDiag(msg: string): void {
   try {
-    const line = `${timestamp(new Date())} ${msg.replace(/[\r\n]/g, ' ')}`.slice(0, MAX_LINE_LENGTH)
-    const lines = [...readDiag(), line].slice(-MAX_LINES)
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(lines))
+    const now = timestamp(new Date())
+    const body = msg.replace(/[\r\n]/g, ' ').slice(0, MAX_LINE_LENGTH - now.length - 1)
+    const entries = load()
+    const prev = entries.at(-1)
+    if (typeof prev === 'object' && prev.msg === body) {
+      prev.n += 1
+      prev.last = now.slice(0, 8)
+    }
+    else {
+      entries.push({ t: now, msg: body, n: 1, last: now.slice(0, 8) })
+    }
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(entries.slice(-MAX_LINES)))
   }
   catch {
     // 容量超過など。診断が本処理を止めないよう黙って捨てる

--- a/web/tests/composables/useCoreS3Serial.test.ts
+++ b/web/tests/composables/useCoreS3Serial.test.ts
@@ -191,6 +191,7 @@ describe('useCoreS3Serial', () => {
 
     it.each([
       ['EVT ALARM state=alarming cause=silence\n', 'EVT ALARM'],
+      ['EVT ALARM\n', 'EVT ALARM (引数なし)'],
       ['STATUS alarm state=idle cause=none hb_age_ms=1200 VER=0.1.0\n', 'STATUS alarm'],
     ])('警告デバイスの行 (%s) は reject して即手放す', async (line) => {
       const dev = createMockPort()
@@ -203,6 +204,26 @@ describe('useCoreS3Serial', () => {
       expect(core.isConnected.value).toBe(false)
       // 8 秒待たずに閉じている (reject が確定した時点で打ち切り)
       expect(dev.port.close).toHaveBeenCalledTimes(1)
+    })
+
+    it('CoreS3 の起動時の EVT ALARM_RESTORED では reject せず、続く JSON で claim する (Refs #225)', async () => {
+      const dev = createMockPort()
+      dev.emit('EVT ALARM_RESTORED\n')
+      installSerialMock({ getPorts: vi.fn(async () => [dev.port]) })
+      await load()
+      const events: string[] = []
+      core.onEvent(name => events.push(name))
+
+      const p = core.connect(0)
+      await vi.advanceTimersByTimeAsync(0)
+      // 警告デバイスと取り違えて見送っていない
+      expect(dev.port.close).not.toHaveBeenCalled()
+
+      dev.emit('{"type":"ready","version":"1.0.0"}\n')
+      await vi.advanceTimersByTimeAsync(0)
+      await expect(p).resolves.toBe(true)
+      // プローブ中の EVT も CoreS3 のものとして配る
+      expect(events).toEqual(['ALARM_RESTORED'])
     })
   })
 
@@ -285,6 +306,74 @@ describe('useCoreS3Serial', () => {
       await vi.advanceTimersByTimeAsync(0)
 
       expect(seen).toEqual([])
+    })
+  })
+
+  // ---------- CoreS3 の EVT を置き場に残す (Refs ippoan/alc-app#225) ----------
+
+  describe('診断ログの置き場に EVT を残す', () => {
+    const DIAG_KEY = 'alc_serial_diag'
+
+    /** 置き場の行 (先頭の `HH:MM:SS.mmm ` を落とした本文) */
+    async function diag(): Promise<string[]> {
+      const { readDiag } = await import('~/utils/serialDiagLog')
+      return readDiag().map(line => line.replace(/^\d\d:\d\d:\d\d\.\d{3} /, ''))
+    }
+
+    beforeEach(() => {
+      localStorage.removeItem(DIAG_KEY)
+    })
+
+    afterEach(() => {
+      localStorage.removeItem(DIAG_KEY)
+    })
+
+    it.each([
+      'EVT BOOT reset=poweron ver=0.3.1',
+      'EVT CRASH reason=panic',
+      'EVT USB_HOST=1',
+      'EVT BUS5V on',
+      'EVT ETH_PROBE_OK',
+      'EVT ETH_CONNECTED ip=192.0.2.10',
+      'EVT ETH_DISCONNECTED',
+      'EVT ETH NG code=3',
+      'EVT WS_CONNECTED',
+      'EVT WS_DISCONNECTED',
+      'EVT WS_STALE_RESTART',
+      'EVT WS_DROPPED code=1006',
+      'EVT WS_REBOOT_CMD',
+      'EVT NFC_INIT_NG',
+      'EVT NFC_READY',
+      'EVT ALARM_RESTORED',
+      'EVT OTA OK ver=0.3.2',
+      'EVT OTA NG reason=hash',
+    ])('許可リストの行 (%s) は `dev <行>` で残し、配送も続ける', async (line) => {
+      const dev = createMockPort()
+      await connectWithJson(dev)
+      const events: string[] = []
+      core.onEvent(name => events.push(name))
+
+      dev.emit(`${line}\n`)
+      await vi.advanceTimersByTimeAsync(0)
+
+      expect(await diag()).toContain(`dev ${line}`)
+      expect(events).toHaveLength(1)
+    })
+
+    it.each([
+      'EVT TENKO_SESSION abc',
+      'EVT NFC_LICENSE issue=20230401 expiry=20280401',
+      'EVT BATT 87',
+      'EVT WS_COMMAND 1 {"action":"get_log"}',
+      'EVT ALARM idle none',
+    ])('許可リスト外の行 (%s) は残さない', async (line) => {
+      const dev = createMockPort()
+      await connectWithJson(dev)
+
+      dev.emit(`${line}\n`)
+      await vi.advanceTimersByTimeAsync(100)
+
+      expect((await diag()).filter(l => l.startsWith('dev '))).toEqual([])
     })
   })
 

--- a/web/tests/utils/serialDiagLog.test.ts
+++ b/web/tests/utils/serialDiagLog.test.ts
@@ -27,8 +27,65 @@ describe('serialDiagLog', () => {
       '09:05:07.042 scan start: candidates=1',
       '23:59:58.007 connect event',
     ])
-    // JSON の文字列配列として置く (他の読み手が同じキーを読めるように)
-    expect(JSON.parse(localStorage.getItem(KEY)!)).toEqual(readDiag())
+  })
+
+  it('直前と同じ本文が続いたら 1 件にまとめ、回数と最後の時刻を付ける', () => {
+    appendDiag('scan start: candidates=0')
+    vi.setSystemTime(new Date(2026, 8, 10, 9, 5, 17, 100))
+    appendDiag('scan start: candidates=0')
+    vi.setSystemTime(new Date(2026, 8, 10, 9, 38, 27, 900))
+    appendDiag('scan start: candidates=0')
+
+    expect(readDiag()).toEqual(['09:05:07.042 scan start: candidates=0 (×3 最後 09:38:27)'])
+  })
+
+  it('間に別の行が入ったらまとめない', () => {
+    appendDiag('scan start: candidates=0')
+    appendDiag('dev EVT BOOT reset=poweron')
+    appendDiag('scan start: candidates=0')
+
+    expect(readDiag()).toEqual([
+      '09:05:07.042 scan start: candidates=0',
+      '09:05:07.042 dev EVT BOOT reset=poweron',
+      '09:05:07.042 scan start: candidates=0',
+    ])
+  })
+
+  it('まとめた件も 160 文字に収め、回数の表示は削らない', () => {
+    appendDiag('x'.repeat(300))
+    appendDiag('x'.repeat(300))
+
+    const [line] = readDiag()
+    expect(line).toHaveLength(160)
+    expect(line!.endsWith('xxx (×2 最後 09:05:07)')).toBe(true)
+  })
+
+  it('本文は 160 文字に切った後で比べる (切った先だけ違う行はまとめる)', () => {
+    appendDiag(`${'x'.repeat(200)}a`)
+    appendDiag(`${'x'.repeat(200)}b`)
+
+    expect(readDiag()).toHaveLength(1)
+    expect(readDiag()[0]!.endsWith('(×2 最後 09:05:07)')).toBe(true)
+  })
+
+  it('古い形 (整形済みの文字列の要素) も読め、その後ろに追記できる', () => {
+    localStorage.setItem(KEY, JSON.stringify(['08:00:00.000 scan start: candidates=0']))
+
+    expect(readDiag()).toEqual(['08:00:00.000 scan start: candidates=0'])
+
+    // 古い形の件にはまとめない (n = 1 として扱う)
+    appendDiag('scan start: candidates=0')
+    appendDiag('scan start: candidates=0')
+    expect(readDiag()).toEqual([
+      '08:00:00.000 scan start: candidates=0',
+      '09:05:07.042 scan start: candidates=0 (×2 最後 09:05:07)',
+    ])
+  })
+
+  it('文字列でも置き場の形でもない要素は捨てる', () => {
+    localStorage.setItem(KEY, JSON.stringify([null, 1, { t: 'x' }, '08:00:00.000 ok']))
+
+    expect(readDiag()).toEqual(['08:00:00.000 ok'])
   })
 
   it('\\r \\n は空白に置き換える', () => {


### PR DESCRIPTION
## 何を直したか

CoreS3 のログ (`.noinit` リング) は電源断で消えます。本番で電源断が起きたとき、その直前に何が起きたか (PoE を抜いたのか・USB を抜いたのか・5V の切り替えで落ちたのか) が残りませんでした。キオスクの PC は CoreS3 が落ちても動き続け、CoreS3 がシリアルに出す `EVT` の行を受け取っているので、PC 側の診断ログ (#223 の `alc_serial_diag`) にも残します (#225)。

あわせて、見つかった不具合を 1 つ直します: CoreS3 は起動時に `EVT ALARM_RESTORED` を出しますが、`classify()` が `EVT ALARM` の前方一致で警告デバイスの行と見なし、CoreS3 を 60 秒見送ることがありました (診断ログに「passed over … revisit in 60s」)。

## 直し方

| 箇所 | 変更 |
|---|---|
| `web/app/composables/useCoreS3Serial.ts` | `classify()` の警告デバイス判定を `line === 'EVT ALARM' \|\| line.startsWith('EVT ALARM ')` に (空白まで見る)。`EVT ALARM_RESTORED` は `'event'` になり CoreS3 を見送らない。`STATUS alarm` の判定は不変。`'event'` の行のうち**許可リストの接頭辞だけ** `dev <行>` で診断ログへ |
| `web/app/utils/serialDiagLog.ts` | 直前と同じ本文が続いたら新しく足さず 1 件にまとめ、`HH:MM:SS.mmm <msg> (×<n> 最後 HH:MM:SS)` で出す。保存の形は `{t, msg, n, last}`、既に保存されている文字列の要素は `n = 1` として読める。`readDiag()` は同期のまま。上限 200 行・160 文字・localStorage が使えないときに例外を出さない、は不変 |
| テスト 2 ファイル | まとめ / 間に別の行が入ったらまとめない / 古い形の読み込み / `EVT ALARM_RESTORED` が `'alarm'` にならない / `EVT ALARM <state>` と `STATUS alarm` は従来どおり / 許可リストの行は入り、許可リスト外は入らない |

- 許可リストは名前で並べています: `EVT BOOT` / `EVT CRASH` / `EVT USB_HOST=` / `EVT BUS5V` / `EVT ETH_PROBE_OK` / `EVT ETH_CONNECTED` / `EVT ETH_DISCONNECTED` / `EVT ETH NG` / `EVT WS_CONNECTED` / `EVT WS_DISCONNECTED` / `EVT WS_STALE_RESTART` / `EVT WS_DROPPED` / `EVT WS_REBOOT_CMD` / `EVT NFC_INIT_NG` / `EVT NFC_READY` / `EVT ALARM_RESTORED` / `EVT OTA OK` / `EVT OTA NG`
- 点呼のセッション・免許証・カード・資格情報・URL を載せる行と、周期的な行 (`BATT` / `HEAP` / 進捗) は入れません。短い接頭辞 (`EVT WS_` / `EVT ETH`) にもしていません
- 同じ行をまとめるのは、CoreS3 が落ちているあいだ arbiter が 10 秒ごとに `scan start` を書き、200 行が約 33 分で埋まって落ちる直前の行が押し出されるためです。置き場は localStorage のままです (IndexedDB に移しても読み口が 200 行 / 40 行のままなので効きません)
- `PWALOG` の返し方 (最大 40 行・1200 B) は変えていません

## 検証

| 項目 | 結果 |
|---|---|
| `npx nuxi typecheck` | exit 0 |
| `npx vitest run` | 60 files / 1500 passed, 2 skipped |
| `npm run test:coverage` | `useCoreS3Serial.ts` / `serialDiagLog.ts` とも lines / branches 100% |
| `node scripts/check_coverage_100.mjs` | 47 files すべて 100% |

## 実機確認 (マージ後)

`get_device_log` の `pwa_log` に `dev EVT …` の行が並ぶこと、CoreS3 の再起動直後に 60 秒の見送りが出ないことを確かめます。

Closes #225
Refs ippoan/alc-app-s3#135 ippoan/alc-app-s3#211 ippoan/alc-app-s3#210

🤖 Generated with [Claude Code](https://claude.com/claude-code)
