### PR TITLE
fix(auth): 管理者 Cookie から端末の「登録済み」を作らず、期限切れの Cookie を捨てる (Refs #234)

### DIFF
--- a/web/app/composables/useAuth.ts
+++ b/web/app/composables/useAuth.ts
@@ -136,11 +136,18 @@ export function useAuth() {
     const raw = document.cookie.match(/(?:^|;\s*)logi_auth_token=([^;]+)/)?.[1]
     if (!raw) return false
     const token = decodeURIComponent(raw)
-    accessToken.value = token
     try {
       const parts = token.split('.')
       if (!parts[1]) throw new Error('Invalid JWT')
       const payload = decodeJwtPayload(parts[1])
+      // exp (秒) が過去なら失効: cookie/client state を掃除して false を返す
+      // (accessToken には載せない)。exp を持たない cookie は有効扱い。
+      if (typeof payload.exp === 'number' && payload.exp * 1000 <= Date.now()) {
+        clearAuthCookieClientSide()
+        clearClientSession()
+        return false
+      }
+      accessToken.value = token
       const tenantId = payload.tenant_id || payload.org || ''
       user.value = {
         id: payload.sub || payload.user_id || '',
@@ -149,8 +156,10 @@ export function useAuth() {
         tenant_id: tenantId,
         role: payload.role || 'viewer',
       }
-      if (tenantId) activateDevice(tenantId)
-    } catch { /* デコード失敗してもログイン状態は維持 */ }
+    } catch {
+      /* デコード失敗してもログイン状態は維持 */
+      accessToken.value = token
+    }
     // ログイン確立 → 無操作 auto-logout の監視を開始
     startInactivityWatch()
     return true
@@ -400,8 +409,6 @@ export function useAuth() {
         tenant_id: tenantId,
         role: payload.role || 'viewer',
       }
-      // tenant_id があればデバイスをアクティベート (X-Tenant-ID ヘッダー用)
-      if (tenantId) activateDevice(tenantId)
     } catch { /* デコード失敗してもログイン状態は維持 */ }
     // ログイン確立 → 無操作 auto-logout の監視を開始
     startInactivityWatch()

--- a/web/tests/composables/useAuth.test.ts
+++ b/web/tests/composables/useAuth.test.ts
@@ -650,8 +650,9 @@ describe('useAuth', () => {
 
       activateDevice('tenant-abc')
       localStorage.setItem('alc_refresh_token', 'rt_x')
-      // cookie の tenant は空 = consumeAuthCookie が activateDevice しない (端末 tenant 保持の検証)
-      const fakeJwt = createFakeJwtWithExp({ ...defaultPayload, tenant_id: '' }, 3600)
+      // consumeAuthCookie はもう activateDevice を呼ばない (#234) — cookie が別テナントを
+      // 持っていても端末 tenant (手動 activateDevice 分) は上書きされない
+      const fakeJwt = createFakeJwtWithExp({ ...defaultPayload, tenant_id: 'cookie-tenant' }, 3600)
       setDocCookie(`logi_auth_token=${fakeJwt}`)
       consumeAuthCookie()
 
@@ -1076,7 +1077,7 @@ describe('useAuth', () => {
       envMock.isClient = true
     })
 
-    it('establishes session and activates device from cookie JWT', async () => {
+    it('establishes session from cookie JWT without activating device (#234)', async () => {
       const fakeJwt = createFakeJwtWithExp(defaultPayload, 3600)
       setDocCookie(`logi_auth_token=${fakeJwt}`)
       const { useAuth } = await import('~/composables/useAuth')
@@ -1084,16 +1085,51 @@ describe('useAuth', () => {
       expect(auth.consumeAuthCookie()).toBe(true)
       expect(auth.isAuthenticated.value).toBe(true)
       expect(auth.user.value?.email).toBe('test@example.com')
-      expect(auth.deviceTenantId.value).toBe('tenant-1')
+      // 管理者ログインだけでは端末を「登録済み」にしない (#234)
+      expect(auth.deviceTenantId.value).toBeNull()
     })
 
-    it('does not activate device when tenant_id is empty', async () => {
+    it('sets empty tenant_id on user when JWT has neither tenant_id nor org, still no device activation', async () => {
       const fakeJwt = createFakeJwtWithExp({ ...defaultPayload, tenant_id: '', org: '' }, 3600)
       setDocCookie(`logi_auth_token=${fakeJwt}`)
       const { useAuth } = await import('~/composables/useAuth')
       const auth = useAuth()
       expect(auth.consumeAuthCookie()).toBe(true)
+      expect(auth.user.value?.tenant_id).toBe('')
       expect(auth.deviceTenantId.value).toBeNull()
+    })
+
+    it('returns false and clears cookie/session when the JWT exp is in the past (#234)', async () => {
+      const expiredJwt = createFakeJwtWithExp(defaultPayload, -60)
+      const writes: string[] = []
+      let cookieValue = `logi_auth_token=${expiredJwt}`
+      Object.defineProperty(document, 'cookie', {
+        get: () => cookieValue,
+        set: (v: string) => {
+          writes.push(v)
+          cookieValue = /Max-Age=0/.test(v) ? '' : v
+        },
+        configurable: true,
+      })
+      const { useAuth } = await import('~/composables/useAuth')
+      const auth = useAuth()
+
+      expect(auth.consumeAuthCookie()).toBe(false)
+      expect(auth.accessToken.value).toBeNull()
+      expect(auth.isAuthenticated.value).toBe(false)
+      // clearAuthCookieClientSide が cookie を Max-Age=0 で上書き
+      expect(writes.some(w => w.includes('logi_auth_token=;') && w.includes('Max-Age=0'))).toBe(true)
+    })
+
+    it('treats a JWT without exp as valid (no expiry claim to check)', async () => {
+      const jwtWithoutExp = createFakeJwt(defaultPayload)
+      setDocCookie(`logi_auth_token=${jwtWithoutExp}`)
+      const { useAuth } = await import('~/composables/useAuth')
+      const auth = useAuth()
+
+      expect(auth.consumeAuthCookie()).toBe(true)
+      expect(auth.accessToken.value).toBe(jwtWithoutExp)
+      expect(auth.isAuthenticated.value).toBe(true)
     })
 
     it('keeps login state even when JWT payload is malformed', async () => {
@@ -1111,7 +1147,7 @@ describe('useAuth', () => {
       const auth = useAuth()
       expect(auth.consumeAuthCookie()).toBe(true)
       expect(auth.user.value).toEqual({ id: 'uid-9', email: '', name: '', tenant_id: 'org-9', role: 'viewer' })
-      expect(auth.deviceTenantId.value).toBe('org-9')
+      expect(auth.deviceTenantId.value).toBeNull()
     })
 
     it('defaults id to empty string when neither sub nor user_id present', async () => {
@@ -1179,7 +1215,8 @@ describe('useAuth', () => {
       expect(result).toBe(true)
       expect(auth.accessToken.value).toBe(fakeJwt)
       expect(auth.user.value?.email).toBe('lw@example.com')
-      expect(auth.deviceTenantId.value).toBe('lw-tenant')
+      // LINE WORKS ログインでも端末を「登録済み」にしない (#234)
+      expect(auth.deviceTenantId.value).toBeNull()
       expect(localStorage.getItem('alc_refresh_token')).toBe('rt_lw')
       expect(replaceStateSpy).toHaveBeenCalledWith({}, '', '/callback')
 


### PR DESCRIPTION
## 何を変えるか

`web/app/composables/useAuth.ts` の 2 点。運行者端末を CoreS3 のシリアル署名で認証する作業 (#234) の 1 本目。

1. **管理者ログインから端末の「登録済み」を作らない。** `consumeAuthCookie` と `handleLineworksHash` から `activateDevice(...)` の呼び出しを削除する。端末の登録状態 (`deviceTenantId`) を作るのは、本物の端末登録の経路 (Android device owner / QR の `activateFromRegistration` / staging bypass) だけになる。管理者ログイン中は accessToken があり、要求は従来どおり管理者の経路を通るので影響しない
2. **期限切れの Cookie を使わない。** `consumeAuthCookie` が JWT payload の `exp` (秒) を見て、過ぎていれば `clearAuthCookieClientSide()` と `clearClientSession()` を呼んで `false` を返す (accessToken に載せない)。`exp` を持たない Cookie は今までどおり有効として扱う。`refreshAccessToken` は `consumeAuthCookie` を呼ぶだけなので変更なし (期限切れなら reject する)

既に「登録済み」になっている端末は、デバイス設定の「リセット」(`deactivateDevice`) で消え、この変更の後はリロードしても戻らない。

## テスト

- `web/tests/composables/useAuth.test.ts`: Cookie は `deviceTenantId` を書かない / 期限切れの Cookie → `false`・accessToken が null・Cookie を消す / `exp` の無い Cookie は有効
- vitest 全体 (63 files / 1537 passed) と `check_coverage_100` (useAuth.ts は lines・branches とも 100%)

Refs #234
Refs ippoan/alc-app-s3#135

🤖 Generated with [Claude Code](https://claude.com/claude-code)
