### PR TITLE
fix(proxy): キオスクの device JWT を /device-data-proxy へ振り分ける (Refs #227)

### DIFF
--- a/web/server/api/proxy/[...path].ts
+++ b/web/server/api/proxy/[...path].ts
@@ -9,13 +9,16 @@
  * X-Alc-Proxy-Secret を constant-time 検証してから JWT 検証 + ACL + OIDC mint +
  * X-Tenant-ID/X-User-* 注入を行う。
  *
- * - browser JWT は cookie (logi_auth_token) / Bearer のどちらでも受ける。キオスク端末は
- *   device JWT を Bearer で送る (方式 B でも Authorization は素通しされ維持される)。
+ * - browser JWT は cookie (logi_auth_token) / Bearer のどちらでも受ける。
+ * - キオスク端末は device JWT を Bearer で送る。`/alc-proxy` は device JWT を受けない
+ *   ので、handler が送るのが device JWT のときだけ auth-worker `/device-data-proxy/*`
+ *   へ流す (Refs #227、判定は server/utils/proxy-target.ts)。
  * - AUTH_WORKER service binding は方式 B では必須 (未設定は 503)。
  * - INTERNAL_SHARED_SECRET は Secrets Store binding (.get()) のため route 側で resolve。
  */
 import type { H3Event } from 'h3'
 import { createAuthWorkerProxyHandler } from '@ippoan/auth-client/server'
+import { AUTH_COOKIE_NAME, selectProxyPrefix } from '../../utils/proxy-target'
 
 function cfEnv(event: H3Event): Record<string, unknown> {
   return (event.context.cloudflare as { env?: Record<string, unknown> } | undefined)?.env ?? {}
@@ -47,9 +50,14 @@ export default defineEventHandler(async (event) => {
     })
   }
 
+  const proxyPrefix = selectProxyPrefix({
+    cookieToken: getCookie(event, AUTH_COOKIE_NAME),
+    bearerToken: /^Bearer\s+(.+)$/i.exec(getHeader(event, 'authorization') ?? '')?.[1],
+  })
   const proxy = createAuthWorkerProxyHandler({
     sharedSecret,
     authWorkerFetch: () => authWorker.fetch.bind(authWorker),
+    proxyPrefix,
   })
   return proxy(event)
 })

--- a/web/server/utils/proxy-target.ts
+++ b/web/server/utils/proxy-target.ts
@@ -1,0 +1,30 @@
+/**
+ * `/api/proxy/*` の転送先 (auth-worker の route prefix) を決める (Refs #227)。
+ *
+ * auth-worker `/alc-proxy` は browser JWT 専用で device JWT を 401 にする。キオスクは
+ * admin ログイン無しで device JWT を Bearer に載せて来るので、その場合だけ
+ * `/device-data-proxy` (device JWT 用の経路) へ流す。
+ *
+ * **判定は auth-client の handler が実際に送る token で行う。** handler
+ * (`createAuthWorkerProxyHandler` の resolveAuthToken) は cookie `logi_auth_token` を
+ * Bearer より優先して送るので、cookie があれば Bearer が device JWT でも送られるのは
+ * cookie 側 = `/alc-proxy`。
+ *
+ * **署名は検証しない** — ここは振り分けだけで、認証は転送先の auth-worker が全部やる。
+ * 読めない token は `/alc-proxy` に倒す (従来どおりの経路)。
+ */
+import { decodeJwtPayloadFromToken } from '@ippoan/auth-client/server'
+
+export type ProxyPrefix = '/alc-proxy' | '/device-data-proxy'
+
+/** auth-client の proxy handler が既定で読む cookie 名 (alc-app は cookieName を渡さない)。 */
+export const AUTH_COOKIE_NAME = 'logi_auth_token'
+
+export function selectProxyPrefix(input: {
+  cookieToken?: string | null
+  bearerToken?: string | null
+}): ProxyPrefix {
+  if (input.cookieToken || !input.bearerToken) return '/alc-proxy'
+  const payload = decodeJwtPayloadFromToken(input.bearerToken) as { aud?: unknown } | null
+  return payload?.aud === 'device' ? '/device-data-proxy' : '/alc-proxy'
+}

--- a/web/tests/server/proxy-target.test.ts
+++ b/web/tests/server/proxy-target.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import { selectProxyPrefix } from '../../server/utils/proxy-target'
+
+/** 署名はダミー (振り分けは署名を見ない)。 */
+function jwt(payload: Record<string, unknown>): string {
+  const seg = (v: unknown) => Buffer.from(JSON.stringify(v)).toString('base64url')
+  return `${seg({ alg: 'HS256', typ: 'JWT' })}.${seg(payload)}.sig`
+}
+
+const DEVICE_JWT = jwt({ sub: 'd1', tenant_id: 't1', role: 'device', aud: 'device' })
+const BROWSER_JWT = jwt({ sub: 'u1', tenant_id: 't1', email: 'a@example.com', role: 'admin' })
+
+describe('selectProxyPrefix (Refs #227、キオスクの device JWT 振り分け)', () => {
+  it('device JWT の Bearer だけ → /device-data-proxy', () => {
+    expect(selectProxyPrefix({ bearerToken: DEVICE_JWT })).toBe('/device-data-proxy')
+  })
+
+  it('cookie があれば Bearer が device JWT でも /alc-proxy (auth-client は cookie を優先して送る)', () => {
+    expect(selectProxyPrefix({ cookieToken: BROWSER_JWT, bearerToken: DEVICE_JWT })).toBe('/alc-proxy')
+  })
+
+  it('browser JWT (aud 無し) の Bearer → /alc-proxy', () => {
+    expect(selectProxyPrefix({ bearerToken: BROWSER_JWT })).toBe('/alc-proxy')
+  })
+
+  it('aud が device 以外 → /alc-proxy', () => {
+    expect(selectProxyPrefix({ bearerToken: jwt({ aud: 'hub' }) })).toBe('/alc-proxy')
+  })
+
+  it('壊れた token → /alc-proxy', () => {
+    expect(selectProxyPrefix({ bearerToken: 'not-a-jwt' })).toBe('/alc-proxy')
+    expect(selectProxyPrefix({ bearerToken: 'a.!!!.c' })).toBe('/alc-proxy')
+    expect(selectProxyPrefix({ bearerToken: `a.${Buffer.from('[1').toString('base64url')}.c` })).toBe('/alc-proxy')
+  })
+
+  it('token 無し → /alc-proxy', () => {
+    expect(selectProxyPrefix({})).toBe('/alc-proxy')
+    expect(selectProxyPrefix({ cookieToken: null, bearerToken: null })).toBe('/alc-proxy')
+    expect(selectProxyPrefix({ cookieToken: '', bearerToken: '' })).toBe('/alc-proxy')
+  })
+})


### PR DESCRIPTION
## 何を変えるか

管理者ログインなしのキオスク (device JWT) の読み書きを、`/api/proxy/...` から auth-worker の `/device-data-proxy` へ振り分ける。#227 の 2/2 で、auth-worker 側の許可表 (1/2) と組で動く。

- `web/server/utils/proxy-target.ts` (新規): `selectProxyPrefix({ cookieToken, bearerToken })`。auth-client の handler が実際に送る token で判定する — handler が使う cookie (`logi_auth_token`) があれば `/alc-proxy`、cookie が無く Bearer の payload が `aud === "device"` のときだけ `/device-data-proxy`、それ以外 (browser JWT・読めない token・無し) は `/alc-proxy`。payload の読み取りは auth-client の `decodeJwtPayloadFromToken` を使う
- `web/server/api/proxy/[...path].ts`: 決めた prefix を `createAuthWorkerProxyHandler` の `proxyPrefix` に渡す。ほかの引数は不変
- 振り分けだけで、token の検証はどちらの口でも auth-worker が行う
- `web/app/utils/api.ts` は変えない (キオスクは既に Bearer 付きで `/api/proxy/...` を叩いている)

auth-client 0.2.153 の実物で、`proxyPrefix` が転送先の URL に入ること、JSON 以外の body がそのまま転送されること (blob のアップロードが壊れない)、query が転送されることを確かめた。

## 確認

- vitest: `tests/server/proxy-target.test.ts` (6 ケース) を含め 61 files / 1506 passed / 2 skipped
- `npx nuxi typecheck`: エラー 0 (gitignore 済みの fc1200-wasm/pkg に stub を置いて。CI と同じ)

## マージ順

auth-worker 側の許可表より先にマージされても、キオスクの応答が 401 から 403 に変わるだけで後退はない。

Refs #227
Refs ippoan/alc-app-s3#135

🤖 Generated with [Claude Code](https://claude.com/claude-code)
