### PR TITLE
fix(kiosk): 確認中は「未登録」を出さず、帯を 1 つにまとめる (Refs #238)

### DIFF
--- a/web/app/components/DeviceUnregisteredBanner.vue
+++ b/web/app/components/DeviceUnregisteredBanner.vue
@@ -1,25 +1,30 @@
 <script setup lang="ts">
 /**
- * 運行者タブの入口に出す「端末未登録」の案内 (Refs #206)。
+ * 運行者タブの入口に出す「端末未登録」の案内 (Refs #206 → #234 → #238)。
  *
  * 端末登録 (device JWT) も管理者ログイン (access token) も無いと、`api.ts` の request() は
  * テナント無しの直 fetch に落ちる。すると by-nfc は 404 になり打刻一覧は空になるが、画面には
  * 「乗務員に登録されていません」「本日の打刻はまだありません」としか出ず原因が分からない。
  * 原因をここで 1 か所だけ出す (fallback 自体と各 catch の文言は触らない)。
+ *
+ * 起動直後の CoreS3 探索中 (`isCheckingKioskAccess`) は出さない — 最大 3 秒で解決するのに
+ * 「未登録」を出してしまうと、運行管理者の PC (ログイン無し共用 PC) で毎回この帯が一瞬
+ * 出ては消えることになる (#238)。管理者ログイン (/login) へは誘導しない — 運行者を
+ * /login に誘導しない決定 (#238) のため。
  */
 import { deviceUnregisteredMessage } from '~/utils/employee-lookup-messages'
 
-const { hasKioskAccess } = useKioskAccess()
+const { hasKioskAccess, isCheckingKioskAccess } = useKioskAccess()
 </script>
 
 <template>
   <div
-    v-if="!hasKioskAccess"
+    v-if="!hasKioskAccess && !isCheckingKioskAccess"
     data-testid="device-unregistered-banner"
     class="w-full max-w-lg mx-auto px-4 mt-2"
   >
     <div class="bg-red-50 border border-red-200 rounded-xl p-3 text-sm text-red-700">
-      {{ deviceUnregisteredMessage }}。メニュー →「端末登録」で QR を読み取ってください。登録するまで免許証の照合と打刻一覧は動きません。CoreS3 が USB でつながっていれば、下 (または NFC 画面) の「CoreS3 を USB で許可」を押すだけでも動きます
+      {{ deviceUnregisteredMessage }}。CoreS3 を USB でつなぐと自動で使えるようになります。Chrome が CoreS3 をまだ許可していなければ「CoreS3 を USB で許可」を押してください。初めて使う CoreS3 は、管理者が登録画面で鍵を登録してください
     </div>
   </div>
 </template>

--- a/web/app/components/NfcStatus.vue
+++ b/web/app/components/NfcStatus.vue
@@ -9,6 +9,7 @@ const emit = defineEmits<{
 
 const { isConnected, error, readers, bridgeVersion, connect, onRead, onLicenseRead } = useNfcReader()
 const { latestVersion, checkLatestVersion, isUpdateAvailable } = useNfcBridgeUpdate()
+const { isCheckingKioskAccess } = useKioskAccess()
 
 // WebSerial の初回許可はユーザー操作が要る (CoreS3 直結のポート選択)
 const coreS3 = useCoreS3Serial()
@@ -75,6 +76,8 @@ onRead((event: NfcReadEvent) => {
 })
 
 const statusText = computed(() => {
+  // 起動時の CoreS3 探索中 (上限 3 秒) は「未検出」と確定させない (Refs #238)
+  if (isCheckingKioskAccess.value) return '確認中…'
   if (error.value) return error.value
   if (!isConnected.value) return 'NFC リーダー未接続'
   if ((readers.value?.length ?? 0) === 0) return 'NFC リーダー未検出'
@@ -154,7 +157,7 @@ const showNfcGuide = ref(false)
     <!-- 未接続時の案内 -->
     <!-- CoreS3 直結 (WebSerial): 常駐アプリは要らない。NFC ブリッジの接続状態とは切り離す —
          NFC ブリッジ (bridge/Android) が繋がっていても CoreS3 の USB 許可はまだかもしれない -->
-    <template v-if="canUseSerial && !coreS3.isConnected.value">
+    <template v-if="canUseSerial && !coreS3.isConnected.value && !isCheckingKioskAccess">
       <div class="flex flex-col items-center gap-2">
         <p class="text-sm text-center text-gray-500">
           CoreS3 が USB でつながっているか確認してください。<br>

--- a/web/app/components/NormalMeasurement.vue
+++ b/web/app/components/NormalMeasurement.vue
@@ -30,7 +30,6 @@ const licenseExpiryStatus = ref<LicenseExpiryStatus | null>(null)
 const { isOnline, pending, isSyncing, save: offlineSave, syncQueue } = useOfflineSync()
 
 // シングルトン再呼出で共有状態取得
-const { hasKioskAccess } = useKioskAccess()
 const { isSyncing: isFaceSyncing, sync: faceSync } = useFaceSync()
 
 // 手動入力フォールバック
@@ -362,15 +361,6 @@ const currentStepIndex = computed(() => stepKeys.indexOf(step.value))
   ]">
     <!-- 左列 (横画面) / 上部 (縦画面): バナー + ステップ + フッターリンク -->
     <div :class="landscape ? 'w-2/5 flex flex-col shrink-0' : 'w-full flex flex-col items-center'">
-      <!-- 端末未アクティベート警告 -->
-      <ClientOnly>
-        <div
-          v-if="!hasKioskAccess"
-          :class="['w-full bg-red-50 border border-red-200 rounded-xl px-4 py-2 mb-2 text-center text-sm text-red-700', landscape ? '' : 'max-w-md']"
-        >
-          端末未登録 — <NuxtLink to="/login" class="underline font-medium">管理者ログイン</NuxtLink>で端末を登録してください
-        </div>
-      </ClientOnly>
       <!-- オフラインバナー -->
       <div
         v-if="!isOnline"

--- a/web/app/components/TenkoKiosk.vue
+++ b/web/app/components/TenkoKiosk.vue
@@ -11,7 +11,6 @@ const props = defineProps<{
 }>()
 
 // シングルトン再呼出で共有状態取得
-const { hasKioskAccess } = useKioskAccess()
 const { isSyncing: isFaceSyncing } = useFaceSync()
 
 // デモモード (prop 優先、なければ URL クエリ)
@@ -301,16 +300,6 @@ onUnmounted(() => {
       <!-- デモ用点呼予定作成 (NFCステップのみ表示) -->
       <ClientOnly>
         <DemoScheduleCreator v-if="isDemoMode && !remoteMode && step === 'nfc'" :class="['w-full mb-4', landscape ? '' : 'max-w-md']" />
-      </ClientOnly>
-
-      <!-- 端末未アクティベート警告 -->
-      <ClientOnly>
-        <div
-          v-if="!hasKioskAccess"
-          :class="['w-full bg-red-50 border border-red-200 rounded-xl px-4 py-2 mb-2 text-center text-sm text-red-700', landscape ? '' : 'max-w-md']"
-        >
-          端末未登録 — <NuxtLink to="/login" class="underline font-medium">管理者ログイン</NuxtLink>で端末を登録してください
-        </div>
       </ClientOnly>
 
       <!-- 顔データ同期中 -->

--- a/web/app/composables/useKioskAccess.ts
+++ b/web/app/composables/useKioskAccess.ts
@@ -10,14 +10,23 @@
  *
  * `useAuth.ts` には置かない — `useDeviceToken` が `useAuth` の `deviceTenantId` を
  * 読むため、逆向きに `useAuth` から `useDeviceToken` を呼ぶと相互依存になる。
+ *
+ * `isCheckingKioskAccess` (Refs #238): 起動直後、CoreS3 の探索 (`useCoreS3Serial`
+ * `isStartupProbing`、上限 3 秒) が終わるまでは「まだ無い」と「このまま無い」を
+ * 区別できない。探索中は「未登録」の案内を出さず確認中として扱う。
  */
 export function useKioskAccess() {
   const { isAuthenticated, isDeviceActivated } = useAuth()
   const { hasDeviceJwt } = useDeviceToken()
+  const { isStartupProbing } = useCoreS3Serial()
 
   const hasKioskAccess = computed(() =>
     isAuthenticated.value || isDeviceActivated.value || hasDeviceJwt.value,
   )
 
-  return { hasKioskAccess }
+  const isCheckingKioskAccess = computed(() =>
+    !hasKioskAccess.value && isStartupProbing.value,
+  )
+
+  return { hasKioskAccess, isCheckingKioskAccess }
 }

--- a/web/tests/components/DeviceUnregisteredBanner.test.ts
+++ b/web/tests/components/DeviceUnregisteredBanner.test.ts
@@ -4,15 +4,17 @@ import { mountSuspended, mockNuxtImport } from '@nuxt/test-utils/runtime'
 import DeviceUnregisteredBanner from '~/components/DeviceUnregisteredBanner.vue'
 import { deviceUnregisteredMessage } from '~/utils/employee-lookup-messages'
 
-// 「未登録」の判定は useKioskAccess に一本化した (Refs #234)。この banner は
-// hasKioskAccess だけを見るので、その 1 変数だけをモックする。
+// 「未登録」の判定は useKioskAccess に一本化した (Refs #234, #238)。この banner は
+// hasKioskAccess / isCheckingKioskAccess だけを見るので、その 2 変数だけをモックする。
 const hasKioskAccess = ref(false)
+const isCheckingKioskAccess = ref(false)
 
-mockNuxtImport('useKioskAccess', () => () => ({ hasKioskAccess }))
+mockNuxtImport('useKioskAccess', () => () => ({ hasKioskAccess, isCheckingKioskAccess }))
 
 describe('DeviceUnregisteredBanner', () => {
   beforeEach(() => {
     hasKioskAccess.value = false
+    isCheckingKioskAccess.value = false
   })
 
   it('hasKioskAccess が false なら赤枠で原因と次の操作を出す', async () => {
@@ -21,8 +23,8 @@ describe('DeviceUnregisteredBanner', () => {
     const banner = wrapper.find('[data-testid="device-unregistered-banner"]')
     expect(banner.exists()).toBe(true)
     expect(banner.text()).toContain(deviceUnregisteredMessage)
-    expect(banner.text()).toContain('「端末登録」で QR を読み取ってください')
-    expect(banner.text()).toContain('登録するまで免許証の照合と打刻一覧は動きません')
+    expect(banner.text()).toContain('CoreS3 を USB でつなぐと自動で使えるようになります')
+    expect(banner.text()).toContain('初めて使う CoreS3 は、管理者が登録画面で鍵を登録してください')
     expect(wrapper.find('.border-red-200').exists()).toBe(true)
     wrapper.unmount()
   })
@@ -41,6 +43,31 @@ describe('DeviceUnregisteredBanner', () => {
     hasKioskAccess.value = true
     await wrapper.vm.$nextTick()
     expect(wrapper.find('[data-testid="device-unregistered-banner"]').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('isCheckingKioskAccess が true の間は出さない (起動時 CoreS3 探索中、Refs #238)', async () => {
+    isCheckingKioskAccess.value = true
+    const wrapper = await mountSuspended(DeviceUnregisteredBanner)
+    expect(wrapper.find('[data-testid="device-unregistered-banner"]').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('確認が終わり isCheckingKioskAccess が false になれば出る', async () => {
+    isCheckingKioskAccess.value = true
+    const wrapper = await mountSuspended(DeviceUnregisteredBanner)
+    expect(wrapper.find('[data-testid="device-unregistered-banner"]').exists()).toBe(false)
+
+    isCheckingKioskAccess.value = false
+    await wrapper.vm.$nextTick()
+    expect(wrapper.find('[data-testid="device-unregistered-banner"]').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('/login へのリンクは置かない (運行者を /login に誘導しない決定、Refs #238)', async () => {
+    const wrapper = await mountSuspended(DeviceUnregisteredBanner)
+    expect(wrapper.find('a[href="/login"]').exists()).toBe(false)
+    expect(wrapper.findComponent({ name: 'NuxtLink' }).exists()).toBe(false)
     wrapper.unmount()
   })
 })

--- a/web/tests/components/NfcStatus.test.ts
+++ b/web/tests/components/NfcStatus.test.ts
@@ -27,6 +27,8 @@ const requestPortMock = vi.fn(async () => true)
 mockNuxtImport('useCoreS3Serial', () => () => ({
   isConnected: readonly(coreS3Connected),
   requestPort: requestPortMock,
+  startupProbe: vi.fn(async () => false),
+  isStartupProbing: ref(false),
 }))
 
 mockNuxtImport('useFingerprint', () => () => ({

--- a/web/tests/components/NfcStatus.test.ts
+++ b/web/tests/components/NfcStatus.test.ts
@@ -34,6 +34,9 @@ mockNuxtImport('useFingerprint', () => () => ({
   deviceModel: ref<string | null>(null),
 }))
 
+const isCheckingKioskAccess = ref(false)
+mockNuxtImport('useKioskAccess', () => () => ({ isCheckingKioskAccess }))
+
 let webSerialSupported = true
 vi.mock('~/utils/webserial', () => ({
   isWebSerialSupported: () => webSerialSupported,
@@ -48,6 +51,7 @@ describe('NfcStatus — serial ブロックの表示条件 (Refs #234)', () => {
     isConnected.value = false
     coreS3Connected.value = false
     webSerialSupported = true
+    isCheckingKioskAccess.value = false
     requestPortMock.mockClear()
   })
 
@@ -92,6 +96,33 @@ describe('NfcStatus — serial ブロックの表示条件 (Refs #234)', () => {
     const button = findButtonByText(wrapper, 'USB デバイスを選択')
     await (button as unknown as { trigger: (e: string) => Promise<void> }).trigger('click')
     expect(requestPortMock).toHaveBeenCalled()
+    wrapper.unmount()
+  })
+
+  // 起動時 CoreS3 探索中は「未登録」確定の表示を出さない (Refs #238)
+  it('確認中は USB 許可ボタンを出さない (起動時 CoreS3 探索中)', async () => {
+    isCheckingKioskAccess.value = true
+    const wrapper = await mountSuspended(NfcStatus)
+    expect(findButtonByText(wrapper, 'USB デバイスを選択')).toBeFalsy()
+    wrapper.unmount()
+  })
+
+  it('確認中は「NFC リーダー未検出」を出さない', async () => {
+    isConnected.value = true
+    isCheckingKioskAccess.value = true
+    const wrapper = await mountSuspended(NfcStatus)
+    expect(wrapper.text()).not.toContain('NFC リーダー未検出')
+    wrapper.unmount()
+  })
+
+  it('確認が終われば USB 許可ボタン・ステータス文言が出る', async () => {
+    isCheckingKioskAccess.value = true
+    const wrapper = await mountSuspended(NfcStatus)
+    expect(findButtonByText(wrapper, 'USB デバイスを選択')).toBeFalsy()
+
+    isCheckingKioskAccess.value = false
+    await wrapper.vm.$nextTick()
+    expect(findButtonByText(wrapper, 'USB デバイスを選択')).toBeTruthy()
     wrapper.unmount()
   })
 })

--- a/web/tests/components/NormalMeasurement.test.ts
+++ b/web/tests/components/NormalMeasurement.test.ts
@@ -43,11 +43,6 @@ mockNuxtImport('useOfflineSync', () => () => ({
   syncQueue: vi.fn(),
 }))
 
-// 「未登録」の判定は useKioskAccess に一本化した (Refs #234)。既定は true (未登録
-// バナーの有無に依存しない他テストに影響させない)、専用テストだけ false に倒す。
-const hasKioskAccess = ref(true)
-mockNuxtImport('useKioskAccess', () => () => ({ hasKioskAccess }))
-
 const faceSyncMock = vi.fn(async () => {})
 mockNuxtImport('useFaceSync', () => () => ({
   isSyncing: ref(false),
@@ -99,21 +94,11 @@ async function touch(wrapper: Awaited<ReturnType<typeof mountNfcStep>>, nfcId: s
 describe('NormalMeasurement — NFC ステップの乗務員照合', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    hasKioskAccess.value = true
   })
 
-  it('hasKioskAccess が false なら「端末未登録」を出す', async () => {
-    hasKioskAccess.value = false
-    const wrapper = await mountNfcStep()
-    expect(wrapper.text()).toContain('端末未登録')
-    wrapper.unmount()
-  })
-
-  it('hasKioskAccess が true なら「端末未登録」を出さない', async () => {
-    const wrapper = await mountNfcStep()
-    expect(wrapper.text()).not.toContain('端末未登録')
-    wrapper.unmount()
-  })
+  // 「端末未登録」の案内は index.vue の DeviceUnregisteredBanner 1 つに寄せた (Refs #238)。
+  // 同じ画面に 2 本出ないよう、ここ (NormalMeasurement 内) の帯は削除済み — 表示条件の
+  // テストは tests/components/DeviceUnregisteredBanner.test.ts へ移した。
 
   it('免許証が乗務員に未登録 (by-nfc が失敗) なら赤枠に理由と次の操作を出す', async () => {
     getEmployeeByNfcIdMock.mockRejectedValue(new Error('404'))

--- a/web/tests/components/TimePunchKiosk.test.ts
+++ b/web/tests/components/TimePunchKiosk.test.ts
@@ -32,6 +32,8 @@ mockNuxtImport('useCoreS3Serial', () => () => ({
   isConnected: readonly(coreS3Connected),
   isSupported: coreS3Supported.value,
   requestPort: coreS3RequestPortMock,
+  startupProbe: vi.fn(async () => false),
+  isStartupProbing: ref(false),
 }))
 
 mockNuxtImport('useAuth', () => () => ({

--- a/web/tests/composables/useKioskAccess.test.ts
+++ b/web/tests/composables/useKioskAccess.test.ts
@@ -8,6 +8,10 @@ const accessToken = ref<string | null>(null)
 const deviceTenantId = ref<string | null>(null)
 const hasDeviceJwt = ref(false)
 
+// isStartupProbing は兄弟 #p135-c238-1 が useCoreS3Serial.ts に足す予定 (未マージ)。
+// ここでは mock だけで検証し、マージ後に rebase してそのまま通す (Refs #238)。
+const isStartupProbing = ref(false)
+
 mockNuxtImport('useAuth', () => () => ({
   accessToken,
   deviceTenantId,
@@ -19,11 +23,16 @@ mockNuxtImport('useDeviceToken', () => () => ({
   hasDeviceJwt,
 }))
 
+mockNuxtImport('useCoreS3Serial', () => () => ({
+  isStartupProbing,
+}))
+
 describe('useKioskAccess', () => {
   beforeEach(() => {
     accessToken.value = null
     deviceTenantId.value = null
     hasDeviceJwt.value = false
+    isStartupProbing.value = false
   })
 
   it('3 条件すべて false なら hasKioskAccess は false', async () => {
@@ -51,5 +60,36 @@ describe('useKioskAccess', () => {
     const { useKioskAccess } = await import('~/composables/useKioskAccess')
     const { hasKioskAccess } = useKioskAccess()
     expect(hasKioskAccess.value).toBe(true)
+  })
+
+  // isCheckingKioskAccess の真理値表 (hasKioskAccess × isStartupProbing, Refs #238)
+  describe('isCheckingKioskAccess', () => {
+    it('hasKioskAccess=false, isStartupProbing=false → false (確認中ではない=未登録確定)', async () => {
+      const { useKioskAccess } = await import('~/composables/useKioskAccess')
+      const { isCheckingKioskAccess } = useKioskAccess()
+      expect(isCheckingKioskAccess.value).toBe(false)
+    })
+
+    it('hasKioskAccess=false, isStartupProbing=true → true (確認中)', async () => {
+      isStartupProbing.value = true
+      const { useKioskAccess } = await import('~/composables/useKioskAccess')
+      const { isCheckingKioskAccess } = useKioskAccess()
+      expect(isCheckingKioskAccess.value).toBe(true)
+    })
+
+    it('hasKioskAccess=true, isStartupProbing=false → false (そもそもアクセスあり)', async () => {
+      accessToken.value = 'jwt'
+      const { useKioskAccess } = await import('~/composables/useKioskAccess')
+      const { isCheckingKioskAccess } = useKioskAccess()
+      expect(isCheckingKioskAccess.value).toBe(false)
+    })
+
+    it('hasKioskAccess=true, isStartupProbing=true → false (アクセスがあるので確認中扱いにしない)', async () => {
+      accessToken.value = 'jwt'
+      isStartupProbing.value = true
+      const { useKioskAccess } = await import('~/composables/useKioskAccess')
+      const { isCheckingKioskAccess } = useKioskAccess()
+      expect(isCheckingKioskAccess.value).toBe(false)
+    })
   })
 })

--- a/web/tests/composables/useKioskAccess.test.ts
+++ b/web/tests/composables/useKioskAccess.test.ts
@@ -8,8 +8,7 @@ const accessToken = ref<string | null>(null)
 const deviceTenantId = ref<string | null>(null)
 const hasDeviceJwt = ref(false)
 
-// isStartupProbing は兄弟 #p135-c238-1 が useCoreS3Serial.ts に足す予定 (未マージ)。
-// ここでは mock だけで検証し、マージ後に rebase してそのまま通す (Refs #238)。
+// isStartupProbing は useCoreS3Serial.ts の起動時探索フラグ (Refs #238)。
 const isStartupProbing = ref(false)
 
 mockNuxtImport('useAuth', () => () => ({
@@ -24,6 +23,7 @@ mockNuxtImport('useDeviceToken', () => () => ({
 }))
 
 mockNuxtImport('useCoreS3Serial', () => () => ({
+  startupProbe: async () => false,
   isStartupProbing,
 }))
 

--- a/web/tests/composables/useNfcReader.test.ts
+++ b/web/tests/composables/useNfcReader.test.ts
@@ -30,6 +30,8 @@ const coreMock = {
   requestPort: vi.fn(async () => true),
   release: vi.fn(async () => {}),
   disconnect: vi.fn(async () => {}),
+  startupProbe: vi.fn(async () => false),
+  isStartupProbing: ref(false),
 }
 mockNuxtImport('useCoreS3Serial', () => () => ({
   ...coreMock,


### PR DESCRIPTION
## 何を変えるか

運行者端末で画面を再読み込みすると、CoreS3 の接続と端末 JWT の取得が済むまでの数秒、「この端末は登録されていません…」の帯・「端末未登録 — 管理者ログインで端末を登録してください」の帯・「NFC リーダー未検出」・「USB デバイスを選択」が出てから消えていた。#238 の 2 本目 (1 本目の起動時の探索を使う)。

- `web/app/composables/useKioskAccess.ts`: `isCheckingKioskAccess` (まだ使える状態になっておらず、起動時の探索の途中) を足す。探索は 3 秒で必ず終わるので、確認中のまま残らない
- `web/app/components/DeviceUnregisteredBanner.vue`: 確認中は出さない。文言を今の手順に合わせた (CoreS3 を USB でつなぐと使える / Chrome が CoreS3 を許可していなければ「CoreS3 を USB で許可」/ 初めての CoreS3 は管理者が登録画面で鍵を登録)。ログイン画面へのリンクは置かない
- `NormalMeasurement.vue` / `TenkoKiosk.vue`: 運行者タブの上に同じ帯が既に出ていて 2 本並んでいたので、画面の中の古い帯 (ログイン画面へのリンク付き) を削除
- `web/app/components/NfcStatus.vue`: 確認中は「確認中…」とし、「USB デバイスを選択」も出さない (3 秒で必ず出る)

## テスト

- useKioskAccess: 確認中の真理値表
- DeviceUnregisteredBanner: 新しい文言 / 確認中は出ない / ログイン画面へのリンクが無い
- NfcStatus: 確認中は未検出と選択ボタンが出ず、終われば出る
- NormalMeasurement: 古い帯のテストを帯の部品側へ
- vitest 全体、`check_coverage_100`、`npx nuxi typecheck`

Refs #238
Refs ippoan/alc-app-s3#135

🤖 Generated with [Claude Code](https://claude.com/claude-code)
