### PR TITLE
fix(device-pairing): 端末登録の pairing で device_id も送る (Refs ippoan/auth-worker#544)

### DIFF
--- a/web/server/utils/device-pairing.ts
+++ b/web/server/utils/device-pairing.ts
@@ -35,6 +35,7 @@ export interface PairInternalForward {
 export function buildPairInternalForward(input: {
   sharedSecret: string
   tenantId: string
+  deviceId: string
   label: string
   role?: string
 }): PairInternalForward {
@@ -47,7 +48,10 @@ export function buildPairInternalForward(input: {
         'X-Internal-Shared-Secret': input.sharedSecret,
       },
       body: JSON.stringify({
+        // tenant_id は auth-worker 側の切り替え (Refs ippoan/auth-worker#544) が配信されるまで
+        // 引き続き必要。device_id を渡すのはそちら側が device_id から tenant を引く新経路のため。
         tenant_id: input.tenantId,
+        device_id: input.deviceId,
         label: input.label,
         role: input.role ?? DEVICE_ROLE_UPLOADER,
       }),
@@ -82,23 +86,27 @@ async function resolveSecret(binding: unknown): Promise<string | null> {
 }
 
 /**
- * rust レスポンス (claim or status) に tenant_id があれば device credential を mint し、
- * レスポンスへ { auth_device_id, device_secret } を merge して返す共通処理 (pure 相当、
- * fetch は注入された authWorker 経由)。mint 失敗時は元レスポンスをそのまま返す
- * (provisioning 失敗で claim/status 自体を壊さない、非破壊 fallback)。
+ * rust レスポンス (claim or status) に tenant_id と device_id の両方があれば device credential
+ * を mint し、レスポンスへ { auth_device_id, device_secret } を merge して返す共通処理 (pure
+ * 相当、fetch は注入された authWorker 経由)。どちらか片方でも欠けていれば mint しない
+ * (device_id は device_id から tenant を引く auth-worker 側の新経路 Refs
+ * ippoan/auth-worker#544 に必須)。mint 失敗時は元レスポンスをそのまま返す (provisioning
+ * 失敗で claim/status 自体を壊さない、非破壊 fallback)。
  */
-async function mintAndMergeCredential(
+export async function mintAndMergeCredential(
   sharedSecret: string,
   authWorker: { fetch: typeof fetch },
   res: ClaimResponse,
 ): Promise<ClaimResponse> {
   const tenantId = res.tenant_id
-  if (!tenantId) return res
+  const deviceId = res.device_id
+  if (!tenantId || !deviceId) return res
   try {
     const pair = buildPairInternalForward({
       sharedSecret,
       tenantId,
-      label: (res.device_id as string | undefined) || 'alc-device',
+      deviceId,
+      label: deviceId,
     })
     const pairRes = await authWorker.fetch(pair.url, pair.init)
     if (pairRes.ok) {

--- a/web/tests/server/device-proxy.test.ts
+++ b/web/tests/server/device-proxy.test.ts
@@ -1,6 +1,6 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { buildAlcProxyForward } from '../../server/utils/device-proxy'
-import { buildPairInternalForward } from '../../server/utils/device-pairing'
+import { buildPairInternalForward, mintAndMergeCredential } from '../../server/utils/device-pairing'
 
 const SECRET = 'test-internal-shared-secret-32!!'
 
@@ -38,10 +38,11 @@ describe('buildAlcProxyForward (rust-alc-api#434 caller #5, device/admin JWT 経
 })
 
 describe('buildPairInternalForward (rust-alc-api#434 caller #5, claim provisioning)', () => {
-  it('/device/pair-internal に X-Internal-Shared-Secret + tenant_id を載せ、role 既定は device-uploader', () => {
+  it('/device/pair-internal に X-Internal-Shared-Secret + tenant_id + device_id を載せ、role 既定は device-uploader', () => {
     const { url, init } = buildPairInternalForward({
       sharedSecret: SECRET,
       tenantId: 'tenant-9',
+      deviceId: 'dev-1',
       label: 'alc-tablet',
     })
     expect(url).toBe('https://auth-internal.internal/device/pair-internal')
@@ -50,6 +51,7 @@ describe('buildPairInternalForward (rust-alc-api#434 caller #5, claim provisioni
     expect(init.method).toBe('POST')
     const body = JSON.parse(init.body as string) as Record<string, unknown>
     expect(body.tenant_id).toBe('tenant-9')
+    expect(body.device_id).toBe('dev-1')
     expect(body.label).toBe('alc-tablet')
     expect(body.role).toBe('device-uploader')
   })
@@ -58,10 +60,58 @@ describe('buildPairInternalForward (rust-alc-api#434 caller #5, claim provisioni
     const { init } = buildPairInternalForward({
       sharedSecret: SECRET,
       tenantId: 't',
+      deviceId: 'd',
       label: 'l',
       role: 'device-kiosk',
     })
     const body = JSON.parse(init.body as string) as Record<string, unknown>
     expect(body.role).toBe('device-kiosk')
+  })
+})
+
+describe('mintAndMergeCredential (ippoan/auth-worker#544 PR 2/3、tenant_id + device_id が揃った時だけ mint)', () => {
+  it('tenant_id と device_id が両方あれば mint し、device_id を body に載せて credential を merge する', async () => {
+    const fetchMock = vi.fn(async (_url: string, init: RequestInit) => {
+      const body = JSON.parse(init.body as string) as Record<string, unknown>
+      expect(body.tenant_id).toBe('tenant-9')
+      expect(body.device_id).toBe('dev-1')
+      expect(body.label).toBe('dev-1')
+      return new Response(JSON.stringify({ device_id: 'auth-dev-1', device_secret: 'sekrit' }), { status: 200 })
+    })
+    const res = await mintAndMergeCredential(SECRET, { fetch: fetchMock as unknown as typeof fetch }, {
+      success: true,
+      tenant_id: 'tenant-9',
+      device_id: 'dev-1',
+    })
+    expect(fetchMock).toHaveBeenCalledOnce()
+    expect(res).toEqual({
+      success: true,
+      tenant_id: 'tenant-9',
+      device_id: 'dev-1',
+      auth_device_id: 'auth-dev-1',
+      device_secret: 'sekrit',
+    })
+  })
+
+  it('device_id が無い応答では mint しない (fetch を呼ばずそのまま返す)', async () => {
+    const fetchMock = vi.fn()
+    const res = await mintAndMergeCredential(SECRET, { fetch: fetchMock as unknown as typeof fetch }, {
+      success: true,
+      tenant_id: 'tenant-9',
+      device_id: null,
+    })
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(res).toEqual({ success: true, tenant_id: 'tenant-9', device_id: null })
+  })
+
+  it('tenant_id が無い応答では mint しない (fetch を呼ばずそのまま返す、既存)', async () => {
+    const fetchMock = vi.fn()
+    const res = await mintAndMergeCredential(SECRET, { fetch: fetchMock as unknown as typeof fetch }, {
+      success: true,
+      tenant_id: null,
+      device_id: 'dev-1',
+    })
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(res).toEqual({ success: true, tenant_id: null, device_id: 'dev-1' })
   })
 })


### PR DESCRIPTION
## 何を変えるか

端末登録の pairing (`/device/pair-internal` への server-to-server 呼び出し) で、`tenant_id` に加えて `device_id` も送る。ippoan/auth-worker#544 の 2/3 で、auth-worker が tenant を登録済み端末の記録から決める形 (3/3) に移るための準備。

- `web/server/utils/device-pairing.ts`: `buildPairInternalForward` の body に `device_id` を追加 (`tenant_id` は auth-worker 側の切り替えが配信されるまで残す)。`mintAndMergeCredential` は `tenant_id` と `device_id` の両方があるときだけ mint する
- claim / status の両経路が同じ関数を通る
- 今の auth-worker は知らない field を無視するので、この PR 単体で挙動は変わらない

## 確認

- `npx vitest run tests/server/device-proxy.test.ts` 7 passed
- `npx nuxi typecheck` — 出るのは origin/main でも出る fc1200-wasm の module not found だけ

Refs ippoan/auth-worker#544
Refs ippoan/alc-app-s3#135

🤖 Generated with [Claude Code](https://claude.com/claude-code)
