### PR TITLE
fix(cores3): CoreS3 の探索を起動時に始め、端末 JWT を最大 3 秒待って取る (Refs #238)

### DIFF
--- a/web/app/components/TimePunchKiosk.vue
+++ b/web/app/components/TimePunchKiosk.vue
@@ -47,7 +47,7 @@ const recentPunches = ref<{ key: string; name: string; time: string }[]>([])
 const highlightedKey = ref<string | null>(null)
 let highlightTimer: ReturnType<typeof setTimeout> | null = null
 
-const { getDeviceJwt } = useDeviceToken()
+const { getDeviceJwt, hasDeviceJwt } = useDeviceToken()
 
 /**
  * CoreS3 経由の自動端末登録 (#213) の失敗理由。成功 / 未実行なら null。
@@ -118,14 +118,29 @@ async function loadTodayPunches() {
   catch (e) { console.error('[TimePunchKiosk] Failed to load today punches:', e) }
 }
 
-onMounted(async () => {
-  updateScreenSize()
-  window.addEventListener('resize', updateScreenSize)
-
+async function loadEmployees() {
   try {
     employees.value = await getEmployees()
   }
   catch (e) { console.error('[TimePunchKiosk] Failed to load employees:', e) }
+}
+
+/**
+ * 端末 JWT が取れたら一覧を引き直す (Refs ippoan/alc-app#238)。起動時は CoreS3 を
+ * 最大 3 秒待つが、初回の open で CoreS3 がリセットされると claim がそれを超えることがあり、
+ * そのとき最初の一覧は JWT 無しで取りに行って空のまま残るため
+ */
+watch(hasDeviceJwt, (has) => {
+  if (!has) return
+  void loadEmployees()
+  void loadTodayPunches()
+})
+
+onMounted(async () => {
+  updateScreenSize()
+  window.addEventListener('resize', updateScreenSize)
+
+  await loadEmployees()
   // 購読が張れれば onopen で 1 回引き直すが、張れない場合もあるのでここでも引く
   await loadTodayPunches()
   void watch$.connect()

--- a/web/app/composables/useCoreS3Serial.ts
+++ b/web/app/composables/useCoreS3Serial.ts
@@ -110,6 +110,14 @@ let heartbeatTimer: ReturnType<typeof setInterval> | null = null
 let logReplyGeneration = 0
 
 /**
+ * 起動時の探索 (startupProbe) の 1 本。起動から数えて 1 回だけ作り、以後は同じものを返す —
+ * 端末 JWT の取得も「確認中」の表示も、この 1 本の 3 秒を共有する (Refs ippoan/alc-app#238)
+ */
+let startupProbePromise: Promise<boolean> | null = null
+/** startupProbePromise が未解決の間だけ true */
+const isStartupProbing = ref(false)
+
+/**
  * 行の接頭辞から素性を決める。
  *
  * 警告デバイスの行を先に見る: `EVT ALARM` は `EVT ` にも当てはまるため。空白まで見る —
@@ -305,9 +313,15 @@ export function useCoreS3Serial() {
     eventHandlers.add(cb)
   }
 
-  /** ポートを預かった (接続した) */
+  /**
+   * ポートを預かった (接続した)。登録した時点で既に接続済みなら、その場で 1 回呼ぶ —
+   * 先に CoreS3 が開いていても、あとから登録した利用側の接続状態が立つように。
+   * 接続時の配布 (claimant.onOpen) は isConnected を立ててから登録済みの分を写して回すので、
+   * 同じ cb が「登録時」と「接続時」の 2 回呼ばれることは無い
+   */
   function onOpen(cb: () => void): void {
     openHandlers.add(cb)
+    if (isConnected.value) cb()
   }
 
   /** ポートを失った / 返した */
@@ -333,6 +347,20 @@ export function useCoreS3Serial() {
     arbiter.register(CLAIMANT_NAME, claimant)
     arbiter.start(delay)
     return await waitForClaim()
+  }
+
+  /**
+   * 起動時の探索。初回の呼び出しで connect(0) を始め、claim されたら true、
+   * CLAIM_TIMEOUT (3 秒) で false に解決する。2 回目以降は同じ promise を返すので、
+   * 待つのは起動から数えて 1 回だけ。WebSerial 非対応なら探索せず false
+   * (isStartupProbing も立てない)
+   */
+  function startupProbe(): Promise<boolean> {
+    if (!startupProbePromise) {
+      if (isSupported) isStartupProbing.value = true
+      startupProbePromise = connect(0).finally(() => { isStartupProbing.value = false })
+    }
+    return startupProbePromise
   }
 
   /** WebSerial の初回許可 (ユーザー操作が要る) → 許可されたら探索して claim を待つ */
@@ -370,6 +398,8 @@ export function useCoreS3Serial() {
     write,
     sendGrace,
     connect,
+    startupProbe,
+    isStartupProbing: readonly(isStartupProbing),
     requestPort,
     release,
     disconnect,

--- a/web/app/composables/useDeviceToken.ts
+++ b/web/app/composables/useDeviceToken.ts
@@ -148,7 +148,9 @@ export function useDeviceToken() {
 
   /**
    * CoreS3 が USB で繋がっていれば、その ed25519 鍵の署名で auth-worker
-   * (#552) から短命 JWT を取りに行く。未接続 / 抑止期間中 / いずれかの失敗
+   * (#552) から短命 JWT を取りに行く。未接続なら起動時の探索 (`startupProbe`、
+   * 起動から最大 3 秒で 1 回だけ) を待ち、それでも未接続なら null (以後は待たずに即 null)。
+   * 抑止期間中 / いずれかの失敗
    * (401 `{error:"invalid_alarm_token"}` / 429 / タイムアウト / 通信エラー、
    * いずれも HTTP status だけで判定する) なら null を返し、CORE_S3_BACKOFF_MS の
    * 間この経路を抑止する (再接続での解除はしない)。失敗理由は `lastError` に残し、
@@ -156,7 +158,11 @@ export function useDeviceToken() {
    */
   async function tryCoreS3Jwt(nowMs: number): Promise<string | null> {
     if (nowMs < coreS3BackoffUntilMs) return null
-    if (!coreS3.isConnected.value) return null
+    if (!coreS3.isConnected.value) {
+      // 結果の真偽ではなく接続を見直す — 探索で繋がった後に抜かれていれば署名は頼めない
+      await coreS3.startupProbe()
+      if (!coreS3.isConnected.value) return null
+    }
 
     lastError.value = null
     try {

--- a/web/app/composables/useHubClaim.ts
+++ b/web/app/composables/useHubClaim.ts
@@ -7,6 +7,7 @@
  * あいだは `useDeviceToken` の署名先が CoreS3 に切り替わっており (#234-2)、
  * `getDeviceJwt()` を呼べば nonce 取得・署名・mint まで自力で完結する。ここは
  * 「繋がったら 1 回呼んでおく」だけの先取りに縮小した (isDeviceActivated には無関係に動く)。
+ * 起動時の CoreS3 の探索 (`startupProbe`) もここで 1 回だけ始める (Refs ippoan/alc-app#238)。
  *
  * ファイル名と戻り値の形 `{ lastError, attemptClaim }` は据え置く
  * (`TimePunchKiosk.vue` が `useHubClaim().lastError` を参照するため)。
@@ -30,6 +31,9 @@ export function useHubClaim() {
   if (!listenerInstalled) {
     listenerInstalled = true
     coreS3.onOpen(() => { void attemptClaim() })
+    // 起動時に CoreS3 を 1 回探す (最大 3 秒。getDeviceJwt の待ちもこの 1 本を共有する)。
+    // 繋がると 3 秒ごとの `HB OK` が全ページで始まるが、運行者端末では NFC の画面で既に同じことが起きている
+    void coreS3.startupProbe()
   }
 
   return {

--- a/web/tests/components/TimePunchKiosk.test.ts
+++ b/web/tests/components/TimePunchKiosk.test.ts
@@ -2,6 +2,10 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { ref, readonly } from 'vue'
 import { mountSuspended, mockNuxtImport } from '@nuxt/test-utils/runtime'
 import TimePunchKiosk from '~/components/TimePunchKiosk.vue'
+import { getEmployees, listTimePunches } from '~/utils/api'
+
+/** onMounted の await 群と watch の後段を流し切る */
+const flush = () => new Promise(resolve => setTimeout(resolve, 0))
 
 // --- API のモック (NFC 表示だけを見るので中身は空で足りる) ---
 
@@ -38,8 +42,10 @@ mockNuxtImport('useFingerprint', () => () => ({
   deviceModel: ref(null),
 }))
 
+const deviceJwtReady = ref(false)
 mockNuxtImport('useDeviceToken', () => () => ({
   getDeviceJwt: vi.fn(() => null),
+  hasDeviceJwt: readonly(deviceJwtReady),
 }))
 
 mockNuxtImport('useHubClaim', () => () => ({
@@ -122,6 +128,41 @@ describe('TimePunchKiosk — CoreS3 の USB 許可ボタン (Refs #234)', () => 
     expect(button).toBeTruthy()
     await button!.trigger('click')
     expect(coreS3RequestPortMock).toHaveBeenCalled()
+    wrapper.unmount()
+  })
+})
+
+describe('TimePunchKiosk — 端末 JWT が取れたら一覧を引き直す (Refs #238)', () => {
+  beforeEach(() => {
+    deviceJwtReady.value = false
+    vi.mocked(getEmployees).mockClear()
+    vi.mocked(listTimePunches).mockClear()
+  })
+
+  it('hasDeviceJwt が true になったら employees と本日の打刻を引き直す', async () => {
+    const wrapper = await mountSuspended(TimePunchKiosk)
+    await flush()
+    expect(getEmployees).toHaveBeenCalledTimes(1)
+    expect(listTimePunches).toHaveBeenCalledTimes(1)
+
+    deviceJwtReady.value = true
+    await flush()
+    expect(getEmployees).toHaveBeenCalledTimes(2)
+    expect(listTimePunches).toHaveBeenCalledTimes(2)
+    wrapper.unmount()
+  })
+
+  it('hasDeviceJwt が false に戻っても (抜線でキャッシュ破棄) 引き直さない', async () => {
+    deviceJwtReady.value = true
+    const wrapper = await mountSuspended(TimePunchKiosk)
+    await flush()
+    vi.mocked(getEmployees).mockClear()
+    vi.mocked(listTimePunches).mockClear()
+
+    deviceJwtReady.value = false
+    await flush()
+    expect(getEmployees).not.toHaveBeenCalled()
+    expect(listTimePunches).not.toHaveBeenCalled()
     wrapper.unmount()
   })
 })

--- a/web/tests/composables/useBleGateway.test.ts
+++ b/web/tests/composables/useBleGateway.test.ts
@@ -622,6 +622,24 @@ describe('useBleGateway', () => {
         expect(await gw.autoConnect()).toBe(true)
       })
 
+      it('CoreS3 が先に (起動時の探索で) 繋がっていても、あとから wire すれば isConnected が立つ (Refs #238)', async () => {
+        const dev = createMockPort()
+        dev.emit('{"type":"ready","version":"1.0.0"}\n')
+        installSerialMock({ getPorts: vi.fn(async () => [dev.port]) })
+        await load()
+
+        const { useCoreS3Serial } = await import('~/composables/useCoreS3Serial')
+        const probe = useCoreS3Serial().startupProbe()
+        await vi.advanceTimersByTimeAsync(0)
+        expect(await probe).toBe(true)
+        // まだ wire していない
+        expect(gw.isConnected.value).toBe(false)
+
+        expect(await autoConnect()).toBe(true)
+        expect(gw.isConnected.value).toBe(true)
+        expect(gw.transport.value).toBe('serial')
+      })
+
       it('警告デバイス (VoiceS3R) のポートは掴まない (#135)', async () => {
         const alarm = createMockPort()
         alarm.emit('EVT ALARM state=alarming cause=silence\n')

--- a/web/tests/composables/useCoreS3Serial.test.ts
+++ b/web/tests/composables/useCoreS3Serial.test.ts
@@ -704,6 +704,49 @@ describe('useCoreS3Serial', () => {
       expect(order).toEqual(['open', 'json'])
     })
 
+    it('onOpen: 接続済みで登録するとその場で 1 回だけ呼び、掴み直したらまた 1 回 (Refs #238)', async () => {
+      const dev = createMockPort()
+      await connectWithJson(dev)
+      const opened: number[] = []
+
+      core.onOpen(() => opened.push(1))
+      expect(opened).toEqual([1])
+      await vi.advanceTimersByTimeAsync(3000)
+      expect(opened).toEqual([1])
+
+      await core.release()
+      dev.emit('{"type":"ready","version":"1.0.0"}\n')
+      await vi.advanceTimersByTimeAsync(10000)
+      expect(core.isConnected.value).toBe(true)
+      expect(opened).toEqual([1, 1])
+    })
+
+    it('onOpen: 未接続で登録すると、接続したときに 1 回だけ呼ぶ', async () => {
+      const dev = createMockPort()
+      installSerialMock({ getPorts: vi.fn(async () => [dev.port]) })
+      await load()
+      const opened: number[] = []
+
+      core.onOpen(() => opened.push(1))
+      expect(opened).toEqual([])
+
+      dev.emit('{"type":"ready","version":"1.0.0"}\n')
+      await connect()
+      expect(opened).toEqual([1])
+    })
+
+    it('onOpen: 接続時の配布の中で登録した cb も 1 回だけ (登録時と接続時で 2 回にならない)', async () => {
+      const dev = createMockPort()
+      installSerialMock({ getPorts: vi.fn(async () => [dev.port]) })
+      await load()
+      const inner: number[] = []
+      core.onOpen(() => core.onOpen(() => inner.push(1)))
+
+      dev.emit('{"type":"ready","version":"1.0.0"}\n')
+      await connect()
+      expect(inner).toEqual([1])
+    })
+
     it('release でポートを返すと onClose が呼ばれ、登録は残るので掴み直す', async () => {
       const dev = createMockPort()
       await connectWithJson(dev)
@@ -728,6 +771,68 @@ describe('useCoreS3Serial', () => {
 
       await vi.advanceTimersByTimeAsync(30000)
       expect(dev.port.open).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  // ---------- startupProbe (Refs ippoan/alc-app#238) ----------
+
+  describe('startupProbe', () => {
+    it('何度呼んでも 1 本で、claim されたら true (isStartupProbing は false → true → false)', async () => {
+      const dev = createMockPort()
+      const getPorts = vi.fn(async () => [dev.port])
+      installSerialMock({ getPorts })
+      await load()
+      dev.emit('{"type":"ready","version":"1.0.0"}\n')
+      expect(core.isStartupProbing.value).toBe(false)
+
+      const first = core.startupProbe()
+      expect(core.isStartupProbing.value).toBe(true)
+      expect(core.startupProbe()).toBe(first)
+      // 別の呼び出し元 (別の useCoreS3Serial()) からも同じ 1 本
+      expect(mod.useCoreS3Serial().startupProbe()).toBe(first)
+
+      await vi.advanceTimersByTimeAsync(0)
+      await expect(first).resolves.toBe(true)
+      expect(core.isStartupProbing.value).toBe(false)
+      expect(core.isConnected.value).toBe(true)
+      expect(getPorts).toHaveBeenCalledTimes(1)
+    })
+
+    it('claim されなければ 3 秒で false、以後は同じ 1 本を返して待たない', async () => {
+      installSerialMock({ getPorts: vi.fn(async () => []) })
+      await load()
+
+      const first = core.startupProbe()
+      let settled = false
+      void first.then(() => { settled = true })
+
+      await vi.advanceTimersByTimeAsync(2999)
+      expect(settled).toBe(false)
+      expect(core.isStartupProbing.value).toBe(true)
+
+      await vi.advanceTimersByTimeAsync(1)
+      await expect(first).resolves.toBe(false)
+      expect(core.isStartupProbing.value).toBe(false)
+
+      expect(core.startupProbe()).toBe(first)
+      expect(core.isStartupProbing.value).toBe(false)
+    })
+
+    it('接続済みなら待たずに true', async () => {
+      const dev = createMockPort()
+      await connectWithJson(dev)
+
+      await expect(core.startupProbe()).resolves.toBe(true)
+      expect(core.isStartupProbing.value).toBe(false)
+    })
+
+    it('WebSerial 非対応なら探索せず即 false (isStartupProbing は立たない)', async () => {
+      await load()
+
+      const p = core.startupProbe()
+      expect(core.isStartupProbing.value).toBe(false)
+      await expect(p).resolves.toBe(false)
+      expect(core.isStartupProbing.value).toBe(false)
     })
   })
 

--- a/web/tests/composables/useDeviceToken.test.ts
+++ b/web/tests/composables/useDeviceToken.test.ts
@@ -20,6 +20,9 @@ const coreS3Mock = vi.hoisted(() => ({
   isConnected: { value: false },
   request: vi.fn(),
   onClose: vi.fn(),
+  // 起動時の探索 (Refs #238)。既定は「繋がらなかった」
+  startupProbe: vi.fn(async () => false),
+  isStartupProbing: { value: false },
 }))
 mockNuxtImport('useCoreS3Serial', () => () => coreS3Mock)
 
@@ -45,6 +48,8 @@ beforeEach(() => {
   coreS3Mock.isConnected.value = false
   coreS3Mock.request.mockReset()
   coreS3Mock.onClose.mockReset()
+  coreS3Mock.startupProbe.mockReset()
+  coreS3Mock.startupProbe.mockImplementation(async () => false)
   authMock.deviceTenantId.value = null
   signAlarmDeviceNonceMock.mockReset()
 })
@@ -321,6 +326,7 @@ describe('useDeviceToken (#434 step 3c)', () => {
 
     it('CoreS3 未接続なら nonce を呼ばず、既存の credential 経路だけを試す', async () => {
       coreS3Mock.isConnected.value = false
+      coreS3Mock.startupProbe.mockImplementation(async () => false)
       const fetchMock = routeFetch({
         '/device/token': () => ({ ok: true, json: () => Promise.resolve({ access_token: 'cred-jwt', expires_in: 3600 }) }),
       })
@@ -331,8 +337,91 @@ describe('useDeviceToken (#434 step 3c)', () => {
       storeKioskCredential(ID, SECRET)
 
       expect(await getDeviceJwt()).toBe('cred-jwt')
+      expect(coreS3Mock.startupProbe).toHaveBeenCalledTimes(1)
       expect(signAlarmDeviceNonceMock).not.toHaveBeenCalled()
       expect(fetchMock.mock.calls.some(([u]) => (u as string).includes('alarm-nonce'))).toBe(false)
+    })
+
+    it('未接続でも起動時の探索で繋がれば (true)、CoreS3 の署名で JWT を取る (Refs #238)', async () => {
+      coreS3Mock.isConnected.value = false
+      coreS3Mock.startupProbe.mockImplementation(async () => {
+        coreS3Mock.isConnected.value = true
+        return true
+      })
+      signAlarmDeviceNonceMock.mockResolvedValue({ pubkey: 'pub-1', sig: 'sig-1' })
+      vi.stubGlobal('fetch', routeFetch({
+        '/device/alarm-nonce': () => ({ ok: true, json: () => Promise.resolve({ nonce: 'n1', expires_in: 60 }) }),
+        '/device/alarm-token': () => ({ ok: true, json: () => Promise.resolve({ access_token: 's3r-jwt', expires_in: 900 }) }),
+      }))
+
+      const useDeviceToken = await load()
+      const { getDeviceJwt } = useDeviceToken()
+
+      expect(await getDeviceJwt()).toBe('s3r-jwt')
+      expect(coreS3Mock.startupProbe).toHaveBeenCalledTimes(1)
+      expect(signAlarmDeviceNonceMock).toHaveBeenCalledWith('n1', coreS3Mock.request)
+    })
+
+    it('探索が false なら null (credential 無し)。抑止も lastError も立てない', async () => {
+      coreS3Mock.isConnected.value = false
+      const fetchMock = vi.fn()
+      vi.stubGlobal('fetch', fetchMock)
+
+      const useDeviceToken = await load()
+      const { getDeviceJwt, lastError } = useDeviceToken()
+
+      expect(await getDeviceJwt()).toBeNull()
+      expect(fetchMock).not.toHaveBeenCalled()
+      expect(lastError.value).toBeNull()
+    })
+
+    it('探索が true でも、その後に抜かれて未接続なら署名を頼まず null', async () => {
+      coreS3Mock.isConnected.value = false
+      coreS3Mock.startupProbe.mockImplementation(async () => true)
+      const fetchMock = vi.fn()
+      vi.stubGlobal('fetch', fetchMock)
+
+      const useDeviceToken = await load()
+      const { getDeviceJwt, lastError } = useDeviceToken()
+
+      expect(await getDeviceJwt()).toBeNull()
+      expect(fetchMock).not.toHaveBeenCalled()
+      expect(signAlarmDeviceNonceMock).not.toHaveBeenCalled()
+      expect(lastError.value).toBeNull()
+    })
+
+    it('待つのは起動時の 1 本の 3 秒だけ — 2 回目以降は解決済みの 1 本を見て即 null', async () => {
+      vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+      try {
+        coreS3Mock.isConnected.value = false
+        // 実体と同じく「1 本を共有する」探索: 3 秒で false に解決する
+        let probe: Promise<boolean> | null = null
+        coreS3Mock.startupProbe.mockImplementation(() => {
+          probe ??= new Promise<boolean>(resolve => setTimeout(() => resolve(false), 3000))
+          return probe
+        })
+        vi.stubGlobal('fetch', vi.fn())
+
+        const useDeviceToken = await load()
+        const { getDeviceJwt } = useDeviceToken()
+
+        let firstDone = false
+        const first = getDeviceJwt().finally(() => { firstDone = true })
+        await vi.advanceTimersByTimeAsync(2999)
+        expect(firstDone).toBe(false)
+        await vi.advanceTimersByTimeAsync(1)
+        await expect(first).resolves.toBeNull()
+
+        let secondDone = false
+        const second = getDeviceJwt().finally(() => { secondDone = true })
+        // タイマーを進めずに解決する (新たに 3 秒待たない)
+        await vi.advanceTimersByTimeAsync(0)
+        expect(secondDone).toBe(true)
+        await expect(second).resolves.toBeNull()
+      }
+      finally {
+        vi.useRealTimers()
+      }
     })
 
     it('S3R が 401/429 で失敗すれば null に落ちて credential 経路を試す', async () => {

--- a/web/tests/composables/useHubClaim.test.ts
+++ b/web/tests/composables/useHubClaim.test.ts
@@ -11,7 +11,11 @@ import { mockNuxtImport } from '@nuxt/test-utils/runtime'
  * useCoreS3Serial / useDeviceToken の実体は他のテストが担保済みなのでここでは mock する。
  */
 
-const coreS3Mock = vi.hoisted(() => ({ onOpen: vi.fn() }))
+const coreS3Mock = vi.hoisted(() => ({
+  onOpen: vi.fn(),
+  startupProbe: vi.fn(async () => false),
+  isStartupProbing: { value: false },
+}))
 mockNuxtImport('useCoreS3Serial', () => () => coreS3Mock)
 
 const deviceTokenMock = vi.hoisted(() => ({
@@ -58,6 +62,14 @@ describe('useHubClaim', () => {
     useHubClaim()
 
     expect(coreS3Mock.onOpen).toHaveBeenCalledTimes(1)
+  })
+
+  it('起動時に CoreS3 の探索 (startupProbe) を 1 回だけ始める (Refs #238)', async () => {
+    const useHubClaim = await load()
+    useHubClaim()
+    useHubClaim()
+
+    expect(coreS3Mock.startupProbe).toHaveBeenCalledTimes(1)
   })
 
   it('attemptClaim は isDeviceActivated に関係なく毎回 getDeviceJwt を呼ぶ (guard を持たない)', async () => {


### PR DESCRIPTION
## 何を変えるか

運行者端末で画面を開いた瞬間に CoreS3 がまだ繋がっていないと、一覧の取得が端末 JWT の経路に乗らずに失敗し、JWT が後で取れても取り直さなかった。CoreS3 に繋がっているのに、体温・血圧の画面が「見つかりません」になることもあった。#238 の 1 本目。

原因は 1 つ: `useCoreS3Serial` の `onOpen(cb)` が、登録した時点で既に接続済みでも cb を呼ばなかった。先に CoreS3 が開いていると、体温計の接続状態も端末 JWT の先取りも立たなかった。あわせて、起動直後に CoreS3 を探し始める人がいなかった。

- `web/app/composables/useCoreS3Serial.ts`
  - `onOpen(cb)`: 登録時に接続済みなら、その場で 1 回呼ぶ (接続時の呼び出しと合わせて 2 回にはならない)
  - `startupProbe()`: 起動時の探索を 1 本の promise にする。CoreS3 が見つかれば true、3 秒で見つからなければ false。何度呼んでも同じ 1 本。Web Serial が使えない環境では即 false
  - `isStartupProbing`: その探索の途中だけ true (次の PR の「確認中」の表示が使う)
- `web/app/composables/useHubClaim.ts`: 起動時に探索を 1 回始める
- `web/app/composables/useDeviceToken.ts`: CoreS3 が未接続なら、起動時の探索の結果を待ってから判定する (待つのは起動から最大 3 秒、1 回だけ)。以後は待たずに今までの経路へ
- `web/app/components/TimePunchKiosk.vue`: 端末 JWT が取れたら、社員一覧と今日の打刻を取り直す

## テスト

- onOpen: 接続済みで登録 → 即時に 1 回だけ / 未接続で登録 → 接続時に 1 回だけ
- startupProbe: 1 本だけ・見つかれば true・3 秒で false・非対応環境で即 false / isStartupProbing の遷移
- useDeviceToken: 未接続 → 探索の結果で JWT を取る / 取らない、2 回目以降は待たない
- 体温計の接続状態: 接続済みの状態で配線しても立つ
- タイムカード: 端末 JWT が取れたら一覧を取り直す
- vitest 全体、`check_coverage_100`、`npx nuxi typecheck`

Refs #238
Refs ippoan/alc-app-s3#135

🤖 Generated with [Claude Code](https://claude.com/claude-code)
