### PR TITLE
feat(alarm): 警告デバイスへの接続を全タブ共通で始める (Refs #231)

### DIFF
--- a/web/app/components/ManagerAlarmBar.vue
+++ b/web/app/components/ManagerAlarmBar.vue
@@ -1,54 +1,25 @@
 <script setup lang="ts">
 /**
- * 据置警告デバイス (Atom VoiceS3R / USB) の heartbeat と着信購読。
+ * 据置警告デバイス (Atom VoiceS3R / USB) の状態表示と「接続」ボタン。
  *
- * 運行管理者の PC は普段、トップ画面「運行管理者」タブの認証ゲートのまま置かれる。
- * 見張る対象は「その PWA がブラウザで開いているか」であって認証の有無ではないので、
- * このバーは認証ゲートの外 (タブに入った時点) に置く。
+ * 見張り (着信購読 + heartbeat) を始める・止めるのはこのバーではなく useAlarmWatch
+ * (トップ画面 pages/index.vue が全タブ共通で 1 回だけ呼ぶ)。運行管理者の PC は運行者などの
+ * タブをログイン無しで使うので、運行管理者タブにだけ出るこのバーの mount を起点にすると、
+ * 警告デバイスが繋がらないままになる (Refs #231)。
  *
  * 止める (= デバイスが鳴る) のは次の 3 つだけ:
  *   PWA を閉じる / reload (app.vue の pagehide → grace=45) / デバイス設定を off にする
- * **SPA 内のロールタブ切替 (このバーの unmount) では切らない** — 運行管理者から
- * システム管理者へ移っただけで鳴るのは誤報だった (#205)。useAlarmDevice / useActiveRooms は
- * singleton なので、mount 中に始めた heartbeat と着信購読は unmount 後もそのまま続く。
- * どのロールタブに居ても着信 (`call=1`) は鳴る — これは望ましい副作用 (#135)
+ * ロールタブ切替 (このバーの unmount) では切らない (#205)。どのロールタブに居ても
+ * 着信 (`call=1`) は鳴る — これは望ましい副作用 (#135)
  */
 const alarm = useAlarmDevice()
-// Web Serial の無いブラウザでは購読も heartbeat も立てない
+// Web Serial の無いブラウザではバーを出さない
 const isSupported = alarm.isSupported
 // この端末で警告デバイスを使うか (端末登録 / デバイス設定で選ぶ)。false の端末では
-// バーもポート探索も出さない。null は未設定 (既存の端末) なので問いかけカードを出す
+// バーを出さない。null は未設定 (既存の端末) なので問いかけカードを出す
+// ([つなぐ] で true になった瞬間に useAlarmWatch が見張りを始める)
 const { enabled, setEnabled } = useAlarmDeviceSetting()
-const { isWatching, activeRooms, joinedRoomId, start, stop } = useActiveRooms()
-
-if (isSupported && enabled.value !== false) {
-  // この instance が「使う」状態か。unmount では下ろさない (singleton は動いたまま)
-  let started = false
-  const startWatching = () => {
-    started = true
-    // 別のロールタブから戻ってきた再 mount では singleton が既に動いている。start() は
-    // 参照カウント (対になる stop が無いと下がらない)、connect() も no-op ではない
-    // (installNgWatch / arbiter.register / 再接続の印の削除) ので、二重に呼ばない
-    if (!isWatching.value) start()
-    // BLE ゲートウェイと同居しない PC なので、ポートの取り合いを待つ必要が無い
-    if (!alarm.isConnected.value) alarm.connect(0)
-  }
-  onMounted(() => {
-    // 探索は「使う」と決まってから。未設定のあいだは問いかけカードだけを出す
-    if (enabled.value === true) startWatching()
-  })
-  watch(enabled, (v) => {
-    // 問いかけカードで [つなぐ] を選んだ瞬間に探索を始める
-    if (v === true && !started) startWatching()
-    // 設定を off にしたときだけ切る (unmount では切らない = ロールタブ切替で鳴らさない)
-    if (v === false && started) {
-      started = false
-      void alarm.disconnect()
-      // 参照カウントなので、遠隔点呼タブの子が先に stop していても WebSocket は残る
-      stop()
-    }
-  })
-}
+const { isWatching, activeRooms, joinedRoomId } = useActiveRooms()
 
 const alarmCauseLabels: Record<string, string> = {
   silence: '無音',

--- a/web/app/composables/useAlarmWatch.ts
+++ b/web/app/composables/useAlarmWatch.ts
@@ -1,0 +1,56 @@
+/**
+ * 据置警告デバイス (Atom VoiceS3R / USB) の見張りを、ロールタブに関わらずアプリで 1 本だけ動かす。
+ *
+ * 見張り = 着信購読 (useActiveRooms.start) と警告デバイスへの接続 (useAlarmDevice.connect)。
+ * **この 2 つは必ず対で動かす** — 購読せずに接続すると heartbeat が `HB NG signaling` になり
+ * デバイスが鳴る (useAlarmDevice 冒頭の規約)。止めるときも対で止める。
+ *
+ * 呼び口はトップ画面 (pages/index.vue) の 1 か所。運行管理者の PC は運行者などのタブを
+ * ログイン無しで使うので、運行管理者タブ (ManagerAlarmBar) に入るまで繋がないと、
+ * 警告デバイスが未接続のままになる (Refs #231)。ManagerAlarmBar は表示と「接続」ボタンだけ。
+ *
+ * 動かすのは「この端末で使う」(useAlarmDeviceSetting が true) かつ Web Serial が使えるときだけ。
+ * 止めるのは設定を off にしたときだけ — ロールタブ切替やトップ画面の unmount では止めない (#205)。
+ */
+
+/**
+ * 見張りを始めたか (アプリ全体で 1 つ)。トップ画面の再 mount で二重に始めないため
+ * module スコープで持つ — start() は参照カウント (対になる stop が無いと下がらない)、
+ * connect() も no-op ではない (installNgWatch / arbiter.register / 再接続の印の削除)
+ */
+let started = false
+
+export function useAlarmWatch(): void {
+  const alarm = useAlarmDevice()
+  // Web Serial の無いブラウザでは購読も heartbeat も立てない
+  if (!alarm.isSupported) return
+  const rooms = useActiveRooms()
+  const { enabled } = useAlarmDeviceSetting()
+
+  function start(): void {
+    if (started) return
+    started = true
+    rooms.start()
+    // BLE ゲートウェイと同居しない PC なので、ポートの取り合いを待つ必要が無い
+    alarm.connect(0)
+  }
+
+  function stop(): void {
+    if (!started) return
+    started = false
+    void alarm.disconnect()
+    // 参照カウントなので、遠隔点呼タブの子が先に stop していても WebSocket は残る
+    rooms.stop()
+  }
+
+  // 探索は「使う」と決まってから。未設定のあいだは ManagerAlarmBar の問いかけカードだけを出す
+  onMounted(() => {
+    if (enabled.value === true) start()
+  })
+  watch(enabled, (v) => {
+    // 問いかけカードで [つなぐ] を選んだ瞬間に始める
+    if (v === true) start()
+    // 設定を off にしたときだけ止める (unmount では止めない = ロールタブ切替で鳴らさない)
+    else if (v === false) stop()
+  })
+}

--- a/web/app/pages/index.vue
+++ b/web/app/pages/index.vue
@@ -33,6 +33,10 @@ initApi(
 // 顔データ同期 (singleton)
 useFaceSync()
 
+// 警告デバイスの見張り (着信購読 + heartbeat)。ロールタブに関わらず始める —
+// 運行者タブで使う運行管理者 PC でも繋がるように (Refs #231)。ManagerAlarmBar は表示だけ
+useAlarmWatch()
+
 // Android 横画面検出
 const { isAndroidLandscape } = useAndroidLandscape()
 

--- a/web/coverage_100.toml
+++ b/web/coverage_100.toml
@@ -15,6 +15,10 @@ path = "app/composables/useAlarmDeviceSetting.ts"
 branches = true
 
 [[files]]
+path = "app/composables/useAlarmWatch.ts"
+branches = true
+
+[[files]]
 path = "app/composables/useAndroidLandscape.ts"
 branches = true
 

--- a/web/tests/components/ManagerAlarmBar.test.ts
+++ b/web/tests/components/ManagerAlarmBar.test.ts
@@ -68,49 +68,20 @@ describe('ManagerAlarmBar', () => {
     settingState.enabled.value = true
   })
 
-  it('mount で購読 → heartbeat の順に始め、unmount では止めない (ロールタブ切替で鳴らさない)', async () => {
-    // まだ購読していない状態から mount する
+  it('購読も接続も始めず止めもしない (見張りはトップ画面の useAlarmWatch の役目 = 二重に起動しない)', async () => {
+    // まだ購読していない・未接続の状態から mount しても、バーは表示だけ
     roomsState.isWatching.value = false
     const wrapper = await mountSuspended(ManagerAlarmBar)
-    expect(calls).toEqual(['start', 'connect(0)'])
+    expect(wrapper.find('[data-testid="manager-alarm-bar"]').exists()).toBe(true)
+    expect(calls).toEqual([])
 
-    // 運行管理者タブを離れても singleton は動いたまま — disconnect / stop は入らない (#205)
-    wrapper.unmount()
-    expect(calls).toEqual(['start', 'connect(0)'])
-  })
-
-  it('ロールタブを往復して再 mount しても購読も探索も二重に始めず、設定 off では切れる', async () => {
-    roomsState.isWatching.value = false
-    const wrapper = await mountSuspended(ManagerAlarmBar)
-    expect(calls).toEqual(['start', 'connect(0)'])
-    wrapper.unmount()
-
-    // singleton は動き続けている (購読中・デバイス接続済み) ので、戻ってきても呼び直さない
-    roomsState.isWatching.value = true
-    alarmState.isConnected.value = true
-    const again = await mountSuspended(ManagerAlarmBar)
-    expect(calls).toEqual(['start', 'connect(0)'])
-
-    // 呼び直していない再 mount 側でも、設定 off なら切れる
-    settingState.enabled.value = false
-    await again.vm.$nextTick()
-    expect(calls).toEqual(['start', 'connect(0)', 'disconnect', 'stop'])
-
-    again.unmount()
-    expect(calls).toEqual(['start', 'connect(0)', 'disconnect', 'stop'])
-  })
-
-  it('デバイス設定を off にしたときだけ切る (切った後の unmount では二重に切らない)', async () => {
-    roomsState.isWatching.value = false
-    const wrapper = await mountSuspended(ManagerAlarmBar)
-    expect(calls).toEqual(['start', 'connect(0)'])
-
+    // 設定 off に変わっても、切るのはバーではない
     settingState.enabled.value = false
     await wrapper.vm.$nextTick()
-    expect(calls).toEqual(['start', 'connect(0)', 'disconnect', 'stop'])
+    expect(calls).toEqual([])
 
     wrapper.unmount()
-    expect(calls).toEqual(['start', 'connect(0)', 'disconnect', 'stop'])
+    expect(calls).toEqual([])
   })
 
   it('Web Serial が無いブラウザでは何も描画せず、購読も heartbeat も立てない', async () => {
@@ -136,7 +107,7 @@ describe('ManagerAlarmBar', () => {
     expect(calls).toEqual([])
   })
 
-  it('未設定 (既存の端末) なら問いかけカードだけを出し、[つなぐ] で保存してから探索を始める', async () => {
+  it('未設定 (既存の端末) なら問いかけカードだけを出し、[つなぐ] で保存してバーに切り替わる', async () => {
     settingState.enabled.value = null
     roomsState.isWatching.value = false
     const wrapper = await mountSuspended(ManagerAlarmBar)
@@ -152,11 +123,11 @@ describe('ManagerAlarmBar', () => {
     await wrapper.vm.$nextTick()
     expect(wrapper.find('[data-testid="manager-alarm-ask"]').exists()).toBe(false)
     expect(wrapper.find('[data-testid="manager-alarm-bar"]').exists()).toBe(true)
-    expect(calls).toEqual(['start', 'connect(0)'])
+    // 探索を始めるのはバーではなく、設定の変化を見ている useAlarmWatch (トップ画面)
+    expect(calls).toEqual([])
 
-    // 始めた後にロールタブを離れても止めない
     wrapper.unmount()
-    expect(calls).toEqual(['start', 'connect(0)'])
+    expect(calls).toEqual([])
   })
 
   it('未設定で [つながない] を選ぶと保存して非表示になり、unmount でも何も止めない', async () => {

--- a/web/tests/composables/useAlarmWatch.test.ts
+++ b/web/tests/composables/useAlarmWatch.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ref, readonly, nextTick } from 'vue'
+import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+import { withSetup } from '../helpers/with-setup'
+
+// --- composable のモック (呼び順を 1 本の配列に記録して「対で動く」ことを検証する) ---
+
+const calls: string[] = []
+
+const alarmState = { isSupported: true }
+mockNuxtImport('useAlarmDevice', () => () => ({
+  isSupported: alarmState.isSupported,
+  connect: (delay: number) => { calls.push(`connect(${delay})`) },
+  disconnect: async () => { calls.push('disconnect') },
+}))
+
+mockNuxtImport('useActiveRooms', () => () => ({
+  start: () => { calls.push('start') },
+  stop: () => { calls.push('stop') },
+}))
+
+// この端末で警告デバイスを使うか (true / false / null = 未設定)
+const enabled = ref<boolean | null>(true)
+mockNuxtImport('useAlarmDeviceSetting', () => () => ({
+  enabled: readonly(enabled),
+  setEnabled: vi.fn(),
+}))
+
+// 「始めたか」は module スコープ (アプリ全体で 1 つ) なので、テストごとに読み直す
+let useAlarmWatch: typeof import('~/composables/useAlarmWatch').useAlarmWatch
+
+describe('useAlarmWatch', () => {
+  beforeEach(async () => {
+    calls.length = 0
+    alarmState.isSupported = true
+    enabled.value = true
+    vi.resetModules()
+    useAlarmWatch = (await import('~/composables/useAlarmWatch')).useAlarmWatch
+  })
+
+  it('設定 on なら mount で着信購読 → 接続の順に対で始め、unmount では止めない', () => {
+    const [, app] = withSetup(() => useAlarmWatch())
+    expect(calls).toEqual(['start', 'connect(0)'])
+
+    // トップ画面を離れても singleton は動いたまま (ロールタブ切替で鳴らさない #205)
+    app.unmount()
+    expect(calls).toEqual(['start', 'connect(0)'])
+  })
+
+  it('設定を off にしたときだけ切断 → 購読停止を対で行い、on に戻せば対で始め直す', async () => {
+    const [, app] = withSetup(() => useAlarmWatch())
+    expect(calls).toEqual(['start', 'connect(0)'])
+
+    enabled.value = false
+    await nextTick()
+    expect(calls).toEqual(['start', 'connect(0)', 'disconnect', 'stop'])
+
+    enabled.value = true
+    await nextTick()
+    expect(calls).toEqual(['start', 'connect(0)', 'disconnect', 'stop', 'start', 'connect(0)'])
+    app.unmount()
+  })
+
+  it('再 mount (2 つ目の呼び出し) では二重に始めず、off では 1 回だけ止める', async () => {
+    const [, first] = withSetup(() => useAlarmWatch())
+    first.unmount()
+    const [, second] = withSetup(() => useAlarmWatch())
+    const [, third] = withSetup(() => useAlarmWatch())
+    expect(calls).toEqual(['start', 'connect(0)'])
+
+    // 生きている 2 instance の watch が両方動いても、止めるのは 1 回
+    enabled.value = false
+    await nextTick()
+    expect(calls).toEqual(['start', 'connect(0)', 'disconnect', 'stop'])
+    second.unmount()
+    third.unmount()
+  })
+
+  it('設定 off の端末では何も始めない', () => {
+    enabled.value = false
+    const [, app] = withSetup(() => useAlarmWatch())
+    expect(calls).toEqual([])
+    app.unmount()
+  })
+
+  it('未設定のあいだは始めず、[つなぐ] で true になった瞬間に始める。[つながない] では何もしない', async () => {
+    enabled.value = null
+    const [, app] = withSetup(() => useAlarmWatch())
+    expect(calls).toEqual([])
+
+    // 始めていないので、off にしても切るものが無い
+    enabled.value = false
+    await nextTick()
+    expect(calls).toEqual([])
+
+    enabled.value = true
+    await nextTick()
+    expect(calls).toEqual(['start', 'connect(0)'])
+
+    // 未設定へ戻っても (localStorage を消した等) 止めない — 止めるのは off だけ
+    enabled.value = null
+    await nextTick()
+    expect(calls).toEqual(['start', 'connect(0)'])
+    app.unmount()
+  })
+
+  it('Web Serial が無いブラウザでは購読も接続も立てず、設定の変化も見ない', async () => {
+    alarmState.isSupported = false
+    const [, app] = withSetup(() => useAlarmWatch())
+    expect(calls).toEqual([])
+
+    enabled.value = false
+    await nextTick()
+    enabled.value = true
+    await nextTick()
+    expect(calls).toEqual([])
+    app.unmount()
+  })
+})

--- a/web/tests/pages/index.test.ts
+++ b/web/tests/pages/index.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { ref, readonly, nextTick } from 'vue'
+import type { VueWrapper } from '@vue/test-utils'
+import { mountSuspended, mockNuxtImport } from '@nuxt/test-utils/runtime'
+import IndexPage from '~/pages/index.vue'
+
+// トップ画面のうち「警告デバイスの見張りをロールタブに関わらず始める」部分だけを見る (Refs #231)。
+// useAlarmWatch は本物、その下の singleton (デバイス / 着信購読 / 設定) だけをモックして
+// 呼び順を 1 本の配列に記録する。子コンポーネントは ManagerAlarmBar 以外 stub
+
+const calls: string[] = []
+
+const alarmState = {
+  isConnected: ref(false),
+  deviceState: ref<{ state: 'idle' | 'alarming' | 'muted'; cause: string } | null>(null),
+}
+mockNuxtImport('useAlarmDevice', () => () => ({
+  isSupported: true,
+  isConnected: readonly(alarmState.isConnected),
+  deviceState: readonly(alarmState.deviceState),
+  connect: (delay: number) => { calls.push(`connect(${delay})`) },
+  disconnect: async () => { calls.push('disconnect') },
+  requestPort: async () => {},
+  notifyIntentionalReload: () => {},
+}))
+
+const roomsState = {
+  isWatching: ref(false),
+  activeRooms: ref<string[]>([]),
+  joinedRoomId: ref<string | null>(null),
+}
+mockNuxtImport('useActiveRooms', () => () => ({
+  isWatching: readonly(roomsState.isWatching),
+  activeRooms: readonly(roomsState.activeRooms),
+  joinedRoomId: readonly(roomsState.joinedRoomId),
+  start: () => { calls.push('start') },
+  stop: () => { calls.push('stop') },
+  setJoined: vi.fn(),
+  reload: vi.fn(async () => true),
+}))
+
+const enabled = ref<boolean | null>(true)
+mockNuxtImport('useAlarmDeviceSetting', () => () => ({
+  enabled: readonly(enabled),
+  setEnabled: (v: boolean) => { enabled.value = v },
+}))
+
+// 見張りと関係の無い全タブ共通の初期化は黙らせる
+mockNuxtImport('useFaceSync', () => () => ({}))
+mockNuxtImport('useAuth', () => () => ({
+  accessToken: ref(null),
+  isAuthenticated: ref(false),
+  deviceTenantId: ref(null),
+  refreshAccessToken: vi.fn(async () => false),
+  handleLineworksHash: vi.fn(),
+  activateFromRegistration: vi.fn(),
+}))
+
+function mountIndex(route: string) {
+  return mountSuspended(IndexPage, {
+    route,
+    shallow: true,
+    global: { stubs: { ManagerAlarmBar: false, ClientOnly: false } },
+  })
+}
+
+function roleButton(wrapper: VueWrapper, label: string) {
+  const button = wrapper.findAll('button').find(b => b.text() === label)
+  if (!button) throw new Error(`role tab not found: ${label}`)
+  return button
+}
+
+async function clickRole(wrapper: VueWrapper, label: string) {
+  await roleButton(wrapper, label).trigger('click')
+  await nextTick()
+}
+
+describe('pages/index — 警告デバイスの見張り', () => {
+  let wrapper: VueWrapper | null = null
+
+  beforeEach(() => {
+    calls.length = 0
+    enabled.value = true
+    alarmState.isConnected.value = false
+    alarmState.deviceState.value = null
+    roomsState.isWatching.value = false
+    roomsState.activeRooms.value = []
+    roomsState.joinedRoomId.value = null
+  })
+
+  afterEach(async () => {
+    // 「始めたか」は module スコープなので、次のテストへ持ち越さないよう設定 off で止めてから外す
+    enabled.value = false
+    await nextTick()
+    wrapper?.unmount()
+    wrapper = null
+  })
+
+  it('運行者タブ (?role=driver) で開いても、設定 on なら着信購読 → 接続の順に対で始まる', async () => {
+    wrapper = await mountIndex('/?role=driver')
+    expect(roleButton(wrapper, '運行者').classes()).toContain('bg-white')
+    // 運行管理者タブのバーは出ていない = バーの mount を待たずに始まっている
+    expect(wrapper.find('[data-testid="manager-alarm-bar"]').exists()).toBe(false)
+    expect(calls).toEqual(['start', 'connect(0)'])
+  })
+
+  it('ロールタブを切り替えても切れず、運行管理者タブのバーは二重に始めない。設定 off で対で止まる', async () => {
+    wrapper = await mountIndex('/?role=driver')
+    expect(calls).toEqual(['start', 'connect(0)'])
+
+    await clickRole(wrapper, '運行管理者')
+    expect(wrapper.find('[data-testid="manager-alarm-bar"]').exists()).toBe(true)
+    await clickRole(wrapper, 'システム管理者')
+    expect(wrapper.find('[data-testid="manager-alarm-bar"]').exists()).toBe(false)
+    await clickRole(wrapper, '運行者')
+    expect(calls).toEqual(['start', 'connect(0)'])
+
+    enabled.value = false
+    await nextTick()
+    expect(calls).toEqual(['start', 'connect(0)', 'disconnect', 'stop'])
+  })
+
+  it('設定 off の端末では運行者タブでも運行管理者タブでも何も始めない', async () => {
+    enabled.value = false
+    wrapper = await mountIndex('/?role=driver')
+    expect(calls).toEqual([])
+
+    await clickRole(wrapper, '運行管理者')
+    expect(calls).toEqual([])
+  })
+
+  it('トップ画面を離れて戻っても (再 mount) 止めず、二重に始めない', async () => {
+    const first = await mountIndex('/?role=driver')
+    first.unmount()
+    expect(calls).toEqual(['start', 'connect(0)'])
+
+    wrapper = await mountIndex('/?role=manager')
+    expect(calls).toEqual(['start', 'connect(0)'])
+  })
+})


### PR DESCRIPTION
## 何を変えるか

警告デバイス (VoiceS3R) への接続が、運行管理者タブの警告バー (`ManagerAlarmBar`) の中でしか始まっていなかった。そのため、運行者タブで開いた PC では警告デバイスが繋がらず、それを前提にする処理 (#231 の 2 本目: 警告デバイスの署名で端末 JWT を取る) が一度も走らない。接続の起点を、全タブ共通のトップ画面へ移す。

- 在室の購読 (`useActiveRooms().start()`) と接続 (`useAlarmDevice().connect(0)`) を対で動かす処理を、新しい composable `useAlarmWatch` に切り出し、`pages/index.vue` から 1 回だけ呼ぶ
- 動かすのは、警告デバイス設定が on で、WebSerial が使えるときだけ。止めるのは設定が off になったときだけで、`disconnect` → `stop` の対で止める。ロールタブの切り替えやトップ画面の unmount では止めない (#205)
- 起動済みかどうかを module スコープで持ち、再 mount や警告バーからの二重起動を防ぐ
- `ManagerAlarmBar` は表示・問いかけカード・「接続」ボタンだけにする

## 挙動の差

- 起動が、運行管理者タブに入った時点から、トップ画面の mount 時点に変わる
- 未接続のまま運行管理者タブへ戻ったときの即時の再スキャンは無くなる。10 秒周期の再スキャンと、USB を挿した瞬間のスキャンは残る

## テスト

- 運行者タブで開いても設定 on なら始まる / 設定 off なら始まらない / タブを切り替えても切れない / 警告バーと二重に始めない / 再 mount でも二重に始めない / 設定 off で対で止まる
- vitest 全体と `check_coverage_100`、`npx nuxi typecheck` が通る

Refs #231
Refs ippoan/alc-app-s3#135

🤖 Generated with [Claude Code](https://claude.com/claude-code)
