### PR TITLE
feat(device-token): 端末 JWT の署名の相手を CoreS3 に替える (Refs #234)

### DIFF
--- a/web/app/composables/useDeviceLogin.ts
+++ b/web/app/composables/useDeviceLogin.ts
@@ -18,7 +18,9 @@
  * useHubClaim.ts (#213 CoreS3 自動端末登録) と同じ構造 (module-level state + 1 関数)。
  *
  * `AUTH SIGN <nonce>` を送って `AUTH SIG <pubkey> <sig>` を parse する部分は
- * `signAlarmDeviceNonce` に切り出してある (useDeviceToken.ts の短命端末 JWT #231 と共有)。
+ * `signAlarmDeviceNonce` に切り出してある (useDeviceToken.ts の短命端末 JWT #231 と共有。
+ * #234-2 で送り先を引数化 — useDeviceToken.ts は CoreS3 (`useCoreS3Serial().request`) を渡し、
+ * ここ (/login) は既定値のまま警告デバイス (`useAlarmDevice().request`) を使い続ける)。
  * firmware の `ERR AUTH: no key` / `ERR AUTH: bad nonce` は useSerialArbiter.request の
  * `errPrefix` (`ERR ${送った行の先頭トークン}` = `ERR AUTH`) に一致するため、nonce を
  * echo しなくても即 reject される (10 秒のタイムアウトを待たない)。
@@ -83,13 +85,18 @@ export function parseAuthSigLine(line: string): { pubkey: string, sig: string } 
 }
 
 /**
- * 警告デバイスに `AUTH SIGN <nonce>` を送り、応答 `AUTH SIG <pubkey> <sig>` を parse して
- * 返す (#214 useDeviceLogin / #231 useDeviceToken 共通)。firmware が `ERR AUTH: ...` を
- * 返せば useAlarmDevice().request がそのまま reject するので、ここでは投げっぱなしにする
+ * `AUTH SIGN <nonce>` を送り、応答 `AUTH SIG <pubkey> <sig>` を parse して
+ * 返す (#214 useDeviceLogin / #231 useDeviceToken 共通)。送り先は `request` (既定は
+ * 警告デバイス `useAlarmDevice().request`、useDeviceToken.ts は CoreS3
+ * `useCoreS3Serial().request` を渡す。#234-2)。firmware が `ERR AUTH: ...` を
+ * 返せば request がそのまま reject するので、ここでは投げっぱなしにする
  * (呼び出し側でメッセージを出し分ける)。parse に失敗したときだけ null を返す。
  */
-export async function signAlarmDeviceNonce(nonce: string): Promise<{ pubkey: string, sig: string } | null> {
-  const line = await useAlarmDevice().request(`AUTH SIGN ${nonce}`, AUTH_SIGN_MATCH_PREFIX, AUTH_SIGN_TIMEOUT_MS)
+export async function signAlarmDeviceNonce(
+  nonce: string,
+  request: (line: string, matchPrefix: string, timeoutMs: number) => Promise<string> = useAlarmDevice().request,
+): Promise<{ pubkey: string, sig: string } | null> {
+  const line = await request(`AUTH SIGN ${nonce}`, AUTH_SIGN_MATCH_PREFIX, AUTH_SIGN_TIMEOUT_MS)
   return parseAuthSigLine(line)
 }
 

--- a/web/app/composables/useDeviceToken.ts
+++ b/web/app/composables/useDeviceToken.ts
@@ -17,22 +17,27 @@
  * テーブル id** であり、ここで扱う auth-worker の device credential とは別系統。
  * 混同を避けるため別 localStorage key (`alc_kiosk_device_*`) を使う。
  *
- * ## 警告デバイス (VoiceS3R) の署名による短命端末 JWT (#231)
+ * ## CoreS3 の署名による短命端末 JWT (#231 → #234-2 で署名の相手を CoreS3 に変更)
  *
  * 運行管理者の PC には credential を発行・保存しない (ログイン無しの共用 PC のため)。
- * 代わりに、警告デバイスが USB で挿さっている間だけ、その ed25519 鍵の署名で
- * auth-worker (ippoan/auth-worker#551) から `aud=device, role=device-kiosk` の
+ * 代わりに、CoreS3 (統合ハブ) が USB で挿さっている間だけ、その ed25519 鍵の署名で
+ * auth-worker (ippoan/auth-worker#552) から `aud=device, role=device-kiosk` の
  * 短命 JWT (900 秒) を取り、**このモジュールと同じメモリ cache** に載せる
- * (storage には一切書かない — 抜線すれば次の getDeviceJwt() で消える)。
- * `getDeviceJwt()` の優先順位は「cache → 警告デバイス署名 → 既存 credential」。
+ * (storage には一切書かない — 抜線すれば次の getDeviceJwt() で消える。CoreS3 の
+ * `onClose` でも即座にキャッシュを捨てる)。
+ * `getDeviceJwt()` の優先順位は「cache → CoreS3 署名 → 既存 credential」。
+ *
+ * 警告デバイス (VoiceS3R) は運行管理者の機器で LAN が無く、認証には使わない
+ * (ユーザー決定。Refs ippoan/alc-app#234)。
  *
  * - 署名の取り方 (`AUTH SIGN <nonce>` → `AUTH SIG <pubkey> <sig>` parse) は
- *   `useDeviceLogin.ts` の `signAlarmDeviceNonce` を共有する (#214 と同じ firmware I/F)。
+ *   `useDeviceLogin.ts` の `signAlarmDeviceNonce` を共有する (#214 と同じ firmware I/F。
+ *   送り先は `useCoreS3Serial().request` を渡す)。
  * - 同時呼び出しは 1 本にまとめる (`jwtInFlight`)。
  * - 失敗 (ERR / 401 `{error:"invalid_alarm_token"}` / 429 / タイムアウト / 通信エラー、
- *   いずれも HTTP status だけで判定する) したら `S3R_BACKOFF_MS` の間警告デバイス経路を
+ *   いずれも HTTP status だけで判定する) したら `CORE_S3_BACKOFF_MS` の間 CoreS3 署名経路を
  *   試さず credential 経路へ落ちる。再接続での解除はしない (次に呼ばれたとき抑止期間が
- *   過ぎていれば自然に再試行する)。
+ *   過ぎていれば自然に再試行する)。失敗理由は `lastError` に残し、成功したら null に戻す。
  * - `/device/alarm-token` の応答に載る `tenant_id` が `deviceTenantId` と食い違っても
  *   拒否しない (`console.warn` のみ — 発行元 auth-worker 側の判断を尊重する)。
  */
@@ -46,10 +51,10 @@ const KIOSK_DEVICE_SECRET_KEY = 'alc_kiosk_device_secret'
 const REFRESH_BEFORE_MS = 60_000
 /** expires_in 欠落時の fallback TTL (秒、auth-worker DEVICE_JWT_TTL_SECONDS と同値)。 */
 const DEFAULT_TTL_SECONDS = 3600
-/** 警告デバイス署名 JWT の expires_in 欠落時 fallback TTL (秒。auth-worker #552 と同値) */
-const ALARM_DEFAULT_TTL_SECONDS = 900
-/** 警告デバイス経路が失敗してから、これだけ試さない (ms)。再接続での解除は無い。 */
-const S3R_BACKOFF_MS = 60_000
+/** CoreS3 署名 JWT の expires_in 欠落時 fallback TTL (秒。auth-worker #552 と同値) */
+const CORE_S3_DEFAULT_TTL_SECONDS = 900
+/** CoreS3 署名経路が失敗してから、これだけ試さない (ms)。再接続での解除は無い。 */
+const CORE_S3_BACKOFF_MS = 60_000
 
 const isClient = typeof window !== 'undefined'
 
@@ -60,15 +65,20 @@ const kioskDeviceSecret = ref<string | null>(
   isClient ? localStorage.getItem(KIOSK_DEVICE_SECRET_KEY) : null,
 )
 
-// 短命 device JWT の cache (module スコープ = 全 caller で共有。警告デバイス経路も
+// 短命 device JWT の cache (module スコープ = 全 caller で共有。CoreS3 署名経路も
 // credential 経路も同じ cache に書く — 呼び出し側からは出どころの違いを見せない)。
-let cachedJwt: string | null = null
+// ref にしてあるのは hasDeviceJwt (#234-2、兄弟 #p135-c234-3 が使う) から参照できるようにするため。
+const cachedJwt = ref<string | null>(null)
 let cachedExpMs = 0
 
 // getDeviceJwt() の single-flight。同時に何回呼ばれても実際の取得は 1 本にまとめる。
 let jwtInFlight: Promise<string | null> | null = null
-// 警告デバイス経路の直近の失敗時刻から S3R_BACKOFF_MS 経つまでは試さない (ms epoch)。
-let s3rBackoffUntilMs = 0
+// CoreS3 署名経路の直近の失敗時刻から CORE_S3_BACKOFF_MS 経つまでは試さない (ms epoch)。
+let coreS3BackoffUntilMs = 0
+// CoreS3 署名経路の直近の失敗理由 (画面表示用)。成功 / 未試行なら null
+const lastError = ref<string | null>(null)
+// CoreS3 の再接続監視 (キャッシュ破棄) を二重登録しないためのガード (useHubClaim と同じ流儀)
+let closeListenerInstalled = false
 
 export function useDeviceToken() {
   const config = useRuntimeConfig()
@@ -77,12 +87,25 @@ export function useDeviceToken() {
   const { deviceTenantId } = useAuth()
 
   const hasKioskCredential = computed(() => !!kioskDeviceId.value && !!kioskDeviceSecret.value)
+  /** 期限内の device JWT を cache に持っているか (#234-2、兄弟 #p135-c234-3 が使う) */
+  const hasDeviceJwt = computed(() => !!cachedJwt.value && cachedExpMs > Date.now())
+
+  const coreS3 = useCoreS3Serial()
+  // CoreS3 を抜線したら短命 JWT も即座に捨てる (親の決定)。useHubClaim と同じ
+  // listenerInstalled 流儀で、useDeviceToken() を複数回呼んでも二重登録しない。
+  if (!closeListenerInstalled) {
+    closeListenerInstalled = true
+    coreS3.onClose(() => {
+      cachedJwt.value = null
+      cachedExpMs = 0
+    })
+  }
 
   /** pairing で得た device credential を保存する (device JWT cache は破棄)。 */
   function storeKioskCredential(id: string, secret: string): void {
     kioskDeviceId.value = id
     kioskDeviceSecret.value = secret
-    cachedJwt = null
+    cachedJwt.value = null
     cachedExpMs = 0
     if (isClient) {
       localStorage.setItem(KIOSK_DEVICE_ID_KEY, id)
@@ -94,7 +117,7 @@ export function useDeviceToken() {
   function clearKioskCredential(): void {
     kioskDeviceId.value = null
     kioskDeviceSecret.value = null
-    cachedJwt = null
+    cachedJwt.value = null
     cachedExpMs = 0
     if (isClient) {
       localStorage.removeItem(KIOSK_DEVICE_ID_KEY)
@@ -103,13 +126,13 @@ export function useDeviceToken() {
   }
 
   /**
-   * device JWT を返す。優先順位は cache → 警告デバイス (VoiceS3R) の署名 (#231) →
+   * device JWT を返す。優先順位は cache → CoreS3 の署名 (#234-2) →
    * 既存 credential (`/device/token`)。全経路失敗時は null (呼び出し側は X-Tenant-ID
    * 経路に fallback)。同時呼び出しは 1 本にまとめる (`jwtInFlight`)。
    */
   async function getDeviceJwt(): Promise<string | null> {
     const nowMs = Date.now()
-    if (cachedJwt && cachedExpMs - REFRESH_BEFORE_MS > nowMs) return cachedJwt
+    if (cachedJwt.value && cachedExpMs - REFRESH_BEFORE_MS > nowMs) return cachedJwt.value
 
     if (!jwtInFlight) {
       jwtInFlight = mintDeviceJwt().finally(() => { jwtInFlight = null })
@@ -117,30 +140,32 @@ export function useDeviceToken() {
     return jwtInFlight
   }
 
-  /** cache 以外の 2 経路を順に試す (警告デバイスの署名 → credential)。 */
+  /** cache 以外の 2 経路を順に試す (CoreS3 の署名 → credential)。 */
   async function mintDeviceJwt(): Promise<string | null> {
     const nowMs = Date.now()
-    return (await tryAlarmDeviceJwt(nowMs)) ?? (await tryCredentialJwt(nowMs))
+    return (await tryCoreS3Jwt(nowMs)) ?? (await tryCredentialJwt(nowMs))
   }
 
   /**
-   * 警告デバイスが USB で繋がっていれば、その ed25519 鍵の署名で auth-worker
+   * CoreS3 が USB で繋がっていれば、その ed25519 鍵の署名で auth-worker
    * (#552) から短命 JWT を取りに行く。未接続 / 抑止期間中 / いずれかの失敗
    * (401 `{error:"invalid_alarm_token"}` / 429 / タイムアウト / 通信エラー、
-   * いずれも HTTP status だけで判定する) なら null を返し、S3R_BACKOFF_MS の
-   * 間この経路を抑止する (再接続での解除はしない)。
+   * いずれも HTTP status だけで判定する) なら null を返し、CORE_S3_BACKOFF_MS の
+   * 間この経路を抑止する (再接続での解除はしない)。失敗理由は `lastError` に残し、
+   * 成功したら null に戻す。
    */
-  async function tryAlarmDeviceJwt(nowMs: number): Promise<string | null> {
-    if (nowMs < s3rBackoffUntilMs) return null
-    if (!useAlarmDevice().isConnected.value) return null
+  async function tryCoreS3Jwt(nowMs: number): Promise<string | null> {
+    if (nowMs < coreS3BackoffUntilMs) return null
+    if (!coreS3.isConnected.value) return null
 
+    lastError.value = null
     try {
       const nonceRes = await fetch(`${authWorkerUrl}/device/alarm-nonce`)
       if (!nonceRes.ok) throw new Error(`alarm-nonce http ${nonceRes.status}`)
       const nonceData = (await nonceRes.json()) as { nonce?: string }
       if (!nonceData.nonce) throw new Error('alarm-nonce: nonce 欠落')
 
-      const signed = await signAlarmDeviceNonce(nonceData.nonce)
+      const signed = await signAlarmDeviceNonce(nonceData.nonce, coreS3.request)
       if (!signed) throw new Error('AUTH SIG の parse に失敗')
 
       const tokenRes = await fetch(`${authWorkerUrl}/device/alarm-token`, {
@@ -164,13 +189,14 @@ export function useDeviceToken() {
         )
       }
 
-      const ttl = typeof tokenData.expires_in === 'number' ? tokenData.expires_in : ALARM_DEFAULT_TTL_SECONDS
-      cachedJwt = tokenData.access_token
+      const ttl = typeof tokenData.expires_in === 'number' ? tokenData.expires_in : CORE_S3_DEFAULT_TTL_SECONDS
+      cachedJwt.value = tokenData.access_token
       cachedExpMs = nowMs + ttl * 1000
-      return cachedJwt
+      return cachedJwt.value
     }
-    catch {
-      s3rBackoffUntilMs = nowMs + S3R_BACKOFF_MS
+    catch (e) {
+      lastError.value = e instanceof Error ? e.message : String(e)
+      coreS3BackoffUntilMs = nowMs + CORE_S3_BACKOFF_MS
       return null
     }
   }
@@ -191,9 +217,9 @@ export function useDeviceToken() {
       const data = (await res.json()) as { access_token?: string; expires_in?: number }
       if (!data.access_token) return null
       const ttl = typeof data.expires_in === 'number' ? data.expires_in : DEFAULT_TTL_SECONDS
-      cachedJwt = data.access_token
+      cachedJwt.value = data.access_token
       cachedExpMs = nowMs + ttl * 1000
-      return cachedJwt
+      return cachedJwt.value
     } catch {
       return null
     }
@@ -246,11 +272,14 @@ export function useDeviceToken() {
 
   return {
     hasKioskCredential,
+    hasDeviceJwt,
     kioskDeviceId: readonly(kioskDeviceId),
     storeKioskCredential,
     clearKioskCredential,
     getDeviceJwt,
     pairKioskDevice,
     setupAsKiosk,
+    /** CoreS3 署名経路の直近の失敗理由。成功 / 未試行なら null */
+    lastError: readonly(lastError),
   }
 }

--- a/web/app/composables/useHubClaim.ts
+++ b/web/app/composables/useHubClaim.ts
@@ -1,106 +1,28 @@
 /**
- * CoreS3 が USB で繋がっていれば、管理者ログイン無しで自動的に端末登録する (#213)。
+ * CoreS3 が USB で繋がったら、短命端末 JWT (#234-2 の CoreS3 署名) を 1 回先取りする。
  *
- * 運行者タブの `TimePunchKiosk` は端末登録 (device-kiosk credential、`useDeviceToken`)
- * が無いと打刻一覧が空になる。端末登録 (`device-claim.vue`) には本来、管理者の Google
- * ログインが要るが、CoreS3 が USB で繋がっている PC はそれ自体が「その場に居る」証拠に
- * なるので、firmware 経由で 1 回限りの登録トークンを取り、無人で端末登録まで済ませる。
+ * かつては CoreS3 の `AUTH TICKET` → `/device/pair/token` で永続 credential を発行し、
+ * 管理者ログイン無しで端末登録まで済ませていた (#213)。だが応答が alc.ippoan.org から
+ * 読めずブラウザで一度も成功していなかったため撤去した。CoreS3 が USB で繋がっている
+ * あいだは `useDeviceToken` の署名先が CoreS3 に切り替わっており (#234-2)、
+ * `getDeviceJwt()` を呼べば nonce 取得・署名・mint まで自力で完結する。ここは
+ * 「繋がったら 1 回呼んでおく」だけの先取りに縮小した (isDeviceActivated には無関係に動く)。
  *
- * プロトコル (firmware は ippoan/alc-app-s3#204、auth-worker は ippoan/auth-worker#519):
- *   host → dev  `AUTH TICKET`
- *   dev  → host `AUTH TICKET <ticket> EXPIRES=<秒>`  … 成功
- *   dev  → host `ERR AUTH TICKET: <理由>`            … 失敗
- * ticket を既存の `POST <authWorkerUrl>/device/pair/token` (body `{device_code}`) に
- * 渡すと `{device_id, device_secret, tenant_id, label}` が 1 回だけ返る。
- *
- * 保存は **device-claim.vue と同じ漏斗** (`useAuth().activateFromRegistration`) を使う —
- * kiosk credential の保存経路をここで新設しない。`device_id`/`device_secret` は
- * auth-worker の device-kiosk credential (`auth_device_id`/`device_secret` として渡す)。
- * rust-alc-api 側の device 行 id は CoreS3 auto-claim には無いので渡さない
- * (`activateDevice` の `devId` は省略可)。
- *
- * ここは CoreS3 の接続を自分で確立しない — `register`/`unregister` は呼ばない。
- * NFC (`useNfcReader`) 側が unregister すると BLE ゲートウェイ (体温計・血圧計) まで
- * 切れる実害があったため、既存の接続状態 (`useCoreS3Serial().isConnected`) と
- * 書き込み口 (`request`) だけを使う (Refs ippoan/alc-app#182)。
+ * ファイル名と戻り値の形 `{ lastError, attemptClaim }` は据え置く
+ * (`TimePunchKiosk.vue` が `useHubClaim().lastError` を参照するため)。
+ * `lastError` は useDeviceToken のもの (CoreS3 署名経路の失敗理由) をそのまま返す。
  */
-import { autoClaimFailedMessage } from '~/utils/employee-lookup-messages'
 
-/** firmware の `AUTH TICKET` 応答を待つ上限 (USB 記述子どおり 10 秒、契約は issue #213 参照) */
-const TICKET_TIMEOUT_MS = 10_000
-const TICKET_COMMAND = 'AUTH TICKET'
-const TICKET_MATCH_PREFIX = 'AUTH TICKET '
-
-/** `AUTH TICKET <ticket> EXPIRES=<秒>` を解く。マッチしなければ null */
-function parseTicketLine(line: string): { ticket: string } | null {
-  const ticket = line.match(/^AUTH TICKET (\S+) EXPIRES=\d+$/)?.[1]
-  return ticket ? { ticket } : null
-}
-
-/** 直近の失敗理由 (画面表示用)。成功 / 未実行なら null */
-const lastError = ref<string | null>(null)
-/** 二重起動防止 (同時に 1 回だけ) */
-let claiming = false
-/** CoreS3 の再接続ごとに 1 回だけ試すための onOpen 登録 (module 内で 1 度だけ) */
+/** CoreS3 の接続 (再接続含む) のたびに 1 回試すための onOpen 登録 (module 内で 1 度だけ) */
 let listenerInstalled = false
 
 export function useHubClaim() {
-  const { isDeviceActivated, activateFromRegistration } = useAuth()
+  const { getDeviceJwt, lastError } = useDeviceToken()
   const coreS3 = useCoreS3Serial()
-  const config = useRuntimeConfig()
 
-  /**
-   * `!isDeviceActivated && coreS3.isConnected` の条件が揃った瞬間に呼ばれる想定。
-   * 既に端末登録済み、または同時実行中なら何もしない。
-   */
+  /** CoreS3 接続中に device JWT を先取りする (getDeviceJwt 自体が single-flight/cache を持つ) */
   async function attemptClaim(): Promise<void> {
-    if (claiming) return
-    if (isDeviceActivated.value) return
-    if (!coreS3.isConnected.value) return
-
-    claiming = true
-    lastError.value = null
-    try {
-      const line = await coreS3.request(TICKET_COMMAND, TICKET_MATCH_PREFIX, TICKET_TIMEOUT_MS)
-      const parsed = parseTicketLine(line)
-      if (!parsed) {
-        lastError.value = autoClaimFailedMessage(`予期しない応答: ${line}`)
-        return
-      }
-
-      // nuxt.config.ts が public.authWorkerUrl に既定値を持つので、ここでの fallback は
-      // 不要 (useAuth.ts の authWorkerUrl 参照と同じ流儀 — 到達不能な分岐を作らない)
-      const authWorkerUrl = (config.public.authWorkerUrl as string).replace(/\/$/, '')
-      const res = await fetch(`${authWorkerUrl}/device/pair/token`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ device_code: parsed.ticket }),
-      })
-      if (!res.ok) {
-        lastError.value = autoClaimFailedMessage(`http ${res.status}`)
-        return
-      }
-
-      const data = await res.json() as { device_id?: string, device_secret?: string, tenant_id?: string }
-      if (!data.tenant_id || !data.device_id || !data.device_secret) {
-        lastError.value = autoClaimFailedMessage('応答が不完全です')
-        return
-      }
-
-      // device-claim.vue と同じ漏斗。auth_device_id/device_secret が kiosk credential
-      activateFromRegistration({
-        tenant_id: data.tenant_id,
-        auth_device_id: data.device_id,
-        device_secret: data.device_secret,
-      })
-    }
-    catch (e) {
-      // request() の ERR/タイムアウト、または fetch の通信エラー
-      lastError.value = autoClaimFailedMessage(e instanceof Error ? e.message : String(e))
-    }
-    finally {
-      claiming = false
-    }
+    await getDeviceJwt()
   }
 
   // CoreS3 の接続 (再接続含む) のたびに 1 回試す。listenerInstalled で二重登録を避ける
@@ -111,8 +33,7 @@ export function useHubClaim() {
   }
 
   return {
-    /** 直近の失敗理由。成功 / 未実行なら null */
-    lastError: readonly(lastError),
+    lastError,
     attemptClaim,
   }
 }

--- a/web/app/utils/employee-lookup-messages.ts
+++ b/web/app/utils/employee-lookup-messages.ts
@@ -22,10 +22,14 @@ export function noPendingSchedule(): string {
 export const deviceUnregisteredMessage = 'この端末は登録されていません (ペアリングが必要です)'
 
 /**
- * CoreS3 経由の自動端末登録 (#213) が失敗したとき。理由 (AUTH TICKET の ERR / タイムアウト /
- * auth-worker の HTTP エラー) を添えて、現地の人が次の一手 (管理者に連絡する等) を選べるように
- * する。文言だけを出す — 端末登録は依然として管理者の Google ログイン (device-claim) で可能
+ * CoreS3 経由の短命端末 JWT 取得 (#234-2、`useDeviceToken` の署名経路) が失敗したとき。
+ * firmware が `ERR AUTH: no key` (CoreS3 に鍵が登録されていない) を返したときは、
+ * 管理者が鍵を登録する場所を明示する。それ以外の理由 (タイムアウト / auth-worker の
+ * HTTP エラー等) はそのまま添えるだけ — 現地の人が次の一手を選べるようにする
  */
 export function autoClaimFailedMessage(reason: string): string {
-  return `CoreS3 経由の端末登録に失敗しました: ${reason}`
+  if (reason.includes('no key')) {
+    return `CoreS3 の鍵が未登録です。管理者が auth.ippoan.org/device/setup で登録してください (${reason})`
+  }
+  return `CoreS3 経由の端末認証に失敗しました: ${reason}`
 }

--- a/web/tests/composables/useDeviceLogin.test.ts
+++ b/web/tests/composables/useDeviceLogin.test.ts
@@ -271,5 +271,15 @@ describe('useDeviceLogin', () => {
       // フェイクタイマーを使わず (= 10 秒のタイムアウトを一切待たず) 即座に reject する
       await expect(signAlarmDeviceNonce('nonce-xyz')).rejects.toThrow('ERR AUTH: no key')
     })
+
+    it('request を明示指定すればそちら宛てに送る (#234-2、useDeviceToken.ts が CoreS3 の request を渡す想定)', async () => {
+      const customRequest = vi.fn().mockResolvedValue('AUTH SIG pub-7 sig-7')
+      const { signAlarmDeviceNonce } = await import('~/composables/useDeviceLogin')
+
+      await expect(signAlarmDeviceNonce('nonce-xyz', customRequest)).resolves.toEqual({ pubkey: 'pub-7', sig: 'sig-7' })
+      expect(customRequest).toHaveBeenCalledWith('AUTH SIGN nonce-xyz', 'AUTH SIG ', 10_000)
+      // 警告デバイス (既定値) には送らない
+      expect(alarmDeviceMock.request).not.toHaveBeenCalled()
+    })
   })
 })

--- a/web/tests/composables/useDeviceToken.test.ts
+++ b/web/tests/composables/useDeviceToken.test.ts
@@ -13,11 +13,21 @@ async function load(): Promise<Mod['useDeviceToken']> {
 const ID = 'dev-abc'
 const SECRET = 'sec-xyz'
 
-// 警告デバイス (VoiceS3R) の署名経路 (#231) 用のモック。
-// useAlarmDevice / useAuth は Nuxt auto-import なので mockNuxtImport、
+// CoreS3 の署名経路 (#234-2、旧 #231 は警告デバイス宛てだった) 用のモック。
+// useCoreS3Serial / useAuth は Nuxt auto-import なので mockNuxtImport、
 // signAlarmDeviceNonce は useDeviceToken.ts が明示 import するので vi.mock で差し替える。
-const alarmDeviceMock = vi.hoisted(() => ({ isConnected: { value: false } }))
-mockNuxtImport('useAlarmDevice', () => () => alarmDeviceMock)
+const coreS3Mock = vi.hoisted(() => ({
+  isConnected: { value: false },
+  request: vi.fn(),
+  onClose: vi.fn(),
+}))
+mockNuxtImport('useCoreS3Serial', () => () => coreS3Mock)
+
+// 警告デバイス (VoiceS3R) には AUTH SIGN を送らないことを確かめるための spy。
+// useDeviceToken.ts は #234-2 で useAlarmDevice への依存を消したので、これが
+// 呼ばれることは無いはず
+const alarmDeviceRequestMock = vi.hoisted(() => vi.fn())
+mockNuxtImport('useAlarmDevice', () => () => ({ isConnected: { value: false }, request: alarmDeviceRequestMock }))
 
 const authMock = vi.hoisted(() => ({ deviceTenantId: { value: null as string | null } }))
 mockNuxtImport('useAuth', () => () => authMock)
@@ -32,7 +42,9 @@ beforeEach(() => {
   vi.restoreAllMocks()
   vi.resetModules()
   localStorage.clear()
-  alarmDeviceMock.isConnected.value = false
+  coreS3Mock.isConnected.value = false
+  coreS3Mock.request.mockReset()
+  coreS3Mock.onClose.mockReset()
   authMock.deviceTenantId.value = null
   signAlarmDeviceNonceMock.mockReset()
 })
@@ -234,7 +246,7 @@ describe('useDeviceToken (#434 step 3c)', () => {
     })
   })
 
-  describe('getDeviceJwt: 警告デバイス (VoiceS3R) の署名による短命端末 JWT (#231)', () => {
+  describe('getDeviceJwt: CoreS3 の署名による短命端末 JWT (#234-2、旧 #231 は警告デバイス宛てだった)', () => {
     /** URL の末尾 (パス) で振り分ける fetch mock。想定外の URL は throw して見逃しを防ぐ。 */
     function routeFetch(handlers: Record<string, () => { ok: boolean, status?: number, json: () => Promise<unknown> }>) {
       return vi.fn((url: string) => {
@@ -245,8 +257,8 @@ describe('useDeviceToken (#434 step 3c)', () => {
       })
     }
 
-    it('警告デバイス接続中なら credential より優先し、alarm-nonce → AUTH SIGN → alarm-token で取って cache する', async () => {
-      alarmDeviceMock.isConnected.value = true
+    it('CoreS3 接続中なら credential より優先し、alarm-nonce → AUTH SIGN → alarm-token で取って cache する (CoreS3.request 宛てに送る)', async () => {
+      coreS3Mock.isConnected.value = true
       signAlarmDeviceNonceMock.mockResolvedValue({ pubkey: 'pub-1', sig: 'sig-1' })
       const fetchMock = routeFetch({
         '/device/alarm-nonce': () => ({ ok: true, json: () => Promise.resolve({ nonce: 'n1', expires_in: 60 }) }),
@@ -259,12 +271,14 @@ describe('useDeviceToken (#434 step 3c)', () => {
       storeKioskCredential(ID, SECRET) // credential も持っているが使われないはず
 
       expect(await getDeviceJwt()).toBe('s3r-jwt')
-      expect(signAlarmDeviceNonceMock).toHaveBeenCalledWith('n1')
+      expect(signAlarmDeviceNonceMock).toHaveBeenCalledWith('n1', coreS3Mock.request)
       expect(fetchMock.mock.calls.some(([u]) => (u as string).includes('/device/token'))).toBe(false)
+      // 警告デバイス (VoiceS3R) には送らない
+      expect(alarmDeviceRequestMock).not.toHaveBeenCalled()
     })
 
     it('S3R の JWT は既存キャッシュに載り、期限前は再利用する (再 fetch しない)', async () => {
-      alarmDeviceMock.isConnected.value = true
+      coreS3Mock.isConnected.value = true
       signAlarmDeviceNonceMock.mockResolvedValue({ pubkey: 'pub-1', sig: 'sig-1' })
       const fetchMock = routeFetch({
         '/device/alarm-nonce': () => ({ ok: true, json: () => Promise.resolve({ nonce: 'n1', expires_in: 60 }) }),
@@ -282,7 +296,7 @@ describe('useDeviceToken (#434 step 3c)', () => {
     })
 
     it('single-flight: 同時 3 回呼んでも nonce の取得は 1 回だけ', async () => {
-      alarmDeviceMock.isConnected.value = true
+      coreS3Mock.isConnected.value = true
       signAlarmDeviceNonceMock.mockResolvedValue({ pubkey: 'pub-1', sig: 'sig-1' })
       let nonceCalls = 0
       const fetchMock = vi.fn((url: string) => {
@@ -305,8 +319,8 @@ describe('useDeviceToken (#434 step 3c)', () => {
       expect(nonceCalls).toBe(1)
     })
 
-    it('警告デバイス未接続なら nonce を呼ばず、既存の credential 経路だけを試す', async () => {
-      alarmDeviceMock.isConnected.value = false
+    it('CoreS3 未接続なら nonce を呼ばず、既存の credential 経路だけを試す', async () => {
+      coreS3Mock.isConnected.value = false
       const fetchMock = routeFetch({
         '/device/token': () => ({ ok: true, json: () => Promise.resolve({ access_token: 'cred-jwt', expires_in: 3600 }) }),
       })
@@ -322,7 +336,7 @@ describe('useDeviceToken (#434 step 3c)', () => {
     })
 
     it('S3R が 401/429 で失敗すれば null に落ちて credential 経路を試す', async () => {
-      alarmDeviceMock.isConnected.value = true
+      coreS3Mock.isConnected.value = true
       const fetchMock = routeFetch({
         '/device/alarm-nonce': () => ({ ok: false, status: 429, json: () => Promise.resolve({}) }),
         '/device/token': () => ({ ok: true, json: () => Promise.resolve({ access_token: 'cred-jwt', expires_in: 3600 }) }),
@@ -337,8 +351,8 @@ describe('useDeviceToken (#434 step 3c)', () => {
       expect(signAlarmDeviceNonceMock).not.toHaveBeenCalled()
     })
 
-    it('AUTH SIGN が (ERR AUTH: 等で) reject しても catch して null に落ちる (credential 未保存なら null)', async () => {
-      alarmDeviceMock.isConnected.value = true
+    it('AUTH SIGN が ERR AUTH: no key で reject すると即失敗し (タイムアウトを待たない) lastError に理由を残す (credential 未保存なら null)', async () => {
+      coreS3Mock.isConnected.value = true
       const fetchMock = routeFetch({
         '/device/alarm-nonce': () => ({ ok: true, json: () => Promise.resolve({ nonce: 'n1', expires_in: 60 }) }),
       })
@@ -346,13 +360,14 @@ describe('useDeviceToken (#434 step 3c)', () => {
       signAlarmDeviceNonceMock.mockRejectedValue(new Error('ERR AUTH: no key'))
 
       const useDeviceToken = await load()
-      const { getDeviceJwt } = useDeviceToken()
+      const { getDeviceJwt, lastError } = useDeviceToken()
 
       expect(await getDeviceJwt()).toBeNull()
+      expect(lastError.value).toContain('ERR AUTH: no key')
     })
 
     it('alarm-nonce の応答に nonce が無ければ null に落ちる', async () => {
-      alarmDeviceMock.isConnected.value = true
+      coreS3Mock.isConnected.value = true
       const fetchMock = routeFetch({
         '/device/alarm-nonce': () => ({ ok: true, json: () => Promise.resolve({ expires_in: 60 }) }),
       })
@@ -366,7 +381,7 @@ describe('useDeviceToken (#434 step 3c)', () => {
     })
 
     it('AUTH SIG の parse に失敗 (signAlarmDeviceNonce が null を返す) は null に落ちる', async () => {
-      alarmDeviceMock.isConnected.value = true
+      coreS3Mock.isConnected.value = true
       signAlarmDeviceNonceMock.mockResolvedValue(null)
       const fetchMock = routeFetch({
         '/device/alarm-nonce': () => ({ ok: true, json: () => Promise.resolve({ nonce: 'n1', expires_in: 60 }) }),
@@ -380,7 +395,7 @@ describe('useDeviceToken (#434 step 3c)', () => {
     })
 
     it('alarm-token が 401 {error:"invalid_alarm_token"} なら (body を見ず status だけで) null に落ちる (nonce 取得・署名は成功していても)', async () => {
-      alarmDeviceMock.isConnected.value = true
+      coreS3Mock.isConnected.value = true
       signAlarmDeviceNonceMock.mockResolvedValue({ pubkey: 'pub-1', sig: 'sig-1' })
       const fetchMock = routeFetch({
         '/device/alarm-nonce': () => ({ ok: true, json: () => Promise.resolve({ nonce: 'n1', expires_in: 60 }) }),
@@ -395,7 +410,7 @@ describe('useDeviceToken (#434 step 3c)', () => {
     })
 
     it('alarm-token の応答に access_token が無ければ null に落ちる', async () => {
-      alarmDeviceMock.isConnected.value = true
+      coreS3Mock.isConnected.value = true
       signAlarmDeviceNonceMock.mockResolvedValue({ pubkey: 'pub-1', sig: 'sig-1' })
       const fetchMock = routeFetch({
         '/device/alarm-nonce': () => ({ ok: true, json: () => Promise.resolve({ nonce: 'n1', expires_in: 60 }) }),
@@ -410,7 +425,7 @@ describe('useDeviceToken (#434 step 3c)', () => {
     })
 
     it('alarm-token の expires_in 欠落時は fallback TTL (900 秒) で cache する', async () => {
-      alarmDeviceMock.isConnected.value = true
+      coreS3Mock.isConnected.value = true
       signAlarmDeviceNonceMock.mockResolvedValue({ pubkey: 'pub-1', sig: 'sig-1' })
       const fetchMock = routeFetch({
         '/device/alarm-nonce': () => ({ ok: true, json: () => Promise.resolve({ nonce: 'n1', expires_in: 60 }) }),
@@ -427,7 +442,7 @@ describe('useDeviceToken (#434 step 3c)', () => {
     })
 
     it('alarm-token の応答に tenant_id が無ければ warn しない', async () => {
-      alarmDeviceMock.isConnected.value = true
+      coreS3Mock.isConnected.value = true
       authMock.deviceTenantId.value = 'tenant-A'
       signAlarmDeviceNonceMock.mockResolvedValue({ pubkey: 'pub-1', sig: 'sig-1' })
       const fetchMock = routeFetch({
@@ -444,8 +459,8 @@ describe('useDeviceToken (#434 step 3c)', () => {
       expect(warnSpy).not.toHaveBeenCalled()
     })
 
-    it('S3R 失敗後 60 秒は nonce を呼ばず (credential 無しなら null)、61 秒後は再試行する', async () => {
-      alarmDeviceMock.isConnected.value = true
+    it('S3R 失敗後 60 秒は nonce を呼ばず (credential 無しなら null、lastError は保持)、61 秒後は再試行する', async () => {
+      coreS3Mock.isConnected.value = true
       let nowMs = 1_000_000
       vi.spyOn(Date, 'now').mockImplementation(() => nowMs)
 
@@ -453,14 +468,16 @@ describe('useDeviceToken (#434 step 3c)', () => {
       vi.stubGlobal('fetch', nonceMock)
 
       const useDeviceToken = await load()
-      const { getDeviceJwt } = useDeviceToken()
+      const { getDeviceJwt, lastError } = useDeviceToken()
 
       expect(await getDeviceJwt()).toBeNull()
       expect(nonceMock).toHaveBeenCalledTimes(1)
+      expect(lastError.value).toContain('alarm-nonce')
 
       nowMs += 59_000 // 59 秒後: まだ抑止期間中
       expect(await getDeviceJwt()).toBeNull()
       expect(nonceMock).toHaveBeenCalledTimes(1)
+      expect(lastError.value).toContain('alarm-nonce') // 抑止中は理由を保持したまま
 
       nowMs += 2_000 // 61 秒後: 抑止解除、再試行する
       expect(await getDeviceJwt()).toBeNull()
@@ -468,7 +485,7 @@ describe('useDeviceToken (#434 step 3c)', () => {
     })
 
     it('alarm-token 応答の tenant_id が deviceTenantId と食い違っても拒否せず warn だけ (#552)', async () => {
-      alarmDeviceMock.isConnected.value = true
+      coreS3Mock.isConnected.value = true
       authMock.deviceTenantId.value = 'tenant-A'
       signAlarmDeviceNonceMock.mockResolvedValue({ pubkey: 'pub-1', sig: 'sig-1' })
 
@@ -490,7 +507,7 @@ describe('useDeviceToken (#434 step 3c)', () => {
     })
 
     it('S3R 経路は localStorage / sessionStorage に一切書かない', async () => {
-      alarmDeviceMock.isConnected.value = true
+      coreS3Mock.isConnected.value = true
       signAlarmDeviceNonceMock.mockResolvedValue({ pubkey: 'pub-1', sig: 'sig-1' })
       const fetchMock = routeFetch({
         '/device/alarm-nonce': () => ({ ok: true, json: () => Promise.resolve({ nonce: 'n1', expires_in: 60 }) }),
@@ -504,6 +521,107 @@ describe('useDeviceToken (#434 step 3c)', () => {
 
       expect(await getDeviceJwt()).toBe('s3r-jwt')
       expect(setItemSpy).not.toHaveBeenCalled()
+    })
+
+    it('成功すると lastError が null に戻る (前回失敗が残っていても)', async () => {
+      coreS3Mock.isConnected.value = true
+      signAlarmDeviceNonceMock.mockRejectedValueOnce(new Error('ERR AUTH: no key'))
+      let nowMs = 1_000_000
+      vi.spyOn(Date, 'now').mockImplementation(() => nowMs)
+      const fetchMock = routeFetch({
+        '/device/alarm-nonce': () => ({ ok: true, json: () => Promise.resolve({ nonce: 'n1', expires_in: 60 }) }),
+        '/device/alarm-token': () => ({ ok: true, json: () => Promise.resolve({ access_token: 's3r-jwt', expires_in: 900 }) }),
+      })
+      vi.stubGlobal('fetch', fetchMock)
+
+      const useDeviceToken = await load()
+      const { getDeviceJwt, lastError } = useDeviceToken()
+
+      expect(await getDeviceJwt()).toBeNull()
+      expect(lastError.value).toContain('no key')
+
+      signAlarmDeviceNonceMock.mockResolvedValue({ pubkey: 'pub-1', sig: 'sig-1' })
+      nowMs += 61_000 // 抑止解除
+
+      expect(await getDeviceJwt()).toBe('s3r-jwt')
+      expect(lastError.value).toBeNull()
+    })
+  })
+
+  describe('hasDeviceJwt (#234-2、兄弟 #p135-c234-3 が使う)', () => {
+    it('未取得なら false', async () => {
+      const useDeviceToken = await load()
+      expect(useDeviceToken().hasDeviceJwt.value).toBe(false)
+    })
+
+    it('取得直後、期限内は true', async () => {
+      coreS3Mock.isConnected.value = true
+      signAlarmDeviceNonceMock.mockResolvedValue({ pubkey: 'pub-1', sig: 'sig-1' })
+      vi.stubGlobal('fetch', vi.fn((url: string) => {
+        if (url.endsWith('/device/alarm-nonce')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ nonce: 'n1' }) })
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ access_token: 's3r-jwt', expires_in: 900 }) })
+      }))
+
+      const useDeviceToken = await load()
+      const { getDeviceJwt, hasDeviceJwt } = useDeviceToken()
+
+      expect(hasDeviceJwt.value).toBe(false)
+      expect(await getDeviceJwt()).toBe('s3r-jwt')
+      expect(hasDeviceJwt.value).toBe(true)
+    })
+
+    it('clearKioskCredential で cache ごと破棄されれば false に戻る', async () => {
+      coreS3Mock.isConnected.value = true
+      signAlarmDeviceNonceMock.mockResolvedValue({ pubkey: 'pub-1', sig: 'sig-1' })
+      vi.stubGlobal('fetch', vi.fn((url: string) => {
+        if (url.endsWith('/device/alarm-nonce')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ nonce: 'n1' }) })
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ access_token: 's3r-jwt', expires_in: 900 }) })
+      }))
+
+      const useDeviceToken = await load()
+      const { getDeviceJwt, hasDeviceJwt, clearKioskCredential } = useDeviceToken()
+
+      expect(await getDeviceJwt()).toBe('s3r-jwt')
+      expect(hasDeviceJwt.value).toBe(true)
+
+      clearKioskCredential()
+      expect(hasDeviceJwt.value).toBe(false)
+    })
+  })
+
+  describe('CoreS3 の onClose でキャッシュを破棄する (#234-2、親の決定)', () => {
+    it('CoreS3 が閉じたら cachedJwt を破棄し、次の getDeviceJwt は再取得する', async () => {
+      coreS3Mock.isConnected.value = true
+      signAlarmDeviceNonceMock.mockResolvedValue({ pubkey: 'pub-1', sig: 'sig-1' })
+      const fetchMock = vi.fn((url: string) => {
+        if (url.endsWith('/device/alarm-nonce')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ nonce: 'n1' }) })
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ access_token: 's3r-jwt', expires_in: 900 }) })
+      })
+      vi.stubGlobal('fetch', fetchMock)
+
+      const useDeviceToken = await load()
+      const { getDeviceJwt, hasDeviceJwt } = useDeviceToken()
+
+      expect(await getDeviceJwt()).toBe('s3r-jwt')
+      expect(hasDeviceJwt.value).toBe(true)
+      expect(coreS3Mock.onClose).toHaveBeenCalledTimes(1)
+
+      // CoreS3 の close ハンドラを発火させる (抜線を模す)
+      const closeCb = coreS3Mock.onClose.mock.calls[0]![0] as () => void
+      closeCb()
+
+      expect(hasDeviceJwt.value).toBe(false)
+      expect(await getDeviceJwt()).toBe('s3r-jwt') // 再取得できる
+      expect(fetchMock).toHaveBeenCalledTimes(4) // 2 (最初) + 2 (再取得)
+    })
+
+    it('useDeviceToken() を複数回呼んでも onClose の登録は 1 回だけ', async () => {
+      const useDeviceToken = await load()
+      useDeviceToken()
+      useDeviceToken()
+      useDeviceToken()
+
+      expect(coreS3Mock.onClose).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/web/tests/composables/useHubClaim.test.ts
+++ b/web/tests/composables/useHubClaim.test.ts
@@ -1,288 +1,88 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mockNuxtImport } from '@nuxt/test-utils/runtime'
 
 /**
- * useHubClaim (#213 CoreS3 経由の自動端末登録) のテスト。
+ * useHubClaim (#234-2 で CoreS3 の JWT 先取りに縮小) のテスト。
  *
- * useCoreS3Serial / useSerialArbiter は実体を使う (mock しない) — CoreS3 の
- * 接続そのものは useCoreS3Serial.test.ts / useSerialArbiter.test.ts が担保済みなので、
- * ここでは「接続イベントを受けて何をするか」だけを見る。
- *
- * **navigator.serial は load() より前に installSerialMock で用意すること。**
- * `useCoreS3Serial()` (→ `useSerialArbiter()`) は呼ばれた瞬間に
- * `isWebSerialSupported()` を評価して `isSupported` に固定するため、後から
- * navigator.serial を生やしても遅い (useCoreS3Serial.test.ts と同じ制約)。
+ * 旧来の `AUTH TICKET` → `/device/pair/token` → `activateFromRegistration` の
+ * 経路は撤去済み (応答が alc.ippoan.org から読めず一度も成功していなかったため)。
+ * ここでは「CoreS3 の onOpen で `useDeviceToken().getDeviceJwt()` を 1 回呼ぶだけ」
+ * であること、`isDeviceActivated` / `useAuth` に一切触れないことだけを見る。
+ * useCoreS3Serial / useDeviceToken の実体は他のテストが担保済みなのでここでは mock する。
  */
 
-// --- Mock SerialPort (useCoreS3Serial.test.ts と同型) ---
-function createMockPort(options?: { vid?: number }) {
-  const queue: Array<{ value?: Uint8Array; done: boolean }> = []
-  let pending: ((chunk: { value?: Uint8Array; done: boolean }) => void) | null = null
+const coreS3Mock = vi.hoisted(() => ({ onOpen: vi.fn() }))
+mockNuxtImport('useCoreS3Serial', () => () => coreS3Mock)
 
-  const reader = {
-    read: vi.fn(() => {
-      const next = queue.shift()
-      if (next) return Promise.resolve(next)
-      return new Promise<{ value?: Uint8Array; done: boolean }>((resolve) => { pending = resolve })
-    }),
-    cancel: vi.fn(async () => {
-      if (pending) { pending({ value: undefined, done: true }); pending = null }
-    }),
-    releaseLock: vi.fn(),
-  }
+const deviceTokenMock = vi.hoisted(() => ({
+  getDeviceJwt: vi.fn(async () => 'jwt-1'),
+  lastError: { value: null as string | null },
+}))
+mockNuxtImport('useDeviceToken', () => () => deviceTokenMock)
 
-  function push(chunk: { value?: Uint8Array; done: boolean }) {
-    if (pending) { pending(chunk); pending = null }
-    else queue.push(chunk)
-  }
+// isDeviceActivated ガード / activateFromRegistration を撤去したことを、
+// useAuth 自体が一切呼ばれないことで確かめる
+const useAuthMock = vi.hoisted(() => vi.fn(() => ({
+  isDeviceActivated: { value: false },
+  activateFromRegistration: vi.fn(),
+})))
+mockNuxtImport('useAuth', () => useAuthMock)
 
-  const writes: string[] = []
-  const writer = {
-    write: vi.fn(async (data: Uint8Array) => { writes.push(new TextDecoder().decode(data)) }),
-    releaseLock: vi.fn(),
-  }
+beforeEach(() => {
+  vi.clearAllMocks()
+  vi.resetModules()
+  deviceTokenMock.lastError.value = null
+})
 
-  const port = {
-    open: vi.fn(async () => {}),
-    close: vi.fn(async () => {}),
-    readable: { getReader: vi.fn(() => reader) },
-    writable: { getWriter: vi.fn(() => writer) },
-    getInfo: vi.fn(() => ({ usbVendorId: options?.vid ?? 0x303A, usbProductId: 0x1001 })),
-  }
-
-  return { port, writes, emit: (text: string) => push({ value: new TextEncoder().encode(text), done: false }) }
-}
-
-function installSerialMock(getPorts: ReturnType<typeof vi.fn>) {
-  Object.defineProperty(navigator, 'serial', {
-    value: { requestPort: vi.fn(), getPorts },
-    configurable: true,
-    writable: true,
-  })
-}
-
-/** dev port を作り、CoreS3 として見つかるように navigator.serial へ仕込む (load() より前に呼ぶこと) */
-function prepareSerial() {
-  const dev = createMockPort()
-  installSerialMock(vi.fn(async () => [dev.port]))
-  return dev
+async function load() {
+  const mod = await import('~/composables/useHubClaim')
+  return mod.useHubClaim
 }
 
 describe('useHubClaim', () => {
-  let hubMod: typeof import('~/composables/useHubClaim')
-  let authMod: typeof import('~/composables/useAuth')
-  let coreMod: typeof import('~/composables/useCoreS3Serial')
-  let hub: ReturnType<typeof hubMod.useHubClaim>
-  let auth: ReturnType<typeof authMod.useAuth>
-  let core: ReturnType<typeof coreMod.useCoreS3Serial>
-  let fetchMock: ReturnType<typeof vi.fn>
+  it('CoreS3 の onOpen で getDeviceJwt を 1 回呼ぶ', async () => {
+    const useHubClaim = await load()
+    useHubClaim()
 
-  /** 3 つのモジュールを新しい singleton state で読み込む。navigator.serial は先に用意しておくこと */
-  async function load() {
-    vi.resetModules()
-    authMod = await import('~/composables/useAuth')
-    coreMod = await import('~/composables/useCoreS3Serial')
-    hubMod = await import('~/composables/useHubClaim')
-    auth = authMod.useAuth()
-    core = coreMod.useCoreS3Serial()
-    hub = hubMod.useHubClaim()
-  }
+    expect(coreS3Mock.onOpen).toHaveBeenCalledTimes(1)
+    const onOpenCb = coreS3Mock.onOpen.mock.calls[0]![0] as () => void
+    onOpenCb()
 
-  /** JSON ready 行を先着させて claim させる (onOpen が発火し、登録済みリスナーが attemptClaim を走らせる) */
-  async function claim(dev: ReturnType<typeof createMockPort>) {
-    dev.emit('{"type":"ready"}\n')
-    const p = core.connect(0)
-    await vi.advanceTimersByTimeAsync(0)
-    await p
-  }
-
-  beforeEach(() => {
-    vi.clearAllMocks()
-    localStorage.clear()
-    vi.useFakeTimers({ toFake: ['setTimeout', 'setInterval', 'clearTimeout', 'clearInterval', 'Date'] })
-    delete (navigator as any).serial
-    fetchMock = vi.fn()
-    vi.stubGlobal('fetch', fetchMock)
+    expect(deviceTokenMock.getDeviceJwt).toHaveBeenCalledTimes(1)
   })
 
-  afterEach(async () => {
-    await core?.disconnect()
-    delete (navigator as any).serial
-    vi.useRealTimers()
-    vi.unstubAllGlobals()
+  it('useHubClaim を複数回呼んでも onOpen の登録は 1 回だけ (二重登録しない)', async () => {
+    const useHubClaim = await load()
+    useHubClaim()
+    useHubClaim()
+    useHubClaim()
+
+    expect(coreS3Mock.onOpen).toHaveBeenCalledTimes(1)
   })
 
-  it('未登録 + CoreS3 接続 → AUTH TICKET → pair/token 成功で端末登録される (device-claim と同じ保存関数)', async () => {
-    const dev = prepareSerial()
-    await load()
-    expect(auth.isDeviceActivated.value).toBe(false)
+  it('attemptClaim は isDeviceActivated に関係なく毎回 getDeviceJwt を呼ぶ (guard を持たない)', async () => {
+    const useHubClaim = await load()
+    const { attemptClaim } = useHubClaim()
 
-    fetchMock.mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve({ device_id: 'dev-1', device_secret: 'sec-1', tenant_id: 'tenant-1', label: 'CoreS3' }),
-    })
+    await attemptClaim()
+    await attemptClaim()
 
-    await claim(dev)
-    await vi.advanceTimersByTimeAsync(0)
-    expect(dev.writes).toContain('AUTH TICKET\n')
-
-    dev.emit('AUTH TICKET tkt-xyz EXPIRES=300\n')
-    await vi.advanceTimersByTimeAsync(0)
-
-    expect(fetchMock).toHaveBeenCalledWith(
-      expect.stringContaining('/device/pair/token'),
-      expect.objectContaining({ method: 'POST', body: JSON.stringify({ device_code: 'tkt-xyz' }) }),
-    )
-    expect(auth.isDeviceActivated.value).toBe(true)
-    expect(localStorage.getItem('alc_kiosk_device_id')).toBe('dev-1')
-    expect(localStorage.getItem('alc_kiosk_device_secret')).toBe('sec-1')
-    expect(hub.lastError.value).toBeNull()
+    expect(deviceTokenMock.getDeviceJwt).toHaveBeenCalledTimes(2)
   })
 
-  it('既に端末登録済みなら CoreS3 が繋がっても何もしない (fetch しない)', async () => {
-    const dev = prepareSerial()
-    localStorage.setItem('alc_device_tenant_id', 'existing-tenant')
-    await load()
-    expect(auth.isDeviceActivated.value).toBe(true)
+  it('lastError は useDeviceToken のものをそのまま返す', async () => {
+    deviceTokenMock.lastError.value = 'CoreS3 sign failed'
+    const useHubClaim = await load()
+    const { lastError } = useHubClaim()
 
-    await claim(dev)
-    await vi.advanceTimersByTimeAsync(0)
-
-    expect(fetchMock).not.toHaveBeenCalled()
+    expect(lastError.value).toBe('CoreS3 sign failed')
   })
 
-  it('CoreS3 未接続なら attemptClaim は何もしない', async () => {
-    await load()
-    await hub.attemptClaim()
-    expect(fetchMock).not.toHaveBeenCalled()
-  })
+  it('useAuth (isDeviceActivated / activateFromRegistration) には一切触れない', async () => {
+    const useHubClaim = await load()
+    const { attemptClaim } = useHubClaim()
+    await attemptClaim()
 
-  it('同時に 2 回走らせても 1 回しか実行しない (claiming ガード)', async () => {
-    const dev = prepareSerial()
-    await load()
-    fetchMock.mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve({ device_id: 'dev-1', device_secret: 'sec-1', tenant_id: 'tenant-1' }),
-    })
-    await claim(dev)
-    await vi.advanceTimersByTimeAsync(0)
-
-    // 1 本目の request() が pending (ticket 未応答) のうちにもう一度呼ぶ
-    void hub.attemptClaim()
-    await vi.advanceTimersByTimeAsync(0)
-
-    // AUTH TICKET は 1 回しか送られない
-    expect(dev.writes.filter(w => w === 'AUTH TICKET\n')).toHaveLength(1)
-  })
-
-  it('リスナーは二重登録されない (useHubClaim を複数回呼んでも接続ごとに 1 回)', async () => {
-    const dev = prepareSerial()
-    await load()
-    hubMod.useHubClaim()
-    hubMod.useHubClaim()
-    fetchMock.mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve({ device_id: 'dev-1', device_secret: 'sec-1', tenant_id: 'tenant-1' }),
-    })
-
-    await claim(dev)
-    await vi.advanceTimersByTimeAsync(0)
-
-    expect(dev.writes.filter(w => w === 'AUTH TICKET\n')).toHaveLength(1)
-  })
-
-  it('AUTH TICKET の応答が予期しない形なら lastError に出す', async () => {
-    const dev = prepareSerial()
-    await load()
-    await claim(dev)
-    await vi.advanceTimersByTimeAsync(0)
-
-    dev.emit('AUTH TICKET malformed\n')
-    await vi.advanceTimersByTimeAsync(0)
-
-    expect(hub.lastError.value).toContain('CoreS3')
-    expect(hub.lastError.value).toContain('予期しない応答')
-    expect(fetchMock).not.toHaveBeenCalled()
-  })
-
-  it('pair/token が非 2xx なら http status を lastError に出す', async () => {
-    const dev = prepareSerial()
-    await load()
-    fetchMock.mockResolvedValue({ ok: false, status: 404 })
-    await claim(dev)
-    await vi.advanceTimersByTimeAsync(0)
-
-    dev.emit('AUTH TICKET tkt-1 EXPIRES=300\n')
-    await vi.advanceTimersByTimeAsync(0)
-
-    expect(hub.lastError.value).toContain('http 404')
-    expect(auth.isDeviceActivated.value).toBe(false)
-  })
-
-  it('pair/token の応答が不完全なら lastError に出す', async () => {
-    const dev = prepareSerial()
-    await load()
-    fetchMock.mockResolvedValue({ ok: true, json: () => Promise.resolve({ tenant_id: 'tenant-1' }) })
-    await claim(dev)
-    await vi.advanceTimersByTimeAsync(0)
-
-    dev.emit('AUTH TICKET tkt-1 EXPIRES=300\n')
-    await vi.advanceTimersByTimeAsync(0)
-
-    expect(hub.lastError.value).toContain('応答が不完全です')
-    expect(auth.isDeviceActivated.value).toBe(false)
-  })
-
-  it('ERR AUTH TICKET は理由を lastError に出す (Error 経由の catch)', async () => {
-    const dev = prepareSerial()
-    await load()
-    await claim(dev)
-    await vi.advanceTimersByTimeAsync(0)
-
-    dev.emit('ERR AUTH TICKET: not ready\n')
-    await vi.advanceTimersByTimeAsync(0)
-
-    expect(hub.lastError.value).toContain('ERR AUTH TICKET: not ready')
-  })
-
-  it('タイムアウトは理由を lastError に出す', async () => {
-    const dev = prepareSerial()
-    await load()
-    await claim(dev)
-    await vi.advanceTimersByTimeAsync(0)
-
-    await vi.advanceTimersByTimeAsync(10_000)
-
-    expect(hub.lastError.value).toContain('timeout')
-  })
-
-  it('fetch が Error でない値で reject しても lastError に出す (String(e) 経由の catch)', async () => {
-    const dev = prepareSerial()
-    await load()
-    fetchMock.mockRejectedValue('boom')
-    await claim(dev)
-    await vi.advanceTimersByTimeAsync(0)
-
-    dev.emit('AUTH TICKET tkt-1 EXPIRES=300\n')
-    await vi.advanceTimersByTimeAsync(0)
-
-    expect(hub.lastError.value).toContain('boom')
-  })
-
-  it('CoreS3 再接続のたびに 1 回試す', async () => {
-    const dev = prepareSerial()
-    await load()
-    fetchMock.mockResolvedValue({ ok: false, status: 500 })
-    await claim(dev)
-    await vi.advanceTimersByTimeAsync(0)
-    dev.emit('AUTH TICKET tkt-1 EXPIRES=300\n')
-    await vi.advanceTimersByTimeAsync(0)
-    expect(hub.lastError.value).toContain('http 500')
-
-    await core.disconnect()
-    const dev2 = createMockPort()
-    installSerialMock(vi.fn(async () => [dev2.port]))
-    await claim(dev2)
-    await vi.advanceTimersByTimeAsync(0)
-    expect(dev2.writes).toContain('AUTH TICKET\n')
+    expect(useAuthMock).not.toHaveBeenCalled()
   })
 })

--- a/web/tests/utils/employee-lookup-messages.test.ts
+++ b/web/tests/utils/employee-lookup-messages.test.ts
@@ -36,4 +36,11 @@ describe('employee-lookup-messages', () => {
     expect(msg).toContain('CoreS3')
     expect(msg).toContain('http 404')
   })
+
+  it('autoClaimFailedMessage は ERR AUTH: no key のとき鍵の登録先を案内する', () => {
+    const msg = autoClaimFailedMessage('ERR AUTH: no key')
+    expect(msg).toContain('鍵が未登録')
+    expect(msg).toContain('auth.ippoan.org/device/setup')
+    expect(msg).toContain('ERR AUTH: no key')
+  })
 })


### PR DESCRIPTION
## 何を変えるか

運行者端末 (ログイン無しで運行者タブを使う PC) の短命の端末 JWT (#231) について、署名の相手を警告デバイス (VoiceS3R) から **CoreS3** に替える。CoreS3 はシリアルで `AUTH SIGN <nonce>` に署名するだけで、HTTPS はブラウザが行う。auth-worker 側は ippoan/auth-worker#552 の口と、ippoan/auth-worker#555 の用途「運行者端末 (kiosk)」の鍵を使う。#234 の 2 本目。

- `web/app/composables/useDeviceToken.ts`: 接続の判定と署名を CoreS3 宛てにする。期限内の JWT を持っているかを `hasDeviceJwt` として export する。失敗の理由を残す。CoreS3 を抜いたらキャッシュを捨てる。警告デバイスへの依存を外す (警告デバイスは端末 JWT を取らない)
- `web/app/composables/useDeviceLogin.ts`: `signAlarmDeviceNonce` の送り先を引数にする。既定は今までどおり警告デバイスで、`/login` の挙動は変えない
- `web/app/composables/useHubClaim.ts`: CoreS3 が繋がったら `getDeviceJwt()` を 1 回呼ぶだけに縮める。CoreS3 の `AUTH TICKET` から保存する credential を発行する旧経路 (#213、ブラウザからは完了できていなかった) を外す。ファイル名と戻り値 (`{ lastError, attemptClaim }`) は据え置き
- `web/app/utils/employee-lookup-messages.ts`: 失敗時の文言を「CoreS3 の鍵が未登録。管理者がデバイスの登録画面で登録する」に替える

PC に資格情報は保存しない (JWT はメモリだけ)。

## テスト

- 優先順位 (キャッシュ → CoreS3 の署名 → 保存済みの credential) / CoreS3 が未接続なら nonce を取りに行かない / `ERR AUTH: no key` で即失敗し 60 秒は試さない / CoreS3 を抜いたらキャッシュを捨てる / 警告デバイスには `AUTH SIGN` を送らない
- vitest 全体・`check_coverage_100`・`npx nuxi typecheck`

Refs #234
Refs ippoan/alc-app-s3#135

🤖 Generated with [Claude Code](https://claude.com/claude-code)
