### PR TITLE
feat(kiosk): 「未登録」の表示を 1 つの判定にまとめ、運行者タブに CoreS3 の許可ボタンを置く (Refs #234)

### DIFF
--- a/web/app/components/DeviceSettings.vue
+++ b/web/app/components/DeviceSettings.vue
@@ -15,7 +15,7 @@ const {
   deactivateDevice, deviceTenantId, deviceId: activatedDeviceId, deviceSettingsToken,
   reAuthenticateDevice,
 } = useAuth()
-const { clearKioskCredential, hasKioskCredential } = useDeviceToken()
+const { hasKioskCredential } = useDeviceToken()
 // 警告デバイス (Atom VoiceS3R) をこの端末につなぐか。端末登録で選んだ値を後から変えられる (#135)
 const { enabled: alarmDeviceEnabled, setEnabled: setAlarmDeviceEnabled } = useAlarmDeviceSetting()
 
@@ -234,8 +234,8 @@ function resetDeviceRegistration() {
   resetting.value = true
   try {
     // WebView 側 (localStorage): tenant / device_id / settings_token / kiosk credential
+    // (kiosk credential のクリアは deactivateDevice() 内で済んでいる)
     deactivateDevice()
-    clearKioskCredential()
     // Android native 側 (SharedPreferences): device_id / settings_token / fcm 登録マーク /
     // kiosk credential を消し RoomWatcher を停止する (stale device_id 起因の WS未接続・FCM未 を解消)。
     const android = (window as unknown as { Android?: { resetDeviceRegistration?: () => void } }).Android

--- a/web/app/components/DeviceUnregisteredBanner.vue
+++ b/web/app/components/DeviceUnregisteredBanner.vue
@@ -9,17 +9,17 @@
  */
 import { deviceUnregisteredMessage } from '~/utils/employee-lookup-messages'
 
-const { isAuthenticated, isDeviceActivated } = useAuth()
+const { hasKioskAccess } = useKioskAccess()
 </script>
 
 <template>
   <div
-    v-if="!isAuthenticated && !isDeviceActivated"
+    v-if="!hasKioskAccess"
     data-testid="device-unregistered-banner"
     class="w-full max-w-lg mx-auto px-4 mt-2"
   >
     <div class="bg-red-50 border border-red-200 rounded-xl p-3 text-sm text-red-700">
-      {{ deviceUnregisteredMessage }}。メニュー →「端末登録」で QR を読み取ってください。登録するまで免許証の照合と打刻一覧は動きません
+      {{ deviceUnregisteredMessage }}。メニュー →「端末登録」で QR を読み取ってください。登録するまで免許証の照合と打刻一覧は動きません。CoreS3 が USB でつながっていれば、下 (または NFC 画面) の「CoreS3 を USB で許可」を押すだけでも動きます
     </div>
   </div>
 </template>

--- a/web/app/components/NfcStatus.vue
+++ b/web/app/components/NfcStatus.vue
@@ -152,9 +152,10 @@ const showNfcGuide = ref(false)
     </div>
 
     <!-- 未接続時の案内 -->
-    <template v-if="!isConnected && !isAndroidApp">
-      <!-- CoreS3 直結 (WebSerial): 常駐アプリは要らない -->
-      <div v-if="canUseSerial" class="flex flex-col items-center gap-2">
+    <!-- CoreS3 直結 (WebSerial): 常駐アプリは要らない。NFC ブリッジの接続状態とは切り離す —
+         NFC ブリッジ (bridge/Android) が繋がっていても CoreS3 の USB 許可はまだかもしれない -->
+    <template v-if="canUseSerial && !coreS3.isConnected.value">
+      <div class="flex flex-col items-center gap-2">
         <p class="text-sm text-center text-gray-500">
           CoreS3 が USB でつながっているか確認してください。<br>
           初めて使う端末では、下のボタンで USB デバイスの使用を許可してください。
@@ -167,17 +168,17 @@ const showNfcGuide = ref(false)
           USB デバイスを選択
         </button>
       </div>
-      <!-- WebSerial が使えない環境は従来の NFC ブリッジ -->
-      <p v-else class="text-sm text-center text-gray-500">
-        NFC ブリッジがインストールされていない場合は
-        <a
-          href="https://github.com/yhonda-ohishi-alc/rust-nfc-bridge/releases/latest"
-          target="_blank"
-          rel="noopener noreferrer"
-          class="text-blue-600 underline hover:text-blue-800"
-        >こちらからダウンロード</a>
-      </p>
     </template>
+    <!-- WebSerial が使えない環境は従来の NFC ブリッジ -->
+    <p v-else-if="!isConnected && !isAndroidApp" class="text-sm text-center text-gray-500">
+      NFC ブリッジがインストールされていない場合は
+      <a
+        href="https://github.com/yhonda-ohishi-alc/rust-nfc-bridge/releases/latest"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="text-blue-600 underline hover:text-blue-800"
+      >こちらからダウンロード</a>
+    </p>
 
     <!-- NFC ブリッジ更新通知 -->
     <p v-if="showUpdateBanner" class="text-sm text-center text-amber-600">

--- a/web/app/components/NormalMeasurement.vue
+++ b/web/app/components/NormalMeasurement.vue
@@ -30,7 +30,7 @@ const licenseExpiryStatus = ref<LicenseExpiryStatus | null>(null)
 const { isOnline, pending, isSyncing, save: offlineSave, syncQueue } = useOfflineSync()
 
 // シングルトン再呼出で共有状態取得
-const { isDeviceActivated } = useAuth()
+const { hasKioskAccess } = useKioskAccess()
 const { isSyncing: isFaceSyncing, sync: faceSync } = useFaceSync()
 
 // 手動入力フォールバック
@@ -365,7 +365,7 @@ const currentStepIndex = computed(() => stepKeys.indexOf(step.value))
       <!-- 端末未アクティベート警告 -->
       <ClientOnly>
         <div
-          v-if="!isDeviceActivated"
+          v-if="!hasKioskAccess"
           :class="['w-full bg-red-50 border border-red-200 rounded-xl px-4 py-2 mb-2 text-center text-sm text-red-700', landscape ? '' : 'max-w-md']"
         >
           端末未登録 — <NuxtLink to="/login" class="underline font-medium">管理者ログイン</NuxtLink>で端末を登録してください

--- a/web/app/components/TenkoKiosk.vue
+++ b/web/app/components/TenkoKiosk.vue
@@ -11,7 +11,7 @@ const props = defineProps<{
 }>()
 
 // シングルトン再呼出で共有状態取得
-const { isDeviceActivated } = useAuth()
+const { hasKioskAccess } = useKioskAccess()
 const { isSyncing: isFaceSyncing } = useFaceSync()
 
 // デモモード (prop 優先、なければ URL クエリ)
@@ -306,7 +306,7 @@ onUnmounted(() => {
       <!-- 端末未アクティベート警告 -->
       <ClientOnly>
         <div
-          v-if="!isDeviceActivated"
+          v-if="!hasKioskAccess"
           :class="['w-full bg-red-50 border border-red-200 rounded-xl px-4 py-2 mb-2 text-center text-sm text-red-700', landscape ? '' : 'max-w-md']"
         >
           端末未登録 — <NuxtLink to="/login" class="underline font-medium">管理者ログイン</NuxtLink>で端末を登録してください

--- a/web/app/components/TimePunchKiosk.vue
+++ b/web/app/components/TimePunchKiosk.vue
@@ -18,6 +18,18 @@ const isKyoceraTablet = computed(() => {
   return KYOCERA_MODELS.some(m => deviceModel.value!.includes(m))
 })
 const showNfcGuide = ref(false)
+
+// CoreS3 の WebSerial 初回許可 (ユーザー操作が要る)。NfcStatus.vue の同名処理を踏襲する
+const isRequestingCoreS3Port = ref(false)
+async function requestCoreS3Port() {
+  isRequestingCoreS3Port.value = true
+  try {
+    await coreS3.requestPort()
+  }
+  finally {
+    isRequestingCoreS3Port.value = false
+  }
+}
 const employees = ref<ApiEmployee[]>([])
 const employeeMap = computed(() => {
   const map: Record<string, string> = {}
@@ -216,6 +228,15 @@ function formatTime(iso: string): string {
                 : 'NFC リーダー未接続' }}
           </span>
         </div>
+        <!-- CoreS3 未接続時の USB 許可ボタン (#234) -->
+        <button
+          v-if="coreS3.isSupported && !coreS3.isConnected.value"
+          class="mt-3 px-4 py-2 bg-blue-600 text-white rounded-lg text-sm hover:bg-blue-700 transition-colors disabled:bg-gray-300"
+          :disabled="isRequestingCoreS3Port"
+          @click="requestCoreS3Port"
+        >
+          CoreS3 を USB で許可
+        </button>
         <!-- インラインエラー -->
         <div
           v-if="errorMsg"

--- a/web/app/composables/useKioskAccess.ts
+++ b/web/app/composables/useKioskAccess.ts
@@ -1,0 +1,23 @@
+/**
+ * 運行者タブ (キオスク) の入口を塞ぐかどうかの一括判定 (Refs #234)。
+ *
+ * 今までの「未登録」表示は isDeviceActivated (端末登録) 単体で判定していたが、
+ * 運行管理者の PC (ログイン無しの共用 PC。端末登録もしない) は、CoreS3 が USB で
+ * 挿さっている間だけその署名で短命 device JWT を取って動く (#231,
+ * `useDeviceToken().hasDeviceJwt`)。この経路を isDeviceActivated は拾えないため、
+ * 「ログイン済み / 端末登録済み / CoreS3 署名の短命 JWT を持つ」のどれか 1 つでも
+ * 満たせばキオスクとして動いてよい、を 1 か所にまとめる。
+ *
+ * `useAuth.ts` には置かない — `useDeviceToken` が `useAuth` の `deviceTenantId` を
+ * 読むため、逆向きに `useAuth` から `useDeviceToken` を呼ぶと相互依存になる。
+ */
+export function useKioskAccess() {
+  const { isAuthenticated, isDeviceActivated } = useAuth()
+  const { hasDeviceJwt } = useDeviceToken()
+
+  const hasKioskAccess = computed(() =>
+    isAuthenticated.value || isDeviceActivated.value || hasDeviceJwt.value,
+  )
+
+  return { hasKioskAccess }
+}

--- a/web/app/pages/login.vue
+++ b/web/app/pages/login.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
-const { loginWithGoogleRedirect, isAuthenticated, isLoading, isDeviceActivated } = useAuth()
+const { loginWithGoogleRedirect, isAuthenticated, isLoading } = useAuth()
+const { hasKioskAccess } = useKioskAccess()
 const { isConnected: isAlarmDeviceConnected } = useAlarmDevice()
 const { lastError: deviceLoginError, busy: deviceLoginBusy, login: loginWithDevice } = useDeviceLogin()
 const route = useRoute()
@@ -64,7 +65,7 @@ function handleDeviceLogin() {
         </p>
 
         <p
-          v-if="isDeviceActivated"
+          v-if="hasKioskAccess"
           class="mt-4 text-left text-xs text-amber-800 bg-amber-50 border border-amber-200 rounded-lg p-3"
         >
           共用端末です。Google の「アカウントを選択」に前の利用者の名前が残っているときは、その名前の右のメニューから「アカウントの削除」を選んで消してください。ログアウトだけでは一覧から消えません。

--- a/web/coverage_100.toml
+++ b/web/coverage_100.toml
@@ -138,6 +138,10 @@ branches = true
 path = "app/composables/useHubClaim.ts"
 branches = true
 
+[[files]]
+path = "app/composables/useKioskAccess.ts"
+branches = true
+
 # --- plugins ---
 
 [[files]]

--- a/web/tests/components/DeviceUnregisteredBanner.test.ts
+++ b/web/tests/components/DeviceUnregisteredBanner.test.ts
@@ -1,27 +1,21 @@
 import { describe, it, expect, beforeEach } from 'vitest'
-import { ref, computed } from 'vue'
+import { ref } from 'vue'
 import { mountSuspended, mockNuxtImport } from '@nuxt/test-utils/runtime'
 import DeviceUnregisteredBanner from '~/components/DeviceUnregisteredBanner.vue'
 import { deviceUnregisteredMessage } from '~/utils/employee-lookup-messages'
 
-// useAuth と同じ式 (useAuth.ts:48-49) をモック側でも保つ
-const accessToken = ref<string | null>(null)
-const deviceTenantId = ref<string | null>(null)
+// 「未登録」の判定は useKioskAccess に一本化した (Refs #234)。この banner は
+// hasKioskAccess だけを見るので、その 1 変数だけをモックする。
+const hasKioskAccess = ref(false)
 
-mockNuxtImport('useAuth', () => () => ({
-  accessToken,
-  deviceTenantId,
-  isAuthenticated: computed(() => !!accessToken.value),
-  isDeviceActivated: computed(() => !!deviceTenantId.value),
-}))
+mockNuxtImport('useKioskAccess', () => () => ({ hasKioskAccess }))
 
 describe('DeviceUnregisteredBanner', () => {
   beforeEach(() => {
-    accessToken.value = null
-    deviceTenantId.value = null
+    hasKioskAccess.value = false
   })
 
-  it('端末未登録かつ未ログインなら赤枠で原因と次の操作を出す', async () => {
+  it('hasKioskAccess が false なら赤枠で原因と次の操作を出す', async () => {
     const wrapper = await mountSuspended(DeviceUnregisteredBanner)
 
     const banner = wrapper.find('[data-testid="device-unregistered-banner"]')
@@ -33,24 +27,18 @@ describe('DeviceUnregisteredBanner', () => {
     wrapper.unmount()
   })
 
-  it('端末登録済み / 管理者ログイン済みのどちらでも出さない', async () => {
-    deviceTenantId.value = 'tenant-x'
-    const activated = await mountSuspended(DeviceUnregisteredBanner)
-    expect(activated.find('[data-testid="device-unregistered-banner"]').exists()).toBe(false)
-    activated.unmount()
-
-    deviceTenantId.value = null
-    accessToken.value = 'jwt'
-    const loggedIn = await mountSuspended(DeviceUnregisteredBanner)
-    expect(loggedIn.find('[data-testid="device-unregistered-banner"]').exists()).toBe(false)
-    loggedIn.unmount()
+  it('hasKioskAccess が true なら出さない', async () => {
+    hasKioskAccess.value = true
+    const wrapper = await mountSuspended(DeviceUnregisteredBanner)
+    expect(wrapper.find('[data-testid="device-unregistered-banner"]').exists()).toBe(false)
+    wrapper.unmount()
   })
 
-  it('登録が済んだ時点で消える', async () => {
+  it('hasKioskAccess が true になった時点で消える', async () => {
     const wrapper = await mountSuspended(DeviceUnregisteredBanner)
     expect(wrapper.find('[data-testid="device-unregistered-banner"]').exists()).toBe(true)
 
-    deviceTenantId.value = 'tenant-x'
+    hasKioskAccess.value = true
     await wrapper.vm.$nextTick()
     expect(wrapper.find('[data-testid="device-unregistered-banner"]').exists()).toBe(false)
     wrapper.unmount()

--- a/web/tests/components/NfcStatus.test.ts
+++ b/web/tests/components/NfcStatus.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ref, readonly } from 'vue'
+import { mountSuspended, mockNuxtImport } from '@nuxt/test-utils/runtime'
+import NfcStatus from '~/components/NfcStatus.vue'
+
+// --- composable のモック (serial ブロックの表示条件だけを動かす、Refs #234) ---
+
+const isConnected = ref(false)
+mockNuxtImport('useNfcReader', () => () => ({
+  isConnected: readonly(isConnected),
+  error: ref<string | null>(null),
+  readers: ref<string[]>([]),
+  bridgeVersion: ref<string | null>(null),
+  connect: vi.fn(),
+  onRead: vi.fn(),
+  onLicenseRead: vi.fn(),
+}))
+
+mockNuxtImport('useNfcBridgeUpdate', () => () => ({
+  latestVersion: ref<string | null>(null),
+  checkLatestVersion: vi.fn(async () => {}),
+  isUpdateAvailable: vi.fn(() => false),
+}))
+
+const coreS3Connected = ref(false)
+const requestPortMock = vi.fn(async () => true)
+mockNuxtImport('useCoreS3Serial', () => () => ({
+  isConnected: readonly(coreS3Connected),
+  requestPort: requestPortMock,
+}))
+
+mockNuxtImport('useFingerprint', () => () => ({
+  isAndroidApp: ref(false),
+  deviceModel: ref<string | null>(null),
+}))
+
+let webSerialSupported = true
+vi.mock('~/utils/webserial', () => ({
+  isWebSerialSupported: () => webSerialSupported,
+}))
+
+function findButtonByText(wrapper: { findAll: (s: string) => { text: () => string }[] }, text: string) {
+  return wrapper.findAll('button').find(b => b.text() === text)
+}
+
+describe('NfcStatus — serial ブロックの表示条件 (Refs #234)', () => {
+  beforeEach(() => {
+    isConnected.value = false
+    coreS3Connected.value = false
+    webSerialSupported = true
+    requestPortMock.mockClear()
+  })
+
+  it('NFC ブリッジ未接続・CoreS3 未接続なら USB 許可ボタンを出す', async () => {
+    const wrapper = await mountSuspended(NfcStatus)
+    expect(findButtonByText(wrapper, 'USB デバイスを選択')).toBeTruthy()
+    wrapper.unmount()
+  })
+
+  it('NFC ブリッジは接続済みでも CoreS3 が未接続なら USB 許可ボタンを出す (ブリッジ接続とは切り離す)', async () => {
+    isConnected.value = true
+    const wrapper = await mountSuspended(NfcStatus)
+    expect(findButtonByText(wrapper, 'USB デバイスを選択')).toBeTruthy()
+    wrapper.unmount()
+  })
+
+  it('CoreS3 が接続済みなら USB 許可ボタンを出さない', async () => {
+    coreS3Connected.value = true
+    const wrapper = await mountSuspended(NfcStatus)
+    expect(findButtonByText(wrapper, 'USB デバイスを選択')).toBeFalsy()
+    wrapper.unmount()
+  })
+
+  it('WebSerial 未対応かつ NFC ブリッジ未接続なら従来の案内を出す', async () => {
+    webSerialSupported = false
+    const wrapper = await mountSuspended(NfcStatus)
+    expect(findButtonByText(wrapper, 'USB デバイスを選択')).toBeFalsy()
+    expect(wrapper.text()).toContain('NFC ブリッジがインストールされていない場合は')
+    wrapper.unmount()
+  })
+
+  it('WebSerial 未対応かつ NFC ブリッジ接続済みなら何も出さない', async () => {
+    webSerialSupported = false
+    isConnected.value = true
+    const wrapper = await mountSuspended(NfcStatus)
+    expect(wrapper.text()).not.toContain('NFC ブリッジがインストールされていない場合は')
+    wrapper.unmount()
+  })
+
+  it('USB 許可ボタン押下で coreS3.requestPort を呼ぶ', async () => {
+    const wrapper = await mountSuspended(NfcStatus)
+    const button = findButtonByText(wrapper, 'USB デバイスを選択')
+    await (button as unknown as { trigger: (e: string) => Promise<void> }).trigger('click')
+    expect(requestPortMock).toHaveBeenCalled()
+    wrapper.unmount()
+  })
+})

--- a/web/tests/components/NormalMeasurement.test.ts
+++ b/web/tests/components/NormalMeasurement.test.ts
@@ -43,9 +43,10 @@ mockNuxtImport('useOfflineSync', () => () => ({
   syncQueue: vi.fn(),
 }))
 
-mockNuxtImport('useAuth', () => () => ({
-  isDeviceActivated: ref(true),
-}))
+// 「未登録」の判定は useKioskAccess に一本化した (Refs #234)。既定は true (未登録
+// バナーの有無に依存しない他テストに影響させない)、専用テストだけ false に倒す。
+const hasKioskAccess = ref(true)
+mockNuxtImport('useKioskAccess', () => () => ({ hasKioskAccess }))
 
 const faceSyncMock = vi.fn(async () => {})
 mockNuxtImport('useFaceSync', () => () => ({
@@ -98,6 +99,20 @@ async function touch(wrapper: Awaited<ReturnType<typeof mountNfcStep>>, nfcId: s
 describe('NormalMeasurement — NFC ステップの乗務員照合', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    hasKioskAccess.value = true
+  })
+
+  it('hasKioskAccess が false なら「端末未登録」を出す', async () => {
+    hasKioskAccess.value = false
+    const wrapper = await mountNfcStep()
+    expect(wrapper.text()).toContain('端末未登録')
+    wrapper.unmount()
+  })
+
+  it('hasKioskAccess が true なら「端末未登録」を出さない', async () => {
+    const wrapper = await mountNfcStep()
+    expect(wrapper.text()).not.toContain('端末未登録')
+    wrapper.unmount()
   })
 
   it('免許証が乗務員に未登録 (by-nfc が失敗) なら赤枠に理由と次の操作を出す', async () => {

--- a/web/tests/components/TimePunchKiosk.test.ts
+++ b/web/tests/components/TimePunchKiosk.test.ts
@@ -22,8 +22,12 @@ mockNuxtImport('useNfcWebSocket', () => () => ({
 }))
 
 const coreS3Connected = ref(false)
+const coreS3Supported = ref(true)
+const coreS3RequestPortMock = vi.fn(async () => true)
 mockNuxtImport('useCoreS3Serial', () => () => ({
   isConnected: readonly(coreS3Connected),
+  isSupported: coreS3Supported.value,
+  requestPort: coreS3RequestPortMock,
 }))
 
 mockNuxtImport('useAuth', () => () => ({
@@ -50,6 +54,8 @@ describe('TimePunchKiosk — NFC 接続表示の 3 状態 (Refs ippoan/alc-app#2
   beforeEach(() => {
     nfcConnected.value = false
     coreS3Connected.value = false
+    coreS3Supported.value = true
+    coreS3RequestPortMock.mockClear()
   })
 
   it('CoreS3 直結が繋がっていれば緑で「NFC 端末接続中」を出す', async () => {
@@ -78,6 +84,44 @@ describe('TimePunchKiosk — NFC 接続表示の 3 状態 (Refs ippoan/alc-app#2
     expect(wrapper.text()).toContain('NFC リーダー未接続')
     expect(wrapper.find('.bg-red-500').exists()).toBe(true)
     expect(wrapper.find('.bg-green-500').exists()).toBe(false)
+    wrapper.unmount()
+  })
+})
+
+describe('TimePunchKiosk — CoreS3 の USB 許可ボタン (Refs #234)', () => {
+  beforeEach(() => {
+    nfcConnected.value = false
+    coreS3Connected.value = false
+    coreS3Supported.value = true
+    coreS3RequestPortMock.mockClear()
+  })
+
+  it('WebSerial 対応かつ CoreS3 未接続ならボタンを出す', async () => {
+    const wrapper = await mountSuspended(TimePunchKiosk)
+    expect(wrapper.text()).toContain('CoreS3 を USB で許可')
+    wrapper.unmount()
+  })
+
+  it('CoreS3 が接続済みならボタンを出さない', async () => {
+    coreS3Connected.value = true
+    const wrapper = await mountSuspended(TimePunchKiosk)
+    expect(wrapper.text()).not.toContain('CoreS3 を USB で許可')
+    wrapper.unmount()
+  })
+
+  it('WebSerial 未対応環境ではボタンを出さない', async () => {
+    coreS3Supported.value = false
+    const wrapper = await mountSuspended(TimePunchKiosk)
+    expect(wrapper.text()).not.toContain('CoreS3 を USB で許可')
+    wrapper.unmount()
+  })
+
+  it('ボタン押下で coreS3.requestPort を呼ぶ', async () => {
+    const wrapper = await mountSuspended(TimePunchKiosk)
+    const button = wrapper.findAll('button').find(b => b.text() === 'CoreS3 を USB で許可')
+    expect(button).toBeTruthy()
+    await button!.trigger('click')
+    expect(coreS3RequestPortMock).toHaveBeenCalled()
     wrapper.unmount()
   })
 })

--- a/web/tests/composables/useKioskAccess.test.ts
+++ b/web/tests/composables/useKioskAccess.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { ref, computed } from 'vue'
+import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+
+// hasDeviceJwt は兄弟 #p135-c234-2 が useDeviceToken.ts に足す予定 (未マージ)。
+// ここでは mock だけで検証し、マージ後に rebase してそのまま通す。
+const accessToken = ref<string | null>(null)
+const deviceTenantId = ref<string | null>(null)
+const hasDeviceJwt = ref(false)
+
+mockNuxtImport('useAuth', () => () => ({
+  accessToken,
+  deviceTenantId,
+  isAuthenticated: computed(() => !!accessToken.value),
+  isDeviceActivated: computed(() => !!deviceTenantId.value),
+}))
+
+mockNuxtImport('useDeviceToken', () => () => ({
+  hasDeviceJwt,
+}))
+
+describe('useKioskAccess', () => {
+  beforeEach(() => {
+    accessToken.value = null
+    deviceTenantId.value = null
+    hasDeviceJwt.value = false
+  })
+
+  it('3 条件すべて false なら hasKioskAccess は false', async () => {
+    const { useKioskAccess } = await import('~/composables/useKioskAccess')
+    const { hasKioskAccess } = useKioskAccess()
+    expect(hasKioskAccess.value).toBe(false)
+  })
+
+  it('isAuthenticated (ログイン済み) だけで true', async () => {
+    accessToken.value = 'jwt'
+    const { useKioskAccess } = await import('~/composables/useKioskAccess')
+    const { hasKioskAccess } = useKioskAccess()
+    expect(hasKioskAccess.value).toBe(true)
+  })
+
+  it('isDeviceActivated (端末登録済み) だけで true', async () => {
+    deviceTenantId.value = 'tenant-x'
+    const { useKioskAccess } = await import('~/composables/useKioskAccess')
+    const { hasKioskAccess } = useKioskAccess()
+    expect(hasKioskAccess.value).toBe(true)
+  })
+
+  it('hasDeviceJwt (CoreS3 署名の短命 JWT) だけで true', async () => {
+    hasDeviceJwt.value = true
+    const { useKioskAccess } = await import('~/composables/useKioskAccess')
+    const { hasKioskAccess } = useKioskAccess()
+    expect(hasKioskAccess.value).toBe(true)
+  })
+})


### PR DESCRIPTION
## 何を変えるか

「未登録」の表示を 1 つの判定にまとめ、運行者タブに CoreS3 の USB 許可ボタンを置く。#234 の 3 本目 (2 本目の `hasDeviceJwt` を使う)。

- 新規 `web/app/composables/useKioskAccess.ts`: `hasKioskAccess` = 管理者ログイン中 / 端末登録済み / 期限内の端末 JWT を持っている、のどれか
- 「未登録」の表示を差し替える: `DeviceUnregisteredBanner.vue`・`TenkoKiosk.vue`・`NormalMeasurement.vue` は `!hasKioskAccess`、`login.vue` は `hasKioskAccess`。バナーに「CoreS3 を USB で許可」の案内を足す
- `TimePunchKiosk.vue`: ブラウザが対応していて CoreS3 が未接続なら「CoreS3 を USB で許可」ボタンを出す (`requestPort()`)
- `NfcStatus.vue`: シリアルの案内を NFC ブリッジの接続状態から切り離す (ブリッジが未接続でも CoreS3 の選択に進める)
- `DeviceSettings.vue`: リセットでの `clearKioskCredential()` の二重呼び出しを削除する (`deactivateDevice()` の中で済んでいる)。「登録済み / 未登録」の表示は端末登録の状態なので変えていない

## テスト

- `useKioskAccess` の 3 条件 / バナー / 打刻画面の許可ボタン / `NfcStatus` / `NormalMeasurement`
- vitest 全体・`check_coverage_100` (`useKioskAccess.ts` を登録)・`npx nuxi typecheck`

Refs #234
Refs ippoan/alc-app-s3#135

🤖 Generated with [Claude Code](https://claude.com/claude-code)
