### PR TITLE
feat(kiosk): 警告デバイスが繋がっていれば、署名で短命の端末 JWT を取る (Refs #231)

### DIFF
--- a/web/app/composables/useDeviceLogin.ts
+++ b/web/app/composables/useDeviceLogin.ts
@@ -17,16 +17,11 @@
  *
  * useHubClaim.ts (#213 CoreS3 自動端末登録) と同じ構造 (module-level state + 1 関数)。
  *
- * ★ firmware の `ERR AUTH: no key` / `ERR AUTH: bad nonce` は、useSerialArbiter.request の
- * `errPrefix` (= 送った行そのものを echo し返した行だけを reject 対象にする、
- * `AUTH TICKET` の `ERR AUTH TICKET: <理由>` 用の仕組み) には一致しない可能性がある
- * (送った行は `AUTH SIGN <nonce>` だが ERR 行は `ERR AUTH: ...` で nonce を echo しない
- * ため)。firmware が実際に nonce を echo するかはここでは分からないので、
- * useAlarmDevice.request の reject 理由をメッセージの内容 (`no key` を含むか) で判定する
- * ことで、echo の有無どちらでも `no key` だけは拾えるようにしてある。echo が無い場合、
- * 実機では `no key` も `bad nonce` も 10 秒のタイムアウト経由でしか reject されず
- * (useSerialArbiter は matchPrefix/errPrefix どちらにも当てはまらない行を黙って捨てる)、
- * その場合は `deviceLoginTimeoutMessage` に落ちる。この点は親へ [質問] 済み。
+ * `AUTH SIGN <nonce>` を送って `AUTH SIG <pubkey> <sig>` を parse する部分は
+ * `signAlarmDeviceNonce` に切り出してある (useDeviceToken.ts の短命端末 JWT #231 と共有)。
+ * firmware の `ERR AUTH: no key` / `ERR AUTH: bad nonce` は useSerialArbiter.request の
+ * `errPrefix` (`ERR ${送った行の先頭トークン}` = `ERR AUTH`) に一致するため、nonce を
+ * echo しなくても即 reject される (10 秒のタイムアウトを待たない)。
  */
 import { getAuthCallbackUrl } from '~/composables/useAuth'
 import {
@@ -81,10 +76,21 @@ function fetchNonce(authWorkerUrl: string, redirectUri: string): Promise<string>
 }
 
 /** `AUTH SIG <pubkey> <sig>` を空白で分割して parse。形式が合わなければ null */
-function parseAuthSigLine(line: string): { pubkey: string, sig: string } | null {
+export function parseAuthSigLine(line: string): { pubkey: string, sig: string } | null {
   const parts = line.split(' ')
   if (parts.length !== 4 || parts[0] !== 'AUTH' || parts[1] !== 'SIG') return null
   return { pubkey: parts[2]!, sig: parts[3]! }
+}
+
+/**
+ * 警告デバイスに `AUTH SIGN <nonce>` を送り、応答 `AUTH SIG <pubkey> <sig>` を parse して
+ * 返す (#214 useDeviceLogin / #231 useDeviceToken 共通)。firmware が `ERR AUTH: ...` を
+ * 返せば useAlarmDevice().request がそのまま reject するので、ここでは投げっぱなしにする
+ * (呼び出し側でメッセージを出し分ける)。parse に失敗したときだけ null を返す。
+ */
+export async function signAlarmDeviceNonce(nonce: string): Promise<{ pubkey: string, sig: string } | null> {
+  const line = await useAlarmDevice().request(`AUTH SIGN ${nonce}`, AUTH_SIGN_MATCH_PREFIX, AUTH_SIGN_TIMEOUT_MS)
+  return parseAuthSigLine(line)
 }
 
 export function useDeviceLogin() {
@@ -112,9 +118,9 @@ export function useDeviceLogin() {
         return
       }
 
-      let line: string
+      let parsed: { pubkey: string, sig: string } | null
       try {
-        line = await useAlarmDevice().request(`AUTH SIGN ${nonce}`, AUTH_SIGN_MATCH_PREFIX, AUTH_SIGN_TIMEOUT_MS)
+        parsed = await signAlarmDeviceNonce(nonce)
       }
       catch (e) {
         const message = e instanceof Error ? e.message : String(e)
@@ -122,7 +128,6 @@ export function useDeviceLogin() {
         return
       }
 
-      const parsed = parseAuthSigLine(line)
       if (!parsed) {
         lastError.value = deviceLoginParseFailedMessage
         return

--- a/web/app/composables/useDeviceToken.ts
+++ b/web/app/composables/useDeviceToken.ts
@@ -16,8 +16,28 @@
  * NOTE: 既存の `useAuth` が持つ `alc_device_id` は **rust-alc-api の devices
  * テーブル id** であり、ここで扱う auth-worker の device credential とは別系統。
  * 混同を避けるため別 localStorage key (`alc_kiosk_device_*`) を使う。
+ *
+ * ## 警告デバイス (VoiceS3R) の署名による短命端末 JWT (#231)
+ *
+ * 運行管理者の PC には credential を発行・保存しない (ログイン無しの共用 PC のため)。
+ * 代わりに、警告デバイスが USB で挿さっている間だけ、その ed25519 鍵の署名で
+ * auth-worker (ippoan/auth-worker#551) から `aud=device, role=device-kiosk` の
+ * 短命 JWT (900 秒) を取り、**このモジュールと同じメモリ cache** に載せる
+ * (storage には一切書かない — 抜線すれば次の getDeviceJwt() で消える)。
+ * `getDeviceJwt()` の優先順位は「cache → 警告デバイス署名 → 既存 credential」。
+ *
+ * - 署名の取り方 (`AUTH SIGN <nonce>` → `AUTH SIG <pubkey> <sig>` parse) は
+ *   `useDeviceLogin.ts` の `signAlarmDeviceNonce` を共有する (#214 と同じ firmware I/F)。
+ * - 同時呼び出しは 1 本にまとめる (`jwtInFlight`)。
+ * - 失敗 (ERR / 401 `{error:"invalid_alarm_token"}` / 429 / タイムアウト / 通信エラー、
+ *   いずれも HTTP status だけで判定する) したら `S3R_BACKOFF_MS` の間警告デバイス経路を
+ *   試さず credential 経路へ落ちる。再接続での解除はしない (次に呼ばれたとき抑止期間が
+ *   過ぎていれば自然に再試行する)。
+ * - `/device/alarm-token` の応答に載る `tenant_id` が `deviceTenantId` と食い違っても
+ *   拒否しない (`console.warn` のみ — 発行元 auth-worker 側の判断を尊重する)。
  */
 import { ref, computed, readonly } from 'vue'
+import { signAlarmDeviceNonce } from '~/composables/useDeviceLogin'
 
 const KIOSK_DEVICE_ID_KEY = 'alc_kiosk_device_id'
 const KIOSK_DEVICE_SECRET_KEY = 'alc_kiosk_device_secret'
@@ -26,6 +46,10 @@ const KIOSK_DEVICE_SECRET_KEY = 'alc_kiosk_device_secret'
 const REFRESH_BEFORE_MS = 60_000
 /** expires_in 欠落時の fallback TTL (秒、auth-worker DEVICE_JWT_TTL_SECONDS と同値)。 */
 const DEFAULT_TTL_SECONDS = 3600
+/** 警告デバイス署名 JWT の expires_in 欠落時 fallback TTL (秒。auth-worker #552 と同値) */
+const ALARM_DEFAULT_TTL_SECONDS = 900
+/** 警告デバイス経路が失敗してから、これだけ試さない (ms)。再接続での解除は無い。 */
+const S3R_BACKOFF_MS = 60_000
 
 const isClient = typeof window !== 'undefined'
 
@@ -36,13 +60,21 @@ const kioskDeviceSecret = ref<string | null>(
   isClient ? localStorage.getItem(KIOSK_DEVICE_SECRET_KEY) : null,
 )
 
-// 短命 device JWT の cache (module スコープ = 全 caller で共有)。
+// 短命 device JWT の cache (module スコープ = 全 caller で共有。警告デバイス経路も
+// credential 経路も同じ cache に書く — 呼び出し側からは出どころの違いを見せない)。
 let cachedJwt: string | null = null
 let cachedExpMs = 0
+
+// getDeviceJwt() の single-flight。同時に何回呼ばれても実際の取得は 1 本にまとめる。
+let jwtInFlight: Promise<string | null> | null = null
+// 警告デバイス経路の直近の失敗時刻から S3R_BACKOFF_MS 経つまでは試さない (ms epoch)。
+let s3rBackoffUntilMs = 0
 
 export function useDeviceToken() {
   const config = useRuntimeConfig()
   const authWorkerUrl = (config.public.authWorkerUrl as string) || 'https://auth.ippoan.org'
+  // tenant 食い違いの warn 用 (#231)。読むだけ — 購読はしない
+  const { deviceTenantId } = useAuth()
 
   const hasKioskCredential = computed(() => !!kioskDeviceId.value && !!kioskDeviceSecret.value)
 
@@ -71,16 +103,83 @@ export function useDeviceToken() {
   }
 
   /**
-   * device JWT を返す。cache が有効ならそれ、無ければ `/device/token` で mint。
-   * credential 未保存 / mint 失敗時は null (呼び出し側は X-Tenant-ID 経路に fallback)。
+   * device JWT を返す。優先順位は cache → 警告デバイス (VoiceS3R) の署名 (#231) →
+   * 既存 credential (`/device/token`)。全経路失敗時は null (呼び出し側は X-Tenant-ID
+   * 経路に fallback)。同時呼び出しは 1 本にまとめる (`jwtInFlight`)。
    */
   async function getDeviceJwt(): Promise<string | null> {
+    const nowMs = Date.now()
+    if (cachedJwt && cachedExpMs - REFRESH_BEFORE_MS > nowMs) return cachedJwt
+
+    if (!jwtInFlight) {
+      jwtInFlight = mintDeviceJwt().finally(() => { jwtInFlight = null })
+    }
+    return jwtInFlight
+  }
+
+  /** cache 以外の 2 経路を順に試す (警告デバイスの署名 → credential)。 */
+  async function mintDeviceJwt(): Promise<string | null> {
+    const nowMs = Date.now()
+    return (await tryAlarmDeviceJwt(nowMs)) ?? (await tryCredentialJwt(nowMs))
+  }
+
+  /**
+   * 警告デバイスが USB で繋がっていれば、その ed25519 鍵の署名で auth-worker
+   * (#552) から短命 JWT を取りに行く。未接続 / 抑止期間中 / いずれかの失敗
+   * (401 `{error:"invalid_alarm_token"}` / 429 / タイムアウト / 通信エラー、
+   * いずれも HTTP status だけで判定する) なら null を返し、S3R_BACKOFF_MS の
+   * 間この経路を抑止する (再接続での解除はしない)。
+   */
+  async function tryAlarmDeviceJwt(nowMs: number): Promise<string | null> {
+    if (nowMs < s3rBackoffUntilMs) return null
+    if (!useAlarmDevice().isConnected.value) return null
+
+    try {
+      const nonceRes = await fetch(`${authWorkerUrl}/device/alarm-nonce`)
+      if (!nonceRes.ok) throw new Error(`alarm-nonce http ${nonceRes.status}`)
+      const nonceData = (await nonceRes.json()) as { nonce?: string }
+      if (!nonceData.nonce) throw new Error('alarm-nonce: nonce 欠落')
+
+      const signed = await signAlarmDeviceNonce(nonceData.nonce)
+      if (!signed) throw new Error('AUTH SIG の parse に失敗')
+
+      const tokenRes = await fetch(`${authWorkerUrl}/device/alarm-token`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ nonce: nonceData.nonce, pubkey: signed.pubkey, sig: signed.sig }),
+      })
+      if (!tokenRes.ok) throw new Error(`alarm-token http ${tokenRes.status}`)
+      const tokenData = (await tokenRes.json()) as {
+        access_token?: string
+        token_type?: string
+        expires_in?: number
+        tenant_id?: string
+      }
+      if (!tokenData.access_token) throw new Error('alarm-token: access_token 欠落')
+
+      // tenant の食い違いは拒否しない (発行元 auth-worker の判断を尊重、warn のみ)
+      if (typeof tokenData.tenant_id === 'string' && tokenData.tenant_id !== deviceTenantId.value) {
+        console.warn(
+          `[useDeviceToken] alarm-token の tenant_id (${tokenData.tenant_id}) が deviceTenantId (${deviceTenantId.value}) と食い違います`,
+        )
+      }
+
+      const ttl = typeof tokenData.expires_in === 'number' ? tokenData.expires_in : ALARM_DEFAULT_TTL_SECONDS
+      cachedJwt = tokenData.access_token
+      cachedExpMs = nowMs + ttl * 1000
+      return cachedJwt
+    }
+    catch {
+      s3rBackoffUntilMs = nowMs + S3R_BACKOFF_MS
+      return null
+    }
+  }
+
+  /** 既存の credential 経路 (`/device/token`)。挙動は変えない。 */
+  async function tryCredentialJwt(nowMs: number): Promise<string | null> {
     const id = kioskDeviceId.value
     const secret = kioskDeviceSecret.value
     if (!id || !secret) return null
-
-    const nowMs = Date.now()
-    if (cachedJwt && cachedExpMs - REFRESH_BEFORE_MS > nowMs) return cachedJwt
 
     try {
       const res = await fetch(`${authWorkerUrl}/device/token`, {

--- a/web/tests/composables/useDeviceLogin.test.ts
+++ b/web/tests/composables/useDeviceLogin.test.ts
@@ -245,4 +245,31 @@ describe('useDeviceLogin', () => {
       expect(lastError.value).toBe(deviceLoginParseFailedMessage)
     })
   })
+
+  // ---------- signAlarmDeviceNonce (#231 useDeviceToken と共有する切り出し関数) ----------
+
+  describe('signAlarmDeviceNonce (切り出し。useDeviceToken.ts の警告デバイス署名経路と共有)', () => {
+    it('AUTH SIGN <nonce> を送り、AUTH SIG <pubkey> <sig> を parse して返す', async () => {
+      alarmDeviceMock.request.mockResolvedValue('AUTH SIG pub-9 sig-9')
+      const { signAlarmDeviceNonce } = await import('~/composables/useDeviceLogin')
+
+      await expect(signAlarmDeviceNonce('nonce-xyz')).resolves.toEqual({ pubkey: 'pub-9', sig: 'sig-9' })
+      expect(alarmDeviceMock.request).toHaveBeenCalledWith('AUTH SIGN nonce-xyz', 'AUTH SIG ', 10_000)
+    })
+
+    it('parse できない応答は null (reject しない)', async () => {
+      alarmDeviceMock.request.mockResolvedValue('garbled')
+      const { signAlarmDeviceNonce } = await import('~/composables/useDeviceLogin')
+
+      await expect(signAlarmDeviceNonce('nonce-xyz')).resolves.toBeNull()
+    })
+
+    it('firmware の `ERR AUTH: ...` はタイムアウトを待たず即 reject し、そのまま伝播する (古い★コメントの懸念は解消済み)', async () => {
+      alarmDeviceMock.request.mockRejectedValue(new Error('ERR AUTH: no key'))
+      const { signAlarmDeviceNonce } = await import('~/composables/useDeviceLogin')
+
+      // フェイクタイマーを使わず (= 10 秒のタイムアウトを一切待たず) 即座に reject する
+      await expect(signAlarmDeviceNonce('nonce-xyz')).rejects.toThrow('ERR AUTH: no key')
+    })
+  })
 })

--- a/web/tests/composables/useDeviceToken.test.ts
+++ b/web/tests/composables/useDeviceToken.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mockNuxtImport } from '@nuxt/test-utils/runtime'
 
 // useDeviceToken はモジュールスコープに credential ref + JWT cache を持つ
 // シングルトンなので、テスト毎に resetModules + dynamic import で分離する。
@@ -12,11 +13,28 @@ async function load(): Promise<Mod['useDeviceToken']> {
 const ID = 'dev-abc'
 const SECRET = 'sec-xyz'
 
+// 警告デバイス (VoiceS3R) の署名経路 (#231) 用のモック。
+// useAlarmDevice / useAuth は Nuxt auto-import なので mockNuxtImport、
+// signAlarmDeviceNonce は useDeviceToken.ts が明示 import するので vi.mock で差し替える。
+const alarmDeviceMock = vi.hoisted(() => ({ isConnected: { value: false } }))
+mockNuxtImport('useAlarmDevice', () => () => alarmDeviceMock)
+
+const authMock = vi.hoisted(() => ({ deviceTenantId: { value: null as string | null } }))
+mockNuxtImport('useAuth', () => () => authMock)
+
+const signAlarmDeviceNonceMock = vi.hoisted(() => vi.fn())
+vi.mock('~/composables/useDeviceLogin', () => ({
+  signAlarmDeviceNonce: signAlarmDeviceNonceMock,
+}))
+
 beforeEach(() => {
   vi.clearAllMocks()
   vi.restoreAllMocks()
   vi.resetModules()
   localStorage.clear()
+  alarmDeviceMock.isConnected.value = false
+  authMock.deviceTenantId.value = null
+  signAlarmDeviceNonceMock.mockReset()
 })
 
 describe('useDeviceToken (#434 step 3c)', () => {
@@ -213,6 +231,279 @@ describe('useDeviceToken (#434 step 3c)', () => {
       expect(await setupAsKiosk('admin-jwt', 'kiosk-1')).toBe(false)
       expect(hasKioskCredential.value).toBe(false)
       expect(localStorage.getItem('alc_kiosk_device_id')).toBeNull()
+    })
+  })
+
+  describe('getDeviceJwt: 警告デバイス (VoiceS3R) の署名による短命端末 JWT (#231)', () => {
+    /** URL の末尾 (パス) で振り分ける fetch mock。想定外の URL は throw して見逃しを防ぐ。 */
+    function routeFetch(handlers: Record<string, () => { ok: boolean, status?: number, json: () => Promise<unknown> }>) {
+      return vi.fn((url: string) => {
+        for (const [suffix, handler] of Object.entries(handlers)) {
+          if (url.endsWith(suffix)) return Promise.resolve(handler())
+        }
+        throw new Error(`unexpected fetch: ${url}`)
+      })
+    }
+
+    it('警告デバイス接続中なら credential より優先し、alarm-nonce → AUTH SIGN → alarm-token で取って cache する', async () => {
+      alarmDeviceMock.isConnected.value = true
+      signAlarmDeviceNonceMock.mockResolvedValue({ pubkey: 'pub-1', sig: 'sig-1' })
+      const fetchMock = routeFetch({
+        '/device/alarm-nonce': () => ({ ok: true, json: () => Promise.resolve({ nonce: 'n1', expires_in: 60 }) }),
+        '/device/alarm-token': () => ({ ok: true, json: () => Promise.resolve({ access_token: 's3r-jwt', expires_in: 900 }) }),
+      })
+      vi.stubGlobal('fetch', fetchMock)
+
+      const useDeviceToken = await load()
+      const { storeKioskCredential, getDeviceJwt } = useDeviceToken()
+      storeKioskCredential(ID, SECRET) // credential も持っているが使われないはず
+
+      expect(await getDeviceJwt()).toBe('s3r-jwt')
+      expect(signAlarmDeviceNonceMock).toHaveBeenCalledWith('n1')
+      expect(fetchMock.mock.calls.some(([u]) => (u as string).includes('/device/token'))).toBe(false)
+    })
+
+    it('S3R の JWT は既存キャッシュに載り、期限前は再利用する (再 fetch しない)', async () => {
+      alarmDeviceMock.isConnected.value = true
+      signAlarmDeviceNonceMock.mockResolvedValue({ pubkey: 'pub-1', sig: 'sig-1' })
+      const fetchMock = routeFetch({
+        '/device/alarm-nonce': () => ({ ok: true, json: () => Promise.resolve({ nonce: 'n1', expires_in: 60 }) }),
+        '/device/alarm-token': () => ({ ok: true, json: () => Promise.resolve({ access_token: 's3r-jwt', expires_in: 900 }) }),
+      })
+      vi.stubGlobal('fetch', fetchMock)
+
+      const useDeviceToken = await load()
+      const { getDeviceJwt } = useDeviceToken()
+
+      expect(await getDeviceJwt()).toBe('s3r-jwt')
+      expect(await getDeviceJwt()).toBe('s3r-jwt')
+      expect(fetchMock).toHaveBeenCalledTimes(2) // nonce + token が 1 回ずつ
+      expect(signAlarmDeviceNonceMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('single-flight: 同時 3 回呼んでも nonce の取得は 1 回だけ', async () => {
+      alarmDeviceMock.isConnected.value = true
+      signAlarmDeviceNonceMock.mockResolvedValue({ pubkey: 'pub-1', sig: 'sig-1' })
+      let nonceCalls = 0
+      const fetchMock = vi.fn((url: string) => {
+        if (url.endsWith('/device/alarm-nonce')) {
+          nonceCalls += 1
+          return Promise.resolve({ ok: true, json: () => Promise.resolve({ nonce: 'n1', expires_in: 60 }) })
+        }
+        if (url.endsWith('/device/alarm-token')) {
+          return Promise.resolve({ ok: true, json: () => Promise.resolve({ access_token: 's3r-jwt', expires_in: 900 }) })
+        }
+        throw new Error(`unexpected fetch: ${url}`)
+      })
+      vi.stubGlobal('fetch', fetchMock)
+
+      const useDeviceToken = await load()
+      const { getDeviceJwt } = useDeviceToken()
+
+      const results = await Promise.all([getDeviceJwt(), getDeviceJwt(), getDeviceJwt()])
+      expect(results).toEqual(['s3r-jwt', 's3r-jwt', 's3r-jwt'])
+      expect(nonceCalls).toBe(1)
+    })
+
+    it('警告デバイス未接続なら nonce を呼ばず、既存の credential 経路だけを試す', async () => {
+      alarmDeviceMock.isConnected.value = false
+      const fetchMock = routeFetch({
+        '/device/token': () => ({ ok: true, json: () => Promise.resolve({ access_token: 'cred-jwt', expires_in: 3600 }) }),
+      })
+      vi.stubGlobal('fetch', fetchMock)
+
+      const useDeviceToken = await load()
+      const { storeKioskCredential, getDeviceJwt } = useDeviceToken()
+      storeKioskCredential(ID, SECRET)
+
+      expect(await getDeviceJwt()).toBe('cred-jwt')
+      expect(signAlarmDeviceNonceMock).not.toHaveBeenCalled()
+      expect(fetchMock.mock.calls.some(([u]) => (u as string).includes('alarm-nonce'))).toBe(false)
+    })
+
+    it('S3R が 401/429 で失敗すれば null に落ちて credential 経路を試す', async () => {
+      alarmDeviceMock.isConnected.value = true
+      const fetchMock = routeFetch({
+        '/device/alarm-nonce': () => ({ ok: false, status: 429, json: () => Promise.resolve({}) }),
+        '/device/token': () => ({ ok: true, json: () => Promise.resolve({ access_token: 'cred-jwt', expires_in: 3600 }) }),
+      })
+      vi.stubGlobal('fetch', fetchMock)
+
+      const useDeviceToken = await load()
+      const { storeKioskCredential, getDeviceJwt } = useDeviceToken()
+      storeKioskCredential(ID, SECRET)
+
+      expect(await getDeviceJwt()).toBe('cred-jwt')
+      expect(signAlarmDeviceNonceMock).not.toHaveBeenCalled()
+    })
+
+    it('AUTH SIGN が (ERR AUTH: 等で) reject しても catch して null に落ちる (credential 未保存なら null)', async () => {
+      alarmDeviceMock.isConnected.value = true
+      const fetchMock = routeFetch({
+        '/device/alarm-nonce': () => ({ ok: true, json: () => Promise.resolve({ nonce: 'n1', expires_in: 60 }) }),
+      })
+      vi.stubGlobal('fetch', fetchMock)
+      signAlarmDeviceNonceMock.mockRejectedValue(new Error('ERR AUTH: no key'))
+
+      const useDeviceToken = await load()
+      const { getDeviceJwt } = useDeviceToken()
+
+      expect(await getDeviceJwt()).toBeNull()
+    })
+
+    it('alarm-nonce の応答に nonce が無ければ null に落ちる', async () => {
+      alarmDeviceMock.isConnected.value = true
+      const fetchMock = routeFetch({
+        '/device/alarm-nonce': () => ({ ok: true, json: () => Promise.resolve({ expires_in: 60 }) }),
+      })
+      vi.stubGlobal('fetch', fetchMock)
+
+      const useDeviceToken = await load()
+      const { getDeviceJwt } = useDeviceToken()
+
+      expect(await getDeviceJwt()).toBeNull()
+      expect(signAlarmDeviceNonceMock).not.toHaveBeenCalled()
+    })
+
+    it('AUTH SIG の parse に失敗 (signAlarmDeviceNonce が null を返す) は null に落ちる', async () => {
+      alarmDeviceMock.isConnected.value = true
+      signAlarmDeviceNonceMock.mockResolvedValue(null)
+      const fetchMock = routeFetch({
+        '/device/alarm-nonce': () => ({ ok: true, json: () => Promise.resolve({ nonce: 'n1', expires_in: 60 }) }),
+      })
+      vi.stubGlobal('fetch', fetchMock)
+
+      const useDeviceToken = await load()
+      const { getDeviceJwt } = useDeviceToken()
+
+      expect(await getDeviceJwt()).toBeNull()
+    })
+
+    it('alarm-token が 401 {error:"invalid_alarm_token"} なら (body を見ず status だけで) null に落ちる (nonce 取得・署名は成功していても)', async () => {
+      alarmDeviceMock.isConnected.value = true
+      signAlarmDeviceNonceMock.mockResolvedValue({ pubkey: 'pub-1', sig: 'sig-1' })
+      const fetchMock = routeFetch({
+        '/device/alarm-nonce': () => ({ ok: true, json: () => Promise.resolve({ nonce: 'n1', expires_in: 60 }) }),
+        '/device/alarm-token': () => ({ ok: false, status: 401, json: () => Promise.resolve({ error: 'invalid_alarm_token' }) }),
+      })
+      vi.stubGlobal('fetch', fetchMock)
+
+      const useDeviceToken = await load()
+      const { getDeviceJwt } = useDeviceToken()
+
+      expect(await getDeviceJwt()).toBeNull()
+    })
+
+    it('alarm-token の応答に access_token が無ければ null に落ちる', async () => {
+      alarmDeviceMock.isConnected.value = true
+      signAlarmDeviceNonceMock.mockResolvedValue({ pubkey: 'pub-1', sig: 'sig-1' })
+      const fetchMock = routeFetch({
+        '/device/alarm-nonce': () => ({ ok: true, json: () => Promise.resolve({ nonce: 'n1', expires_in: 60 }) }),
+        '/device/alarm-token': () => ({ ok: true, json: () => Promise.resolve({ expires_in: 900 }) }),
+      })
+      vi.stubGlobal('fetch', fetchMock)
+
+      const useDeviceToken = await load()
+      const { getDeviceJwt } = useDeviceToken()
+
+      expect(await getDeviceJwt()).toBeNull()
+    })
+
+    it('alarm-token の expires_in 欠落時は fallback TTL (900 秒) で cache する', async () => {
+      alarmDeviceMock.isConnected.value = true
+      signAlarmDeviceNonceMock.mockResolvedValue({ pubkey: 'pub-1', sig: 'sig-1' })
+      const fetchMock = routeFetch({
+        '/device/alarm-nonce': () => ({ ok: true, json: () => Promise.resolve({ nonce: 'n1', expires_in: 60 }) }),
+        '/device/alarm-token': () => ({ ok: true, json: () => Promise.resolve({ access_token: 's3r-jwt' }) }),
+      })
+      vi.stubGlobal('fetch', fetchMock)
+
+      const useDeviceToken = await load()
+      const { getDeviceJwt } = useDeviceToken()
+
+      expect(await getDeviceJwt()).toBe('s3r-jwt')
+      expect(await getDeviceJwt()).toBe('s3r-jwt') // fallback TTL でも cache が効く
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+    })
+
+    it('alarm-token の応答に tenant_id が無ければ warn しない', async () => {
+      alarmDeviceMock.isConnected.value = true
+      authMock.deviceTenantId.value = 'tenant-A'
+      signAlarmDeviceNonceMock.mockResolvedValue({ pubkey: 'pub-1', sig: 'sig-1' })
+      const fetchMock = routeFetch({
+        '/device/alarm-nonce': () => ({ ok: true, json: () => Promise.resolve({ nonce: 'n1', expires_in: 60 }) }),
+        '/device/alarm-token': () => ({ ok: true, json: () => Promise.resolve({ access_token: 's3r-jwt', token_type: 'Bearer', expires_in: 900 }) }),
+      })
+      vi.stubGlobal('fetch', fetchMock)
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      const useDeviceToken = await load()
+      const { getDeviceJwt } = useDeviceToken()
+
+      expect(await getDeviceJwt()).toBe('s3r-jwt')
+      expect(warnSpy).not.toHaveBeenCalled()
+    })
+
+    it('S3R 失敗後 60 秒は nonce を呼ばず (credential 無しなら null)、61 秒後は再試行する', async () => {
+      alarmDeviceMock.isConnected.value = true
+      let nowMs = 1_000_000
+      vi.spyOn(Date, 'now').mockImplementation(() => nowMs)
+
+      const nonceMock = vi.fn(() => Promise.resolve({ ok: false, json: () => Promise.resolve({}) }))
+      vi.stubGlobal('fetch', nonceMock)
+
+      const useDeviceToken = await load()
+      const { getDeviceJwt } = useDeviceToken()
+
+      expect(await getDeviceJwt()).toBeNull()
+      expect(nonceMock).toHaveBeenCalledTimes(1)
+
+      nowMs += 59_000 // 59 秒後: まだ抑止期間中
+      expect(await getDeviceJwt()).toBeNull()
+      expect(nonceMock).toHaveBeenCalledTimes(1)
+
+      nowMs += 2_000 // 61 秒後: 抑止解除、再試行する
+      expect(await getDeviceJwt()).toBeNull()
+      expect(nonceMock).toHaveBeenCalledTimes(2)
+    })
+
+    it('alarm-token 応答の tenant_id が deviceTenantId と食い違っても拒否せず warn だけ (#552)', async () => {
+      alarmDeviceMock.isConnected.value = true
+      authMock.deviceTenantId.value = 'tenant-A'
+      signAlarmDeviceNonceMock.mockResolvedValue({ pubkey: 'pub-1', sig: 'sig-1' })
+
+      const fetchMock = routeFetch({
+        '/device/alarm-nonce': () => ({ ok: true, json: () => Promise.resolve({ nonce: 'n1', expires_in: 60 }) }),
+        '/device/alarm-token': () => ({
+          ok: true,
+          json: () => Promise.resolve({ access_token: 's3r-jwt', token_type: 'Bearer', expires_in: 900, tenant_id: 'tenant-B' }),
+        }),
+      })
+      vi.stubGlobal('fetch', fetchMock)
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      const useDeviceToken = await load()
+      const { getDeviceJwt } = useDeviceToken()
+
+      expect(await getDeviceJwt()).toBe('s3r-jwt')
+      expect(warnSpy).toHaveBeenCalledTimes(1)
+    })
+
+    it('S3R 経路は localStorage / sessionStorage に一切書かない', async () => {
+      alarmDeviceMock.isConnected.value = true
+      signAlarmDeviceNonceMock.mockResolvedValue({ pubkey: 'pub-1', sig: 'sig-1' })
+      const fetchMock = routeFetch({
+        '/device/alarm-nonce': () => ({ ok: true, json: () => Promise.resolve({ nonce: 'n1', expires_in: 60 }) }),
+        '/device/alarm-token': () => ({ ok: true, json: () => Promise.resolve({ access_token: 's3r-jwt', expires_in: 900 }) }),
+      })
+      vi.stubGlobal('fetch', fetchMock)
+      const setItemSpy = vi.spyOn(Storage.prototype, 'setItem')
+
+      const useDeviceToken = await load()
+      const { getDeviceJwt } = useDeviceToken()
+
+      expect(await getDeviceJwt()).toBe('s3r-jwt')
+      expect(setItemSpy).not.toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
## 何を変えるか

運行管理者の PC は、運行者などのタブをログイン無しで使う。PC に警告デバイス (VoiceS3R) が繋がっていれば、その署名で auth-worker から**短命の端末 JWT** を取り、端末 JWT の経路 (`/api/proxy` → `/device-data-proxy`) で動かす。PC に資格情報は保存しない。auth-worker 側の口は ippoan/auth-worker#552 (本番反映済み)。

`web/app/composables/useDeviceToken.ts` の `getDeviceJwt()` は、端末 JWT の唯一の出どころ (`initApi` と打刻の WS の両方がここを呼ぶ)。その優先順位を次のようにする。

1. メモリのキャッシュ (既存のもの)
2. 警告デバイスが繋がっていれば、`GET /device/alarm-nonce` → 警告デバイスに `AUTH SIGN <nonce>` → `POST /device/alarm-token` で取り、同じキャッシュに入れる。localStorage 等には書かない
3. 保存済みの credential (`/device/token`)。今までと同じ

- 同時の呼び出しは 1 本にまとめる
- 警告デバイスの経路が失敗したら、60 秒は試さずに 3 へ回す
- 応答の `tenant_id` がこの端末のテナントと違うときは、警告を出すだけにする

署名の取り方 (`AUTH SIGN` を送り、`AUTH SIG` を parse する部分) は `useDeviceLogin.ts` から `signAlarmDeviceNonce` として切り出し、管理者ログインのボタンと共有する。`ERR AUTH:` 行はタイムアウトを待たずに失敗として扱う (既存のシリアル処理で拾えることをテストで固定し、古い注意書きを削除した)。

## テスト

- 優先順位 (キャッシュ → 警告デバイス → credential) / 取った JWT をキャッシュする / 同時の呼び出しを 1 本にする / 失敗後 60 秒は試さない / 未接続なら nonce を取りに行かない / `ERR AUTH:` で即失敗 / 401・429 で credential へ回す / storage に書かない
- vitest 全体と `check_coverage_100`、`npx nuxi typecheck` が通る

Refs #231
Refs ippoan/alc-app-s3#135

🤖 Generated with [Claude Code](https://claude.com/claude-code)
