### PR TITLE
feat(medical): 体温・血圧の画面を CoreS3 前提にし、血圧を隠す (Refs #238)

### DIFF
--- a/web/app/components/BleStatus.vue
+++ b/web/app/components/BleStatus.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { isWebSerialSupported } from '~/utils/webserial'
+import { SHOW_BLOOD_PRESSURE } from '~/utils/medical-inputs'
 
 const emit = defineEmits<{
   skip: []
@@ -51,9 +52,9 @@ onMounted(async () => {
     <!-- 未接続 (自動接続失敗) -->
     <div v-else-if="!isConnected" class="flex flex-col items-center gap-3">
       <p class="text-gray-500 text-sm text-center">
-        BLE ゲートウェイが見つかりません。<br>
+        CoreS3 が見つかりません。<br>
         <template v-if="isWebSerialSupported()">
-          ATOM Lite が USB 接続されていることを確認してください。
+          CoreS3 が USB でつながっているか確認してください。
         </template>
         <template v-else>
           Android BLE ブリッジが起動していることを確認してください。
@@ -64,7 +65,7 @@ onMounted(async () => {
           class="px-4 py-2 bg-blue-600 text-white rounded-lg text-sm hover:bg-blue-700 transition-colors"
           @click="connect"
         >
-          {{ isWebSerialSupported() ? '手動で接続' : '再接続' }}
+          {{ isWebSerialSupported() ? 'USB デバイスを選択' : '再接続' }}
         </button>
         <button
           class="px-4 py-2 bg-gray-200 text-gray-700 rounded-lg text-sm hover:bg-gray-300 transition-colors"
@@ -86,7 +87,7 @@ onMounted(async () => {
             />
             体温計
           </span>
-          <span class="flex items-center gap-2">
+          <span v-if="SHOW_BLOOD_PRESSURE" class="flex items-center gap-2">
             <span
               class="w-2.5 h-2.5 rounded-full"
               :class="bloodPressureConnected ? 'bg-green-500' : 'bg-gray-300'"
@@ -96,7 +97,7 @@ onMounted(async () => {
         </div>
 
         <!-- 測定値カード -->
-        <div class="grid grid-cols-2 gap-3">
+        <div class="grid gap-3" :class="SHOW_BLOOD_PRESSURE ? 'grid-cols-2' : 'grid-cols-1'">
           <!-- 体温 -->
           <div
             class="rounded-xl p-4 text-center"
@@ -112,6 +113,7 @@ onMounted(async () => {
 
           <!-- 血圧 -->
           <div
+            v-if="SHOW_BLOOD_PRESSURE"
             class="rounded-xl p-4 text-center"
             :class="latestBloodPressure ? 'bg-blue-50 border border-blue-200' : 'bg-gray-50 border border-gray-200'"
           >

--- a/web/app/components/DeviceSettings.vue
+++ b/web/app/components/DeviceSettings.vue
@@ -1,13 +1,7 @@
 <script setup lang="ts">
 import type { DeviceSettingsResponse } from '~/types'
-
-// BLE Gateway の既知 VID:PID (CH340, CP210x, Espressif, FTDI FT232R)
-const BLE_GW_DEVICES = [
-  { vid: 0x1A86 },            // CH340/CH552
-  { vid: 0x10C4 },            // CP210x
-  { vid: 0x303A },            // Espressif native USB
-  { vid: 0x0403, pid: 0x6001 }, // FTDI FT232R (ATOM Lite)
-]
+import { BLE_GW_DEVICES } from '~/composables/useSerialArbiter'
+import { SHOW_BLOOD_PRESSURE } from '~/utils/medical-inputs'
 
 const { ports, isSupported, refreshPorts, forgetPort } = useSerialDeviceManager()
 const { isAndroidApp } = useFingerprint()
@@ -387,7 +381,7 @@ async function testBleGw() {
         `接続成功`,
         ver ? `FW: v${ver}` : null,
         `体温計: ${thermo ? '接続' : '未接続'}`,
-        `血圧計: ${bp ? '接続' : '未接続'}`,
+        SHOW_BLOOD_PRESSURE ? `血圧計: ${bp ? '接続' : '未接続'}` : null,
       ].filter(Boolean).join(' / ')
     } else {
       bleGwTestResult.value = '接続失敗 — ATOM Lite が USB に接続されているか確認してください'
@@ -412,8 +406,8 @@ async function testAndroidBle() {
       bleGwTestResult.value = [
         `BLE ブリッジ接続成功`,
         `体温計: ${thermo ? '検出済み' : '未検出'}`,
-        `血圧計: ${bp ? '検出済み' : '未検出'}`,
-      ].join(' / ')
+        SHOW_BLOOD_PRESSURE ? `血圧計: ${bp ? '検出済み' : '未検出'}` : null,
+      ].filter(Boolean).join(' / ')
     } else {
       bleGwTestResult.value = 'BLE ブリッジ接続失敗 — アプリを再起動してください'
     }
@@ -636,7 +630,7 @@ async function syncFc1200Date() {
       <!-- BLE セクション (Android) -->
       <div class="bg-white rounded-xl shadow-sm overflow-hidden">
         <div class="px-4 py-3 bg-gray-50 border-b">
-          <h3 class="text-sm font-medium text-gray-800">BLE 医療機器 (体温計・血圧計)</h3>
+          <h3 class="text-sm font-medium text-gray-800">BLE 医療機器 ({{ SHOW_BLOOD_PRESSURE ? '体温計・血圧計' : '体温計' }})</h3>
           <p class="text-xs text-gray-500">Android BLE スキャン → WebSocket ブリッジ</p>
         </div>
         <div class="p-4">
@@ -655,7 +649,7 @@ async function syncFc1200Date() {
                 <span class="w-1.5 h-1.5 rounded-full" :class="bleGw.thermometerConnected.value ? 'bg-green-500' : 'bg-gray-300'" />
                 体温計: {{ bleGw.thermometerConnected.value ? '検出' : '未検出' }}
               </span>
-              <span class="flex items-center gap-1">
+              <span v-if="SHOW_BLOOD_PRESSURE" class="flex items-center gap-1">
                 <span class="w-1.5 h-1.5 rounded-full" :class="bleGw.bloodPressureConnected.value ? 'bg-green-500' : 'bg-gray-300'" />
                 血圧計: {{ bleGw.bloodPressureConnected.value ? '検出' : '未検出' }}
               </span>
@@ -778,8 +772,8 @@ async function syncFc1200Date() {
       <div class="bg-white rounded-xl shadow-sm overflow-hidden">
         <div class="px-4 py-3 bg-gray-50 border-b flex items-center justify-between">
           <div>
-            <h3 class="text-sm font-medium text-gray-800">BLE ゲートウェイ (ATOM Lite)</h3>
-            <p class="text-xs text-gray-500">体温計・血圧計接続用 / 115200 baud</p>
+            <h3 class="text-sm font-medium text-gray-800">BLE 体温計・血圧計 (CoreS3)</h3>
+            <p class="text-xs text-gray-500">{{ SHOW_BLOOD_PRESSURE ? '体温計・血圧計接続用' : '体温計接続用' }} / 115200 baud</p>
           </div>
           <button
             class="px-3 py-1.5 bg-blue-600 text-white rounded-lg text-xs hover:bg-blue-700 transition-colors"
@@ -800,7 +794,7 @@ async function syncFc1200Date() {
               <div class="flex items-center gap-2">
                 <span class="w-2 h-2 rounded-full" :class="bleGw.isConnected.value ? 'bg-green-500' : 'bg-gray-300'" />
                 <div>
-                  <p class="text-sm text-gray-800">ATOM Lite BLE Gateway</p>
+                  <p class="text-sm text-gray-800">ESP32-S3 (CoreS3 など)</p>
                   <p class="text-xs text-gray-500 font-mono">{{ formatVidPid(entry.info) }}</p>
                 </div>
               </div>
@@ -822,7 +816,7 @@ async function syncFc1200Date() {
                 <span class="w-1.5 h-1.5 rounded-full" :class="bleGw.thermometerConnected.value ? 'bg-green-500' : 'bg-gray-300'" />
                 体温計
               </span>
-              <span class="flex items-center gap-1">
+              <span v-if="SHOW_BLOOD_PRESSURE" class="flex items-center gap-1">
                 <span class="w-1.5 h-1.5 rounded-full" :class="bleGw.bloodPressureConnected.value ? 'bg-green-500' : 'bg-gray-300'" />
                 血圧計
               </span>

--- a/web/app/components/ManualMedicalInput.vue
+++ b/web/app/components/ManualMedicalInput.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { SubmitMedicalData } from '~/types'
+import { SHOW_BLOOD_PRESSURE } from '~/utils/medical-inputs'
 
 const emit = defineEmits<{
   submit: [data: SubmitMedicalData]
@@ -7,8 +8,9 @@ const emit = defineEmits<{
 }>()
 
 const temperature = ref<number | null>(36.5)
-const systolic = ref<number | null>(120)
-const diastolic = ref<number | null>(80)
+// 血圧欄を隠している間は既定値を送らない (偽の 120/80 が送信され続けないように)
+const systolic = ref<number | null>(SHOW_BLOOD_PRESSURE ? 120 : null)
+const diastolic = ref<number | null>(SHOW_BLOOD_PRESSURE ? 80 : null)
 const pulse = ref<number | null>(70)
 
 function handleSubmit() {
@@ -64,7 +66,7 @@ function handleSkip() {
       </div>
 
       <!-- 収縮期血圧 -->
-      <div class="flex flex-col gap-1">
+      <div v-if="SHOW_BLOOD_PRESSURE" class="flex flex-col gap-1">
         <label class="text-xs font-medium text-gray-600">収縮期血圧 (mmHg)</label>
         <input
           v-model.number="systolic"
@@ -78,7 +80,7 @@ function handleSkip() {
       </div>
 
       <!-- 拡張期血圧 -->
-      <div class="flex flex-col gap-1">
+      <div v-if="SHOW_BLOOD_PRESSURE" class="flex flex-col gap-1">
         <label class="text-xs font-medium text-gray-600">拡張期血圧 (mmHg)</label>
         <input
           v-model.number="diastolic"

--- a/web/app/components/NormalMeasurement.vue
+++ b/web/app/components/NormalMeasurement.vue
@@ -4,6 +4,7 @@ import { getEmployeeByNfcId, getEmployeeByCode, startMeasurement, updateMeasurem
 import { saveVideo, markVideoUploaded, getPendingVideos, cleanupOldVideos } from '~/utils/video-store'
 import { checkLicenseExpiry, formatExpiryDate, type LicenseExpiryStatus } from '~/utils/license'
 import { employeeNotFoundByNfc, employeeNotFoundByCode } from '~/utils/employee-lookup-messages'
+import { SHOW_BLOOD_PRESSURE } from '~/utils/medical-inputs'
 
 const { isDemoMode: isDemoModeFromUrl } = useDemoMode()
 
@@ -349,7 +350,7 @@ function reset() {
   stopMeasuringCamera()
 }
 
-const steps = ['NFC', '体温・血圧', '測定', '結果'] as const
+const steps = ['NFC', SHOW_BLOOD_PRESSURE ? '体温・血圧' : '体温', '測定', '結果'] as const
 const stepKeys = ['nfc', 'medical', 'measuring', 'result'] as const
 const currentStepIndex = computed(() => stepKeys.indexOf(step.value))
 </script>
@@ -510,7 +511,7 @@ const currentStepIndex = computed(() => stepKeys.indexOf(step.value))
       <!-- Step 2: 体温・血圧 (BLE Medical Gateway / 手動入力) -->
       <div v-if="step === 'medical'" class="flex flex-col gap-4">
         <div class="bg-white rounded-2xl p-6 shadow-sm">
-          <h2 class="text-lg font-semibold text-gray-700 mb-2">体温・血圧</h2>
+          <h2 class="text-lg font-semibold text-gray-700 mb-2">{{ SHOW_BLOOD_PRESSURE ? '体温・血圧' : '体温' }}</h2>
           <p class="text-sm text-gray-500 mb-4">{{ employeeName }}</p>
 
           <!-- タブ切替 (デモ時は BLE タブ非表示) -->
@@ -586,7 +587,7 @@ const currentStepIndex = computed(() => stepKeys.indexOf(step.value))
         />
         <!-- 医療データ入力元バッジ -->
         <div
-          v-if="medicalInputSource && (measurementResult.temperature || measurementResult.systolic)"
+          v-if="medicalInputSource && (measurementResult.temperature || (SHOW_BLOOD_PRESSURE && measurementResult.systolic))"
           class="text-center text-xs"
         >
           <span

--- a/web/app/components/TenkoKiosk.vue
+++ b/web/app/components/TenkoKiosk.vue
@@ -3,6 +3,7 @@ import type { FaceAuthResult, MeasurementResult, SubmitMedicalData } from '~/typ
 import { getEmployeeByNfcId, getEmployeeByCode } from '~/utils/api'
 import { checkFaceApproval } from '~/utils/face-approval'
 import { employeeNotFoundByNfc, employeeNotFoundByCode } from '~/utils/employee-lookup-messages'
+import { SHOW_BLOOD_PRESSURE } from '~/utils/medical-inputs'
 
 const props = defineProps<{
   demoMode?: boolean
@@ -465,7 +466,7 @@ onUnmounted(() => {
       <!-- Step 5: 体温・血圧 (業務前のみ) -->
       <div v-else-if="step === 'medical'" class="flex flex-col gap-4">
         <div class="bg-white rounded-2xl p-4 shadow-sm">
-          <h2 class="text-lg font-semibold text-gray-700 mb-2">体温・血圧</h2>
+          <h2 class="text-lg font-semibold text-gray-700 mb-2">{{ SHOW_BLOOD_PRESSURE ? '体温・血圧' : '体温' }}</h2>
 
           <!-- タブ切替 (デモ時は BLE タブ非表示) -->
           <div v-if="!isDemoMode" class="flex gap-1 bg-gray-100 rounded-lg p-1 mb-4">
@@ -556,14 +557,14 @@ onUnmounted(() => {
           />
           <!-- 医療データ入力元バッジ (業務前のみ) -->
           <div
-            v-if="medicalInputSource && isPreOperation && (session.temperature || session.systolic)"
+            v-if="medicalInputSource && isPreOperation && (session.temperature || (SHOW_BLOOD_PRESSURE && session.systolic))"
             class="mt-3 text-center text-xs"
           >
             <span
               class="inline-flex items-center gap-1 px-2 py-1 rounded-full"
               :class="medicalInputSource === 'manual' ? 'bg-amber-100 text-amber-700' : 'bg-blue-100 text-blue-700'"
             >
-              体温・血圧: {{ medicalInputSource === 'manual' ? '手動入力' : 'BLE機器' }}
+              {{ SHOW_BLOOD_PRESSURE ? '体温・血圧' : '体温' }}: {{ medicalInputSource === 'manual' ? '手動入力' : 'BLE機器' }}
             </span>
           </div>
         </div>

--- a/web/app/utils/medical-inputs.ts
+++ b/web/app/utils/medical-inputs.ts
@@ -1,0 +1,8 @@
+/**
+ * 血圧計の表示 ON/OFF (Refs ippoan/alc-app#238 / ippoan/alc-app-s3#135)。
+ *
+ * 血圧計 (ニプロ NBP-1BLE) の受信・送信ロジックは残したまま、画面表示だけを
+ * このフラグで隠す。将来オプションとして表示単位を選べるようにする計画だが、
+ * 単位 (テナント単位か端末単位か等) は未確定のため、今は定数 1 つで一律に隠す。
+ */
+export const SHOW_BLOOD_PRESSURE = false

--- a/web/tests/components/BleStatus.test.ts
+++ b/web/tests/components/BleStatus.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ref, readonly } from 'vue'
+import { mountSuspended, mockNuxtImport } from '@nuxt/test-utils/runtime'
+
+let webSerialSupported = true
+vi.mock('~/utils/webserial', () => ({
+  isWebSerialSupported: () => webSerialSupported,
+}))
+
+const isConnected = ref(false)
+const thermometerConnected = ref(false)
+const bloodPressureConnected = ref(false)
+const latestTemperature = ref<{ value: number } | null>(null)
+const latestBloodPressure = ref<{ systolic: number, diastolic: number, pulse?: number } | null>(null)
+const hasMedicalData = ref(false)
+const startAutoConnectMock = vi.fn(async () => true)
+
+mockNuxtImport('useBleGateway', () => () => ({
+  isConnected: readonly(isConnected),
+  error: ref<string | null>(null),
+  thermometerConnected: readonly(thermometerConnected),
+  bloodPressureConnected: readonly(bloodPressureConnected),
+  latestTemperature: readonly(latestTemperature),
+  latestBloodPressure: readonly(latestBloodPressure),
+  hasMedicalData: readonly(hasMedicalData),
+  transport: ref(null),
+  connect: vi.fn(),
+  startAutoConnect: startAutoConnectMock,
+  clearReadings: vi.fn(),
+  resetGateway: vi.fn(),
+}))
+
+// SHOW_BLOOD_PRESSURE は定数エクスポートなので、値ごとに vi.doMock + resetModules で
+// component を取り直す (モジュールスコープ状態のテスト分離パターンに準拠)。
+describe('BleStatus — CoreS3 前提の文言・血圧の出し分け (Refs #238)', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    webSerialSupported = true
+    isConnected.value = false
+    thermometerConnected.value = false
+    bloodPressureConnected.value = false
+    latestTemperature.value = null
+    latestBloodPressure.value = null
+    hasMedicalData.value = false
+    startAutoConnectMock.mockReset()
+    startAutoConnectMock.mockResolvedValue(true)
+  })
+
+  it('未接続なら CoreS3 前提の文言を出す (ATOM Lite の文言は残らない)', async () => {
+    vi.doMock('~/utils/medical-inputs', () => ({ SHOW_BLOOD_PRESSURE: false }))
+    startAutoConnectMock.mockResolvedValue(false)
+    const { default: BleStatus } = await import('~/components/BleStatus.vue')
+    const wrapper = await mountSuspended(BleStatus)
+    // onMounted の startAutoConnect (async) を消化
+    await new Promise(resolve => setTimeout(resolve, 0))
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.text()).toContain('CoreS3 が見つかりません')
+    expect(wrapper.text()).toContain('CoreS3 が USB でつながっているか確認してください')
+    expect(wrapper.text()).not.toContain('ATOM Lite')
+    const btn = wrapper.findAll('button').find(b => b.text() === 'USB デバイスを選択')
+    expect(btn).toBeTruthy()
+
+    wrapper.unmount()
+  })
+
+  it('SHOW_BLOOD_PRESSURE=false: 接続中でも血圧の表示が出ない', async () => {
+    vi.doMock('~/utils/medical-inputs', () => ({ SHOW_BLOOD_PRESSURE: false }))
+    isConnected.value = true
+    latestBloodPressure.value = { systolic: 120, diastolic: 80 }
+    const { default: BleStatus } = await import('~/components/BleStatus.vue')
+    const wrapper = await mountSuspended(BleStatus)
+
+    expect(wrapper.text()).not.toContain('血圧')
+
+    wrapper.unmount()
+  })
+
+  it('SHOW_BLOOD_PRESSURE=true: 接続中は従来どおり血圧を出す', async () => {
+    vi.doMock('~/utils/medical-inputs', () => ({ SHOW_BLOOD_PRESSURE: true }))
+    isConnected.value = true
+    latestBloodPressure.value = { systolic: 118, diastolic: 76 }
+    const { default: BleStatus } = await import('~/components/BleStatus.vue')
+    const wrapper = await mountSuspended(BleStatus)
+
+    expect(wrapper.text()).toContain('血圧')
+    expect(wrapper.text()).toContain('118')
+    expect(wrapper.text()).toContain('76')
+
+    wrapper.unmount()
+  })
+})

--- a/web/tests/components/ManualMedicalInput.test.ts
+++ b/web/tests/components/ManualMedicalInput.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import type { SubmitMedicalData } from '~/types'
+
+// SHOW_BLOOD_PRESSURE は定数エクスポートなので、値ごとに vi.doMock + resetModules で
+// component を取り直す (モジュールスコープ状態のテスト分離パターンに準拠)。
+describe('ManualMedicalInput — SHOW_BLOOD_PRESSURE の出し分け (Refs #238)', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  it('SHOW_BLOOD_PRESSURE=false: 血圧欄が無く、送信データの systolic/diastolic が無い (null 送信、偽の 120/80 を防ぐ)', async () => {
+    vi.doMock('~/utils/medical-inputs', () => ({ SHOW_BLOOD_PRESSURE: false }))
+    const { default: ManualMedicalInput } = await import('~/components/ManualMedicalInput.vue')
+    const wrapper = await mountSuspended(ManualMedicalInput)
+
+    expect(wrapper.text()).not.toContain('収縮期血圧')
+    expect(wrapper.text()).not.toContain('拡張期血圧')
+
+    const submitBtn = wrapper.findAll('button').find(b => b.text() === '送信')
+    await submitBtn!.trigger('click')
+
+    const emitted = wrapper.emitted('submit')
+    expect(emitted).toBeTruthy()
+    const data = emitted![0]![0] as SubmitMedicalData
+    expect(data.systolic).toBeUndefined()
+    expect(data.diastolic).toBeUndefined()
+    // 体温・脈拍は影響を受けない
+    expect(data.temperature).toBe(36.5)
+    expect(data.pulse).toBe(70)
+
+    wrapper.unmount()
+  })
+
+  it('SHOW_BLOOD_PRESSURE=true: 血圧欄があり、従来どおり既定値 120/80 が送られる', async () => {
+    vi.doMock('~/utils/medical-inputs', () => ({ SHOW_BLOOD_PRESSURE: true }))
+    const { default: ManualMedicalInput } = await import('~/components/ManualMedicalInput.vue')
+    const wrapper = await mountSuspended(ManualMedicalInput)
+
+    expect(wrapper.text()).toContain('収縮期血圧')
+    expect(wrapper.text()).toContain('拡張期血圧')
+
+    const submitBtn = wrapper.findAll('button').find(b => b.text() === '送信')
+    await submitBtn!.trigger('click')
+
+    const emitted = wrapper.emitted('submit')
+    const data = emitted![0]![0] as SubmitMedicalData
+    expect(data.systolic).toBe(120)
+    expect(data.diastolic).toBe(80)
+
+    wrapper.unmount()
+  })
+})

--- a/web/tests/components/NormalMeasurement.test.ts
+++ b/web/tests/components/NormalMeasurement.test.ts
@@ -128,17 +128,17 @@ describe('NormalMeasurement — NFC ステップの乗務員照合', () => {
     wrapper.unmount()
   })
 
-  it('乗務員が引ければ顔認証を経ずに体温・血圧ステップへ進む', async () => {
+  it('乗務員が引ければ顔認証を経ずに体温ステップへ進む (血圧は隠す、Refs #238)', async () => {
     getEmployeeByNfcIdMock.mockResolvedValue(APPROVED_EMPLOYEE)
     const wrapper = await mountNfcStep()
 
     await touch(wrapper, '2601012901010')
 
-    // 現在ステップのパンくず (青) が「体温・血圧」
+    // 現在ステップのパンくず (青) が「体温」(血圧は隠しているのでラベルからも落ちる)
     const active = wrapper.findAll('div.rounded-full').filter(d => d.classes('bg-blue-600'))
     expect(active).toHaveLength(1)
-    expect(active[0]!.text()).toBe('体温・血圧')
-    expect(wrapper.text()).toContain('体温・血圧')
+    expect(active[0]!.text()).toBe('体温')
+    expect(wrapper.text()).toContain('体温')
     wrapper.unmount()
   })
 
@@ -157,7 +157,7 @@ describe('NormalMeasurement — NFC ステップの乗務員照合', () => {
     const wrapper = await mountNfcStep()
 
     const labels = wrapper.findAll('div.rounded-full').map(d => d.text())
-    expect(labels).toEqual(['NFC', '体温・血圧', '測定', '結果'])
+    expect(labels).toEqual(['NFC', '体温', '測定', '結果'])
     wrapper.unmount()
   })
 


### PR DESCRIPTION
## 何を変えるか

体温・血圧は既に CoreS3 (内蔵 BLE でニプロ NT-100B / NBP-1BLE を読む) から来ているのに、画面は「ATOM Lite が USB 接続されていることを確認してください」と案内していた。血圧計は、機能を残したまま今は画面から隠す (将来オプションにする)。#238 の 3 本目。

- 新規 `web/app/utils/medical-inputs.ts`: `SHOW_BLOOD_PRESSURE = false`。血圧を隠す判定はここ 1 か所
- `BleStatus.vue`: 未接続の案内を CoreS3 前提に (「CoreS3 が見つかりません。CoreS3 が USB でつながっているか確認してください。」)、「手動で接続」を「USB デバイスを選択」に。血圧の表示を出し分け
- `ManualMedicalInput.vue`: 血圧の入力欄を出し分け。**隠している間は血圧を送らない** (既定値 120/80 をそのまま送らない)
- `NormalMeasurement.vue` / `TenkoKiosk.vue`: ステップ名・見出し・結果の表示を「体温」に
- `DeviceSettings.vue`: 対象機器の一覧を `useSerialArbiter.ts` の定義の import に (複製を削除)。見出しを「BLE 体温計・血圧計 (CoreS3)」に、ESP32-S3 のポートを「ESP32-S3 (CoreS3 など)」と表示。BLE テストの血圧の表示を出し分け
- 送信ロジックと管理側の血圧の画面 (DailyHealthStatus) は変えていない

## テスト

- BleStatus / ManualMedicalInput: 血圧を隠す・出すの両方 (隠すときは systolic / diastolic が null)
- NormalMeasurement: ステップ名
- vitest 全体、`check_coverage_100`、`npx nuxi typecheck`

Refs #238
Refs ippoan/alc-app-s3#135

🤖 Generated with [Claude Code](https://claude.com/claude-code)
