### PR TITLE
fix(device-pairing): pair-internal へ送る本文から tenant_id を外す (Refs ippoan/auth-worker#544)

### DIFF
--- a/web/server/utils/device-pairing.ts
+++ b/web/server/utils/device-pairing.ts
@@ -30,11 +30,11 @@ export interface PairInternalForward {
 
 /**
  * auth-worker `/device/pair-internal` への server-to-server forward request を構築する
- * (pure、テスト対象)。X-Internal-Shared-Secret で認証し tenant_id を明示渡しする。
+ * (pure、テスト対象)。X-Internal-Shared-Secret で認証し device_id を渡す (tenant は
+ * auth-worker 側が device_id から決める)。
  */
 export function buildPairInternalForward(input: {
   sharedSecret: string
-  tenantId: string
   deviceId: string
   label: string
   role?: string
@@ -48,9 +48,6 @@ export function buildPairInternalForward(input: {
         'X-Internal-Shared-Secret': input.sharedSecret,
       },
       body: JSON.stringify({
-        // tenant_id は auth-worker 側の切り替え (Refs ippoan/auth-worker#544) が配信されるまで
-        // 引き続き必要。device_id を渡すのはそちら側が device_id から tenant を引く新経路のため。
-        tenant_id: input.tenantId,
         device_id: input.deviceId,
         label: input.label,
         role: input.role ?? DEVICE_ROLE_UPLOADER,
@@ -86,25 +83,22 @@ async function resolveSecret(binding: unknown): Promise<string | null> {
 }
 
 /**
- * rust レスポンス (claim or status) に tenant_id と device_id の両方があれば device credential
- * を mint し、レスポンスへ { auth_device_id, device_secret } を merge して返す共通処理 (pure
- * 相当、fetch は注入された authWorker 経由)。どちらか片方でも欠けていれば mint しない
- * (device_id は device_id から tenant を引く auth-worker 側の新経路 Refs
- * ippoan/auth-worker#544 に必須)。mint 失敗時は元レスポンスをそのまま返す (provisioning
- * 失敗で claim/status 自体を壊さない、非破壊 fallback)。
+ * rust レスポンス (claim or status) に device_id があれば device credential を mint し、
+ * レスポンスへ { auth_device_id, device_secret } を merge して返す共通処理 (pure 相当、fetch は
+ * 注入された authWorker 経由)。device_id が欠けていれば mint しない (auth-worker は device_id
+ * から tenant を決める Refs ippoan/auth-worker#544)。mint 失敗時は元レスポンスをそのまま返す
+ * (provisioning 失敗で claim/status 自体を壊さない、非破壊 fallback)。
  */
 export async function mintAndMergeCredential(
   sharedSecret: string,
   authWorker: { fetch: typeof fetch },
   res: ClaimResponse,
 ): Promise<ClaimResponse> {
-  const tenantId = res.tenant_id
   const deviceId = res.device_id
-  if (!tenantId || !deviceId) return res
+  if (!deviceId) return res
   try {
     const pair = buildPairInternalForward({
       sharedSecret,
-      tenantId,
       deviceId,
       label: deviceId,
     })

--- a/web/tests/server/device-proxy.test.ts
+++ b/web/tests/server/device-proxy.test.ts
@@ -38,10 +38,9 @@ describe('buildAlcProxyForward (rust-alc-api#434 caller #5, device/admin JWT 経
 })
 
 describe('buildPairInternalForward (rust-alc-api#434 caller #5, claim provisioning)', () => {
-  it('/device/pair-internal に X-Internal-Shared-Secret + tenant_id + device_id を載せ、role 既定は device-uploader', () => {
+  it('/device/pair-internal に X-Internal-Shared-Secret + device_id を載せ (tenant_id は送らない)、role 既定は device-uploader', () => {
     const { url, init } = buildPairInternalForward({
       sharedSecret: SECRET,
-      tenantId: 'tenant-9',
       deviceId: 'dev-1',
       label: 'alc-tablet',
     })
@@ -50,7 +49,7 @@ describe('buildPairInternalForward (rust-alc-api#434 caller #5, claim provisioni
     expect(h['X-Internal-Shared-Secret']).toBe(SECRET)
     expect(init.method).toBe('POST')
     const body = JSON.parse(init.body as string) as Record<string, unknown>
-    expect(body.tenant_id).toBe('tenant-9')
+    expect(body).not.toHaveProperty('tenant_id')
     expect(body.device_id).toBe('dev-1')
     expect(body.label).toBe('alc-tablet')
     expect(body.role).toBe('device-uploader')
@@ -59,7 +58,6 @@ describe('buildPairInternalForward (rust-alc-api#434 caller #5, claim provisioni
   it('role を明示できる', () => {
     const { init } = buildPairInternalForward({
       sharedSecret: SECRET,
-      tenantId: 't',
       deviceId: 'd',
       label: 'l',
       role: 'device-kiosk',
@@ -69,11 +67,11 @@ describe('buildPairInternalForward (rust-alc-api#434 caller #5, claim provisioni
   })
 })
 
-describe('mintAndMergeCredential (ippoan/auth-worker#544 PR 2/3、tenant_id + device_id が揃った時だけ mint)', () => {
-  it('tenant_id と device_id が両方あれば mint し、device_id を body に載せて credential を merge する', async () => {
+describe('mintAndMergeCredential (ippoan/auth-worker#544、device_id がある時だけ mint)', () => {
+  it('device_id があれば mint し、device_id だけを body に載せて credential を merge する', async () => {
     const fetchMock = vi.fn(async (_url: string, init: RequestInit) => {
       const body = JSON.parse(init.body as string) as Record<string, unknown>
-      expect(body.tenant_id).toBe('tenant-9')
+      expect(body).not.toHaveProperty('tenant_id')
       expect(body.device_id).toBe('dev-1')
       expect(body.label).toBe('dev-1')
       return new Response(JSON.stringify({ device_id: 'auth-dev-1', device_secret: 'sekrit' }), { status: 200 })
@@ -104,14 +102,13 @@ describe('mintAndMergeCredential (ippoan/auth-worker#544 PR 2/3、tenant_id + de
     expect(res).toEqual({ success: true, tenant_id: 'tenant-9', device_id: null })
   })
 
-  it('tenant_id が無い応答では mint しない (fetch を呼ばずそのまま返す、既存)', async () => {
+  it('device_id が undefined の応答でも mint しない (tenant_id の有無に依らない)', async () => {
     const fetchMock = vi.fn()
     const res = await mintAndMergeCredential(SECRET, { fetch: fetchMock as unknown as typeof fetch }, {
       success: true,
       tenant_id: null,
-      device_id: 'dev-1',
     })
     expect(fetchMock).not.toHaveBeenCalled()
-    expect(res).toEqual({ success: true, tenant_id: null, device_id: 'dev-1' })
+    expect(res).toEqual({ success: true, tenant_id: null })
   })
 })


### PR DESCRIPTION
## 何を変えるか

端末登録 (claim / QR 永久登録の承認ポーリング) で device credential を mint するとき、auth-worker の `POST /device/pair-internal` に送る本文から `tenant_id` を外す。

- `web/server/utils/device-pairing.ts`
  - `buildPairInternalForward`: 入力と本文から `tenantId` / `tenant_id` を削除
  - `mintAndMergeCredential`: mint する条件を「device_id がある」だけに
  - claim と承認ポーリングの handler 側の条件 (承認済みで tenant が決まっているときだけ mint) は変えていない
- `web/tests/server/device-proxy.test.ts`: 本文に `tenant_id` が無いことを確かめる / device_id が無ければ mint しないことを確かめる

## なぜ

auth-worker は ippoan/auth-worker#547 (本番反映済み) 以降、tenant を本文の `device_id` から決めるようになり、本文の `tenant_id` は使わなくなった。送る必要が無くなったので外す。

rust-alc-api 側の同じ後片付けは別 PR。どちらが先にマージされても動作は変わらない。

Refs ippoan/auth-worker#544

🤖 Generated with [Claude Code](https://claude.com/claude-code)
