### PR TITLE
feat(timecard): 本日の打刻履歴を部品にし、PC では通常点呼の隣にも出す (Refs #238)

### DIFF
--- a/web/app/components/TimePunchKiosk.vue
+++ b/web/app/components/TimePunchKiosk.vue
@@ -1,8 +1,7 @@
 <script setup lang="ts">
-import type { ApiEmployee, TimePunchWithDevice } from '~/types'
-import { punchTimecard, listTimePunches, getEmployees } from '~/utils/api'
-import { jstTodayStartIso } from '~/utils/jst'
+import { punchTimecard } from '~/utils/api'
 import { deviceUnregisteredMessage } from '~/utils/employee-lookup-messages'
+import TodayPunchHistory from './TodayPunchHistory.vue'
 
 const props = defineProps<{
   landscape?: boolean
@@ -10,7 +9,6 @@ const props = defineProps<{
 
 const nfc = useNfcWebSocket()
 const coreS3 = useCoreS3Serial()
-const { accessToken } = useAuth()
 const { deviceModel } = useFingerprint()
 const KYOCERA_MODELS = ['KC-T305CN', 'KC-305CN', 'KYT35', 'A404KC', 'KC-T306']
 const isKyoceraTablet = computed(() => {
@@ -30,24 +28,13 @@ async function requestCoreS3Port() {
     isRequestingCoreS3Port.value = false
   }
 }
-const employees = ref<ApiEmployee[]>([])
-const employeeMap = computed(() => {
-  const map: Record<string, string> = {}
-  for (const e of employees.value) map[e.id] = e.name
-  return map
-})
 
 const processing = ref(false)
 const errorMsg = ref('')
 let errorTimer: ReturnType<typeof setTimeout> | null = null
 
-/** 本日の打刻 (新しい順)。**サーバから引き直したものだけ**を出す。 */
-const recentPunches = ref<{ key: string; name: string; time: string }[]>([])
-/** 直近に自分で打った行 (数秒だけ強調する)。 */
-const highlightedKey = ref<string | null>(null)
-let highlightTimer: ReturnType<typeof setTimeout> | null = null
-
-const { getDeviceJwt, hasDeviceJwt } = useDeviceToken()
+/** 「本日の打刻履歴」部品への参照。打刻直後に reload() で引き直す (Refs ippoan/alc-app#238)。 */
+const punchHistory = ref<InstanceType<typeof TodayPunchHistory> | null>(null)
 
 /**
  * CoreS3 経由の自動端末登録 (#213) の失敗理由。成功 / 未実行なら null。
@@ -57,94 +44,13 @@ const { getDeviceJwt, hasDeviceJwt } = useDeviceToken()
 const { lastError: hubClaimError } = useHubClaim()
 
 /**
- * 打刻更新の購読 (Refs ippoan/alc-app-s3#134)。**管理画面と同じ composable。**
- * 他の端末 (NFC タイムカード端末や別のキオスク) で打たれた打刻も、この画面の
- * 「本日の打刻履歴」に出したいので購読する。トークンはキオスクの device JWT、
- * 管理者がこの画面を開いている場合は browser JWT。**どちらも無ければ**
- * (未ペアリング) WS は張らずポーリングに落ちる — 画面は壊さない。
- */
-const watch$ = useTimecardWatch({
-  getToken: () => accessToken.value ?? getDeviceJwt(),
-  onChange: () => { void loadTodayPunches() },
-})
-
-/**
  * NFC 待機表示の 3 状態 (Refs ippoan/alc-app#216)。
  * CoreS3 が USB 直結されていれば最優先 (打刻は CoreS3 firmware 自身が行う)、
  * 次に PC の NFC ブリッジ、どちらも無ければ未接続。
  */
 const nfcState = computed(() => coreS3.isConnected.value ? 'core' : nfc.isConnected.value ? 'bridge' : 'none')
 
-const isLargeScreen = ref(false)
-function updateScreenSize() {
-  isLargeScreen.value = window.innerWidth >= 1024
-}
-
-const displayedPunches = computed(() => {
-  const limit = isLargeScreen.value ? 20 : 10
-  return recentPunches.value.slice(0, limit)
-})
-
-/**
- * 表示名。**未解決のタップは行ごと落とさず、どのカードかを出す** — 落とすと
- * 「かざしたのに履歴に出ない」になり、カードの登録漏れに気付けない。
- */
-function displayName(p: TimePunchWithDevice): string {
-  return (p.employee_id && employeeMap.value[p.employee_id])
-    || p.employee_name
-    || (p.card_id ? `未登録カード ${p.card_id}` : '不明')
-}
-
-/**
- * 本日の打刻を引き直す。
- *
- * **打刻の応答からは作らない。** 打刻はキオスクも端末も同じ ingest 経路に乗り、
- * 社員の解決 (凍結) はサーバがやるので、画面に出す行はサーバから引いた 1 本に
- * 揃える (Refs ippoan/alc-app-s3#134)。他の端末で打たれた打刻も同じ経路で出る。
- *
- * **「今日」は JST で切る。** サーバ側も JST 固定 (`list_today_punches` の
- * Asia/Tokyo、CSV の +09:00) なので、ブラウザのローカル時刻で切ると
- * JST 以外に設定された端末でサーバと食い違う。
- */
-async function loadTodayPunches() {
-  try {
-    const res = await listTimePunches({ date_from: jstTodayStartIso(), per_page: 200 })
-    recentPunches.value = res.punches.map(p => ({
-      key: p.id,
-      name: displayName(p),
-      time: formatTime(p.punched_at),
-    }))
-  }
-  catch (e) { console.error('[TimePunchKiosk] Failed to load today punches:', e) }
-}
-
-async function loadEmployees() {
-  try {
-    employees.value = await getEmployees()
-  }
-  catch (e) { console.error('[TimePunchKiosk] Failed to load employees:', e) }
-}
-
-/**
- * 端末 JWT が取れたら一覧を引き直す (Refs ippoan/alc-app#238)。起動時は CoreS3 を
- * 最大 3 秒待つが、初回の open で CoreS3 がリセットされると claim がそれを超えることがあり、
- * そのとき最初の一覧は JWT 無しで取りに行って空のまま残るため
- */
-watch(hasDeviceJwt, (has) => {
-  if (!has) return
-  void loadEmployees()
-  void loadTodayPunches()
-})
-
 onMounted(async () => {
-  updateScreenSize()
-  window.addEventListener('resize', updateScreenSize)
-
-  await loadEmployees()
-  // 購読が張れれば onopen で 1 回引き直すが、張れない場合もあるのでここでも引く
-  await loadTodayPunches()
-  void watch$.connect()
-
   // CoreS3 直結の読み取りは購読しない — 打刻は CoreS3 firmware 自身が `kind=timecard` で
   // 送る (alc-app-s3 hub-drivers/timecard.rs)。ここで useNfcReader() に切り替えると 1 タップが 2 行になる
   nfc.connect()
@@ -156,10 +62,7 @@ onMounted(async () => {
     try {
       await punchTimecard(event.employee_id)
       // **応答に打刻行は入らない** (端末の打刻と同じ ingest 経路)。引き直す
-      await loadTodayPunches()
-      highlightedKey.value = recentPunches.value[0]?.key ?? null
-      if (highlightTimer) clearTimeout(highlightTimer)
-      highlightTimer = setTimeout(() => { highlightedKey.value = null }, 3000)
+      await punchHistory.value?.reload()
     }
     catch (e: any) {
       // 未登録カードでも打刻自体は記録される (履歴に「未登録カード …」で出る)
@@ -177,9 +80,7 @@ onMounted(async () => {
 })
 
 onUnmounted(() => {
-  window.removeEventListener('resize', updateScreenSize)
   if (errorTimer) clearTimeout(errorTimer)
-  if (highlightTimer) clearTimeout(highlightTimer)
 })
 
 /**
@@ -191,10 +92,6 @@ function punchFailureMessage(e: unknown): string {
   if (err?.punchFailure === 'unpaired') return deviceUnregisteredMessage
   if (err?.punchFailure === 'forbidden') return 'この端末では打刻できません (ペアリングの種別を確認してください)'
   return err?.status ? `打刻に失敗しました (${err.status})` : '打刻に失敗しました'
-}
-
-function formatTime(iso: string): string {
-  return new Date(iso).toLocaleTimeString('ja-JP', { hour: '2-digit', minute: '2-digit', second: '2-digit' })
 }
 </script>
 
@@ -263,43 +160,9 @@ function formatTime(iso: string): string {
     </div>
 
     <!-- 右列 (横画面) / 下部 (縦画面): 最近の打刻 -->
-    <div :class="landscape ? 'flex-1 min-w-0' : 'w-full max-w-md mt-4'">
-      <div v-if="recentPunches.length" class="bg-white rounded-2xl shadow-sm border overflow-hidden">
-        <div class="px-4 py-3 border-b bg-gray-50">
-          <h2 class="text-sm font-medium text-gray-600">本日の打刻履歴</h2>
-        </div>
-        <div :class="landscape ? 'max-h-[calc(100vh-10rem)] overflow-y-auto' : ''">
-          <table class="w-full text-sm">
-            <thead>
-              <tr class="border-b border-gray-200 text-gray-400">
-                <th class="text-left py-2 px-4 font-medium">名前</th>
-                <th class="text-right py-2 px-4 font-medium">時刻</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr
-                v-for="(p, i) in displayedPunches"
-                :key="p.key"
-                class="border-b border-gray-100 transition-colors duration-1000"
-                :class="p.key === highlightedKey
-                  ? 'bg-green-100 text-green-800 font-medium'
-                  : (i === 0 ? 'bg-blue-50 text-gray-800 font-medium' : 'text-gray-600')"
-              >
-                <td class="py-2 px-4">{{ p.name }}</td>
-                <td
-                  class="py-2 px-4 text-right tabular-nums transition-colors duration-1000"
-                  :class="p.key === highlightedKey ? 'text-green-700' : (i === 0 ? 'text-blue-600' : 'text-gray-400')"
-                >
-                  {{ p.time }}
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-      </div>
-      <div v-else class="bg-white rounded-2xl shadow-sm border p-8 text-center text-gray-400 text-sm">
-        本日の打刻はまだありません
-      </div>
-    </div>
+    <TodayPunchHistory
+      ref="punchHistory"
+      :class="landscape ? 'flex-1 min-w-0' : 'w-full max-w-md mt-4'"
+    />
   </div>
 </template>

--- a/web/app/components/TodayPunchHistory.vue
+++ b/web/app/components/TodayPunchHistory.vue
@@ -1,0 +1,185 @@
+<script setup lang="ts">
+/**
+ * 「本日の打刻履歴」(名前と時刻の一覧)。
+ *
+ * **TimePunchKiosk.vue (タイムカード画面) から切り出した部品**
+ * (Refs ippoan/alc-app#238)。通常点呼の画面 (index.vue, PC のときだけ) でも
+ * 同じ表示を使うため、取得・購読・表示を 1 箇所にまとめる。
+ * `useTimecardWatch` のコメントが 2 実装目を禁じているのと同じ理由で、
+ * この一覧も 2 実装目を作らない。
+ */
+import type { ApiEmployee, TimePunchWithDevice } from '~/types'
+import { listTimePunches, getEmployees } from '~/utils/api'
+import { jstTodayStartIso } from '~/utils/jst'
+
+const { accessToken } = useAuth()
+const { getDeviceJwt, hasDeviceJwt } = useDeviceToken()
+
+const employees = ref<ApiEmployee[]>([])
+const employeeMap = computed(() => {
+  const map: Record<string, string> = {}
+  for (const e of employees.value) map[e.id] = e.name
+  return map
+})
+
+/** 本日の打刻 (新しい順)。**サーバから引き直したものだけ**を出す。 */
+const recentPunches = ref<{ key: string; name: string; time: string }[]>([])
+/** 直近に自分で打った行 (数秒だけ強調する)。 */
+const highlightedKey = ref<string | null>(null)
+let highlightTimer: ReturnType<typeof setTimeout> | null = null
+
+const isLargeScreen = ref(false)
+function updateScreenSize() {
+  isLargeScreen.value = window.innerWidth >= 1024
+}
+
+const displayedPunches = computed(() => {
+  const limit = isLargeScreen.value ? 20 : 10
+  return recentPunches.value.slice(0, limit)
+})
+
+/**
+ * 表示名。**未解決のタップは行ごと落とさず、どのカードかを出す** — 落とすと
+ * 「かざしたのに履歴に出ない」になり、カードの登録漏れに気付けない。
+ */
+function displayName(p: TimePunchWithDevice): string {
+  return (p.employee_id && employeeMap.value[p.employee_id])
+    || p.employee_name
+    || (p.card_id ? `未登録カード ${p.card_id}` : '不明')
+}
+
+/**
+ * 本日の打刻を引き直す。
+ *
+ * **打刻の応答からは作らない。** 打刻はどの画面 (タイムカード / 通常点呼) から
+ * 打ってもサーバの同じ ingest 経路に乗り、社員の解決 (凍結) はサーバがやるので、
+ * 画面に出す行はサーバから引いた 1 本に揃える (Refs ippoan/alc-app-s3#134)。
+ * 他の端末で打たれた打刻も同じ経路で出る。
+ *
+ * **「今日」は JST で切る。** サーバ側も JST 固定 (`list_today_punches` の
+ * Asia/Tokyo、CSV の +09:00) なので、ブラウザのローカル時刻で切ると
+ * JST 以外に設定された端末でサーバと食い違う。
+ */
+async function loadTodayPunches() {
+  try {
+    const res = await listTimePunches({ date_from: jstTodayStartIso(), per_page: 200 })
+    recentPunches.value = res.punches.map(p => ({
+      key: p.id,
+      name: displayName(p),
+      time: formatTime(p.punched_at),
+    }))
+  }
+  catch (e) { console.error('[TodayPunchHistory] Failed to load today punches:', e) }
+}
+
+async function loadEmployees() {
+  try {
+    employees.value = await getEmployees()
+  }
+  catch (e) { console.error('[TodayPunchHistory] Failed to load employees:', e) }
+}
+
+/**
+ * 端末 JWT が取れたら一覧を引き直す (Refs ippoan/alc-app#238)。起動時は CoreS3 を
+ * 最大 3 秒待つが、初回の open で CoreS3 がリセットされると claim がそれを超えることがあり、
+ * そのとき最初の一覧は JWT 無しで取りに行って空のまま残るため
+ */
+watch(hasDeviceJwt, (has) => {
+  if (!has) return
+  void loadEmployees()
+  void loadTodayPunches()
+})
+
+/**
+ * 打刻更新の購読 (Refs ippoan/alc-app-s3#134)。**管理画面と同じ composable。**
+ * 他の端末 (NFC タイムカード端末や別のキオスク) で打たれた打刻も、この一覧に
+ * 出したいので購読する。トークンは呼び出し元の device JWT、管理者がログイン
+ * していれば browser JWT。**どちらも無ければ**(未ペアリング) WS は張らず
+ * ポーリングに落ちる — 画面は壊さない。
+ */
+const watch$ = useTimecardWatch({
+  getToken: () => accessToken.value ?? getDeviceJwt(),
+  onChange: () => { void loadTodayPunches() },
+})
+
+onMounted(async () => {
+  updateScreenSize()
+  window.addEventListener('resize', updateScreenSize)
+
+  await loadEmployees()
+  // 購読が張れれば onopen で 1 回引き直すが、張れない場合もあるのでここでも引く
+  await loadTodayPunches()
+  void watch$.connect()
+})
+
+onUnmounted(() => {
+  window.removeEventListener('resize', updateScreenSize)
+  if (highlightTimer) clearTimeout(highlightTimer)
+  // useTimecardWatch 自身も onUnmounted で stop() するが (べき等なのでここで呼んでも害は無い)、
+  // 購読を明示的に止めたことがこの部品のテストからも見えるようにここでも呼ぶ
+  watch$.stop()
+})
+
+function formatTime(iso: string): string {
+  return new Date(iso).toLocaleTimeString('ja-JP', { hour: '2-digit', minute: '2-digit', second: '2-digit' })
+}
+
+/** 指定した key の行を数秒だけ強調する。`null` を渡すと即座に消す。 */
+function highlight(key: string | null) {
+  highlightedKey.value = key
+  if (highlightTimer) clearTimeout(highlightTimer)
+  if (key !== null) {
+    highlightTimer = setTimeout(() => { highlightedKey.value = null }, 3000)
+  }
+}
+
+/**
+ * 打刻直後に呼び出し元 (TimePunchKiosk / 通常点呼) から呼ぶ。
+ * 引き直してから先頭行 (今打ったはずの行) を数秒だけ強調する。
+ */
+async function reload() {
+  await loadTodayPunches()
+  highlight(recentPunches.value[0]?.key ?? null)
+}
+
+defineExpose({ reload, highlight })
+</script>
+
+<template>
+  <div v-if="recentPunches.length" class="bg-white rounded-2xl shadow-sm border overflow-hidden">
+    <div class="px-4 py-3 border-b bg-gray-50">
+      <h2 class="text-sm font-medium text-gray-600">本日の打刻履歴</h2>
+    </div>
+    <div class="max-h-[calc(100vh-10rem)] overflow-y-auto">
+      <table class="w-full text-sm">
+        <thead>
+          <tr class="border-b border-gray-200 text-gray-400">
+            <th class="text-left py-2 px-4 font-medium">名前</th>
+            <th class="text-right py-2 px-4 font-medium">時刻</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            v-for="(p, i) in displayedPunches"
+            :key="p.key"
+            class="border-b border-gray-100 transition-colors duration-1000"
+            :class="p.key === highlightedKey
+              ? 'bg-green-100 text-green-800 font-medium'
+              : (i === 0 ? 'bg-blue-50 text-gray-800 font-medium' : 'text-gray-600')"
+          >
+            <td class="py-2 px-4">{{ p.name }}</td>
+            <td
+              class="py-2 px-4 text-right tabular-nums transition-colors duration-1000"
+              :class="p.key === highlightedKey ? 'text-green-700' : (i === 0 ? 'text-blue-600' : 'text-gray-400')"
+            >
+              {{ p.time }}
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+  <div v-else class="bg-white rounded-2xl shadow-sm border p-8 text-center text-gray-400 text-sm">
+    本日の打刻はまだありません
+  </div>
+</template>

--- a/web/app/pages/index.vue
+++ b/web/app/pages/index.vue
@@ -445,7 +445,12 @@ function onRoleTabClick(role: RoleTab) {
 
         <!-- コンテンツ (1箇所のみ: 横画面=flex子要素, 縦画面=contents透過でルート直下) -->
         <div :class="isAndroidLandscape ? 'flex-1 min-w-0 flex flex-col' : 'contents'">
-          <NormalMeasurement v-if="driverSubTab === 'normal'" :landscape="isAndroidLandscape" class="flex-1 min-h-0" />
+          <!-- PC のときだけ「本日の打刻履歴」を通常点呼の隣に出す (Refs ippoan/alc-app#238)。
+               isPC でなければ contents で透過し、NormalMeasurement 単体のレイアウトのまま -->
+          <div v-if="driverSubTab === 'normal'" :class="isPC ? 'flex-1 min-h-0 flex gap-4' : 'contents'">
+            <NormalMeasurement :landscape="isAndroidLandscape" class="flex-1 min-h-0" />
+            <TodayPunchHistory v-if="isPC" class="w-96 shrink-0" />
+          </div>
           <TenkoKiosk v-if="driverSubTab === 'tenko'" :landscape="isAndroidLandscape" class="flex-1 min-h-0" />
           <TenkoKiosk v-if="driverSubTab === 'remote'" :remote-mode="true" :landscape="isAndroidLandscape" class="flex-1 min-h-0" />
           <TenkoKiosk v-if="driverSubTab === 'remote_demo'" :remote-mode="true" :demo-mode="true" :landscape="isAndroidLandscape" class="flex-1 min-h-0" />

--- a/web/tests/components/TimePunchKiosk.test.ts
+++ b/web/tests/components/TimePunchKiosk.test.ts
@@ -1,11 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { ref, readonly } from 'vue'
+import { flushPromises } from '@vue/test-utils'
 import { mountSuspended, mockNuxtImport } from '@nuxt/test-utils/runtime'
 import TimePunchKiosk from '~/components/TimePunchKiosk.vue'
-import { getEmployees, listTimePunches } from '~/utils/api'
-
-/** onMounted の await 群と watch の後段を流し切る */
-const flush = () => new Promise(resolve => setTimeout(resolve, 0))
+import { punchTimecard, listTimePunches } from '~/utils/api'
 
 // --- API のモック (NFC 表示だけを見るので中身は空で足りる) ---
 
@@ -56,6 +54,7 @@ mockNuxtImport('useHubClaim', () => () => ({
 
 mockNuxtImport('useTimecardWatch', () => () => ({
   connect: vi.fn(async () => {}),
+  stop: vi.fn(),
 }))
 
 describe('TimePunchKiosk — NFC 接続表示の 3 状態 (Refs ippoan/alc-app#216)', () => {
@@ -134,37 +133,30 @@ describe('TimePunchKiosk — CoreS3 の USB 許可ボタン (Refs #234)', () => 
   })
 })
 
-describe('TimePunchKiosk — 端末 JWT が取れたら一覧を引き直す (Refs #238)', () => {
+describe('TimePunchKiosk — 打刻後に本日の打刻履歴 (TodayPunchHistory) を引き直す (Refs ippoan/alc-app#238)', () => {
   beforeEach(() => {
-    deviceJwtReady.value = false
-    vi.mocked(getEmployees).mockClear()
+    nfcConnected.value = false
+    coreS3Connected.value = false
+    coreS3Supported.value = true
+    nfcOnReadMock.mockClear()
+    vi.mocked(punchTimecard).mockClear()
     vi.mocked(listTimePunches).mockClear()
   })
 
-  it('hasDeviceJwt が true になったら employees と本日の打刻を引き直す', async () => {
+  it('NFC 読み取り成功で打刻し、履歴部品 (TodayPunchHistory) の一覧を引き直す', async () => {
     const wrapper = await mountSuspended(TimePunchKiosk)
-    await flush()
-    expect(getEmployees).toHaveBeenCalledTimes(1)
-    expect(listTimePunches).toHaveBeenCalledTimes(1)
-
-    deviceJwtReady.value = true
-    await flush()
-    expect(getEmployees).toHaveBeenCalledTimes(2)
-    expect(listTimePunches).toHaveBeenCalledTimes(2)
-    wrapper.unmount()
-  })
-
-  it('hasDeviceJwt が false に戻っても (抜線でキャッシュ破棄) 引き直さない', async () => {
-    deviceJwtReady.value = true
-    const wrapper = await mountSuspended(TimePunchKiosk)
-    await flush()
-    vi.mocked(getEmployees).mockClear()
+    // TodayPunchHistory の初回マウント時の引き直し (onMounted, 非同期) を待ってからリセットし、
+    // 打刻後の呼び出しだけを見る
+    await flushPromises()
     vi.mocked(listTimePunches).mockClear()
 
-    deviceJwtReady.value = false
-    await flush()
-    expect(getEmployees).not.toHaveBeenCalled()
-    expect(listTimePunches).not.toHaveBeenCalled()
+    const onRead = nfcOnReadMock.mock.calls[0]?.[0] as ((e: { employee_id: string }) => Promise<void>) | undefined
+    expect(onRead).toBeTruthy()
+    await onRead!({ employee_id: 'emp-1' })
+    await flushPromises()
+
+    expect(punchTimecard).toHaveBeenCalledWith('emp-1')
+    expect(listTimePunches).toHaveBeenCalled()
     wrapper.unmount()
   })
 })

--- a/web/tests/components/TodayPunchHistory.test.ts
+++ b/web/tests/components/TodayPunchHistory.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ref } from 'vue'
+import { mountSuspended, mockNuxtImport } from '@nuxt/test-utils/runtime'
+import TodayPunchHistory from '~/components/TodayPunchHistory.vue'
+
+// TimePunchKiosk.vue から切り出した部品 (Refs ippoan/alc-app#238)。
+// 取得 (今日の打刻を JST で引く) / 表示 (未登録カード) / 購読での引き直し /
+// unmount での購読停止 / reload・highlight の公開 を見る。
+
+const listTimePunchesMock = vi.fn(async () => ({ punches: [] as any[] }))
+const getEmployeesMock = vi.fn(async () => [] as any[])
+
+vi.mock('~/utils/api', () => ({
+  listTimePunches: (...args: any[]) => listTimePunchesMock(...args),
+  getEmployees: (...args: any[]) => getEmployeesMock(...args),
+}))
+
+mockNuxtImport('useAuth', () => () => ({
+  accessToken: ref(null),
+}))
+
+const deviceJwtReady = ref(false)
+mockNuxtImport('useDeviceToken', () => () => ({
+  getDeviceJwt: vi.fn(() => null),
+  hasDeviceJwt: deviceJwtReady,
+}))
+
+/** onMounted の await 群と watch の後段を流し切る */
+const flush = () => new Promise(resolve => setTimeout(resolve, 0))
+
+let watchOnChange: (() => void) | null = null
+const watchConnectMock = vi.fn(async () => {})
+const watchStopMock = vi.fn()
+mockNuxtImport('useTimecardWatch', () => (options: { onChange: () => void }) => {
+  watchOnChange = options.onChange
+  return {
+    isConnected: ref(false),
+    connect: watchConnectMock,
+    stop: watchStopMock,
+  }
+})
+
+describe('TodayPunchHistory — 今日の打刻の取得と表示', () => {
+  beforeEach(() => {
+    listTimePunchesMock.mockClear()
+    getEmployeesMock.mockClear()
+    watchConnectMock.mockClear()
+    watchStopMock.mockClear()
+    watchOnChange = null
+  })
+
+  it('本日の打刻を JST の今日で引く (date_from が渡る)', async () => {
+    const wrapper = await mountSuspended(TodayPunchHistory)
+    expect(listTimePunchesMock).toHaveBeenCalledWith(
+      expect.objectContaining({ date_from: expect.any(String), per_page: 200 }),
+    )
+    wrapper.unmount()
+  })
+
+  it('打刻が無ければ「本日の打刻はまだありません」を出す', async () => {
+    const wrapper = await mountSuspended(TodayPunchHistory)
+    expect(wrapper.text()).toContain('本日の打刻はまだありません')
+    wrapper.unmount()
+  })
+
+  it('社員解決できたタップは社員名を、未解決の未登録カードは「未登録カード <id>」を出す', async () => {
+    getEmployeesMock.mockResolvedValueOnce([{ id: 'emp-1', name: '山田太郎' }] as any)
+    listTimePunchesMock.mockResolvedValueOnce({
+      punches: [
+        { id: 'p1', employee_id: 'emp-1', employee_name: null, card_id: null, punched_at: '2026-09-11T00:00:00Z' },
+        { id: 'p2', employee_id: null, employee_name: null, card_id: 'card-xyz', punched_at: '2026-09-11T00:01:00Z' },
+      ],
+    })
+    const wrapper = await mountSuspended(TodayPunchHistory)
+    // mountSuspended は onMounted 内の await 群の完了までは待たない (Suspense は
+    // setup() の非同期のみを見る) ので、DOM への反映を明示的に待つ
+    await flush()
+    expect(wrapper.text()).toContain('山田太郎')
+    expect(wrapper.text()).toContain('未登録カード card-xyz')
+    wrapper.unmount()
+  })
+
+  it('購読の onChange が呼ばれたら一覧を引き直す', async () => {
+    const wrapper = await mountSuspended(TodayPunchHistory)
+    listTimePunchesMock.mockClear()
+    expect(watchOnChange).toBeTruthy()
+    watchOnChange!()
+    await Promise.resolve()
+    expect(listTimePunchesMock).toHaveBeenCalled()
+    wrapper.unmount()
+  })
+
+  it('unmount で購読を止める', async () => {
+    const wrapper = await mountSuspended(TodayPunchHistory)
+    expect(watchStopMock).not.toHaveBeenCalled()
+    wrapper.unmount()
+    expect(watchStopMock).toHaveBeenCalled()
+  })
+})
+
+describe('TodayPunchHistory — reload / highlight の公開 (親から呼ぶ)', () => {
+  beforeEach(() => {
+    listTimePunchesMock.mockClear()
+    getEmployeesMock.mockClear()
+  })
+
+  it('reload() で引き直し、先頭行 (直近の打刻) をハイライトする', async () => {
+    listTimePunchesMock.mockResolvedValueOnce({ punches: [] })
+    const wrapper = await mountSuspended(TodayPunchHistory)
+
+    listTimePunchesMock.mockResolvedValueOnce({
+      punches: [
+        { id: 'new-1', employee_id: null, employee_name: '鈴木花子', card_id: null, punched_at: '2026-09-11T01:00:00Z' },
+      ],
+    })
+    await (wrapper.vm as any).reload()
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.text()).toContain('鈴木花子')
+    expect(wrapper.find('.bg-green-100').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('highlight(null) で強調を消せる', async () => {
+    listTimePunchesMock.mockResolvedValueOnce({
+      punches: [
+        { id: 'p1', employee_id: null, employee_name: '佐藤一郎', card_id: null, punched_at: '2026-09-11T01:00:00Z' },
+      ],
+    })
+    const wrapper = await mountSuspended(TodayPunchHistory)
+    ;(wrapper.vm as any).highlight('p1')
+    await wrapper.vm.$nextTick()
+    expect(wrapper.find('.bg-green-100').exists()).toBe(true)
+
+    ;(wrapper.vm as any).highlight(null)
+    await wrapper.vm.$nextTick()
+    expect(wrapper.find('.bg-green-100').exists()).toBe(false)
+    wrapper.unmount()
+  })
+})
+
+describe('TodayPunchHistory — 端末 JWT が取れたら一覧を引き直す (Refs #238)', () => {
+  beforeEach(() => {
+    deviceJwtReady.value = false
+    getEmployeesMock.mockClear()
+    listTimePunchesMock.mockClear()
+  })
+
+  it('hasDeviceJwt が true になったら employees と本日の打刻を引き直す', async () => {
+    const wrapper = await mountSuspended(TodayPunchHistory)
+    await flush()
+    expect(getEmployeesMock).toHaveBeenCalledTimes(1)
+    expect(listTimePunchesMock).toHaveBeenCalledTimes(1)
+
+    deviceJwtReady.value = true
+    await flush()
+    expect(getEmployeesMock).toHaveBeenCalledTimes(2)
+    expect(listTimePunchesMock).toHaveBeenCalledTimes(2)
+    wrapper.unmount()
+  })
+
+  it('hasDeviceJwt が false に戻っても (抜線でキャッシュ破棄) 引き直さない', async () => {
+    deviceJwtReady.value = true
+    const wrapper = await mountSuspended(TodayPunchHistory)
+    await flush()
+    getEmployeesMock.mockClear()
+    listTimePunchesMock.mockClear()
+
+    deviceJwtReady.value = false
+    await flush()
+    expect(getEmployeesMock).not.toHaveBeenCalled()
+    expect(listTimePunchesMock).not.toHaveBeenCalled()
+    wrapper.unmount()
+  })
+})

--- a/web/tests/pages/index.test.ts
+++ b/web/tests/pages/index.test.ts
@@ -3,6 +3,8 @@ import { ref, readonly, nextTick } from 'vue'
 import type { VueWrapper } from '@vue/test-utils'
 import { mountSuspended, mockNuxtImport } from '@nuxt/test-utils/runtime'
 import IndexPage from '~/pages/index.vue'
+import NormalMeasurement from '~/components/NormalMeasurement.vue'
+import TodayPunchHistory from '~/components/TodayPunchHistory.vue'
 
 // トップ画面のうち「警告デバイスの見張りをロールタブに関わらず始める」部分だけを見る (Refs #231)。
 // useAlarmWatch は本物、その下の singleton (デバイス / 着信購読 / 設定) だけをモックして
@@ -136,5 +138,36 @@ describe('pages/index — 警告デバイスの見張り', () => {
 
     wrapper = await mountIndex('/?role=manager')
     expect(calls).toEqual(['start', 'connect(0)'])
+  })
+})
+
+describe('pages/index — 本日の打刻履歴 (TodayPunchHistory) を通常点呼の隣に出すのは PC だけ (Refs ippoan/alc-app#238)', () => {
+  let wrapper: VueWrapper | null = null
+  const originalUserAgent = navigator.userAgent
+
+  afterEach(() => {
+    Object.defineProperty(navigator, 'userAgent', { value: originalUserAgent, configurable: true })
+    wrapper?.unmount()
+    wrapper = null
+  })
+
+  it('PC (Android/iPhone/iPad でない UA) では通常点呼の隣に本日の打刻履歴も出す', async () => {
+    Object.defineProperty(navigator, 'userAgent', { value: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)', configurable: true })
+    wrapper = await mountIndex('/?role=driver')
+    expect(wrapper.findComponent(NormalMeasurement).exists()).toBe(true)
+    expect(wrapper.findComponent(TodayPunchHistory).exists()).toBe(true)
+  })
+
+  it('Android では本日の打刻履歴を出さない (通常点呼のみ)', async () => {
+    Object.defineProperty(navigator, 'userAgent', { value: 'Mozilla/5.0 (Linux; Android 14)', configurable: true })
+    wrapper = await mountIndex('/?role=driver')
+    expect(wrapper.findComponent(NormalMeasurement).exists()).toBe(true)
+    expect(wrapper.findComponent(TodayPunchHistory).exists()).toBe(false)
+  })
+
+  it('通常点呼タブ以外 (点呼) では PC でも本日の打刻履歴を出さない', async () => {
+    Object.defineProperty(navigator, 'userAgent', { value: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)', configurable: true })
+    wrapper = await mountIndex('/?role=driver&tab=tenko')
+    expect(wrapper.findComponent(TodayPunchHistory).exists()).toBe(false)
   })
 })


### PR DESCRIPTION
## 何を変えるか

タイムカードの画面にある「本日の打刻履歴」を、運行者タブの通常点呼の画面にも出す。PC のときだけ。#238 の 4 本目。

- 新規 `web/app/components/TodayPunchHistory.vue`: TimePunchKiosk.vue に一体で入っていた打刻履歴 (社員一覧・表示名・今日の打刻の取得・打刻の購読・表示) を切り出した。打刻直後の再読込とハイライトは `reload` / `highlight` で親から呼ぶ。端末 JWT が取れたときの取り直しもこの中
- `TimePunchKiosk.vue`: 切り出した部品を使う形に (NFC・CoreS3 の部分は変えていない)
- `web/app/pages/index.vue`: PC (幅 1024 以上かつモバイルでない) のときだけ、通常点呼の隣に打刻履歴を置いて 2 列にする。それ以外は今までどおり。通常点呼の部品 (NormalMeasurement.vue) は変えていない

## テスト

- TodayPunchHistory: 今日の打刻 (JST) / 未登録カードの表示 / 購読で取り直す / unmount で購読を止める / reload・highlight
- TimePunchKiosk: 打刻後に reload が呼ばれる
- index: PC かつ通常点呼のときだけ出る
- vitest 全体、`check_coverage_100`、`npx nuxi typecheck`

Refs #238
Refs ippoan/alc-app-s3#135

🤖 Generated with [Claude Code](https://claude.com/claude-code)
