### PR TITLE
feat(medical): 体温が届いたら自動で次へ進み、体温の画面を CoreS3 前提の文言に (Refs #238)

### DIFF
--- a/web/app/components/BleStatus.vue
+++ b/web/app/components/BleStatus.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { isWebSerialSupported } from '~/utils/webserial'
-import { SHOW_BLOOD_PRESSURE } from '~/utils/medical-inputs'
+import { SHOW_BLOOD_PRESSURE, MEDICAL_AUTO_NEXT_DELAY_MS } from '~/utils/medical-inputs'
 
 const emit = defineEmits<{
   skip: []
@@ -39,6 +39,43 @@ onMounted(async () => {
     autoConnectFailed.value = true
   }
 })
+
+// 血圧を隠している間 (体温だけの運用) は、mount 後に体温が届いたら値を少し見せてから
+// 自動で次へ進む (Refs #238)。血圧を表示する運用では血圧が後から届くため対象外。
+// immediate にしない — 前の運転者の値や mount 前の古い値では発火させず、mount 後の
+// clearReadings() を経て新しく届いた値だけを見る。
+let autoNextTimer: ReturnType<typeof setTimeout> | null = null
+function clearAutoNextTimer() {
+  if (autoNextTimer) {
+    clearTimeout(autoNextTimer)
+    autoNextTimer = null
+  }
+}
+if (!SHOW_BLOOD_PRESSURE) {
+  watch(latestTemperature, (t) => {
+    if (!t) return
+    clearAutoNextTimer()
+    autoNextTimer = setTimeout(() => {
+      autoNextTimer = null
+      emit('next')
+    }, MEDICAL_AUTO_NEXT_DELAY_MS)
+  })
+}
+onUnmounted(clearAutoNextTimer)
+
+function handleNext() {
+  clearAutoNextTimer()
+  emit('next')
+}
+function handleSkip() {
+  clearAutoNextTimer()
+  emit('skip')
+}
+function handleRescan() {
+  clearAutoNextTimer()
+  resetGateway()
+  clearReadings()
+}
 </script>
 
 <template>
@@ -69,7 +106,7 @@ onMounted(async () => {
         </button>
         <button
           class="px-4 py-2 bg-gray-200 text-gray-700 rounded-lg text-sm hover:bg-gray-300 transition-colors"
-          @click="emit('skip')"
+          @click="handleSkip"
         >
           スキップ
         </button>
@@ -137,13 +174,13 @@ onMounted(async () => {
           医療機器で測定するとデータが表示されます
         </p>
 
-        <!-- 再スキャンボタン (データ受信後に別の機器を測定したい場合) -->
+        <!-- 再測定ボタン (読み値をクリアして測り直す) -->
         <button
           v-if="hasMedicalData"
           class="px-3 py-1.5 bg-amber-50 text-amber-700 border border-amber-200 rounded-lg text-xs hover:bg-amber-100 transition-colors mx-auto"
-          @click="resetGateway(); clearReadings()"
+          @click="handleRescan"
         >
-          別の機器を測定（再スキャン）
+          測り直す
         </button>
 
         <!-- エラー -->
@@ -157,13 +194,13 @@ onMounted(async () => {
               ? 'bg-blue-600 text-white hover:bg-blue-700'
               : 'bg-gray-200 text-gray-500 cursor-not-allowed'"
             :disabled="!hasMedicalData"
-            @click="emit('next')"
+            @click="handleNext"
           >
             次へ
           </button>
           <button
             class="px-4 py-3 bg-gray-100 text-gray-600 rounded-xl font-medium text-sm hover:bg-gray-200 transition-colors"
-            @click="emit('skip')"
+            @click="handleSkip"
           >
             スキップ
           </button>

--- a/web/app/components/NormalMeasurement.vue
+++ b/web/app/components/NormalMeasurement.vue
@@ -521,7 +521,7 @@ const currentStepIndex = computed(() => stepKeys.indexOf(step.value))
               :class="medicalInputTab === 'ble' ? 'bg-white text-gray-800 shadow-sm' : 'text-gray-500 hover:text-gray-700'"
               @click="medicalInputTab = 'ble'"
             >
-              BLE機器
+              CoreS3
             </button>
             <button
               class="flex-1 px-3 py-1.5 rounded-md text-sm font-medium transition-colors"
@@ -594,7 +594,7 @@ const currentStepIndex = computed(() => stepKeys.indexOf(step.value))
             class="inline-flex items-center gap-1 px-2 py-1 rounded-full"
             :class="medicalInputSource === 'manual' ? 'bg-amber-100 text-amber-700' : 'bg-blue-100 text-blue-700'"
           >
-            {{ medicalInputSource === 'manual' ? '手動入力' : 'BLE機器' }}
+            {{ medicalInputSource === 'manual' ? '手動入力' : 'CoreS3' }}
           </span>
         </div>
         <!-- API 保存状態 -->

--- a/web/app/components/TenkoKiosk.vue
+++ b/web/app/components/TenkoKiosk.vue
@@ -475,7 +475,7 @@ onUnmounted(() => {
               :class="medicalInputTab === 'ble' ? 'bg-white text-gray-800 shadow-sm' : 'text-gray-500 hover:text-gray-700'"
               @click="medicalInputTab = 'ble'"
             >
-              BLE機器
+              CoreS3
             </button>
             <button
               class="flex-1 px-3 py-1.5 rounded-md text-sm font-medium transition-colors"
@@ -564,7 +564,7 @@ onUnmounted(() => {
               class="inline-flex items-center gap-1 px-2 py-1 rounded-full"
               :class="medicalInputSource === 'manual' ? 'bg-amber-100 text-amber-700' : 'bg-blue-100 text-blue-700'"
             >
-              {{ SHOW_BLOOD_PRESSURE ? '体温・血圧' : '体温' }}: {{ medicalInputSource === 'manual' ? '手動入力' : 'BLE機器' }}
+              {{ SHOW_BLOOD_PRESSURE ? '体温・血圧' : '体温' }}: {{ medicalInputSource === 'manual' ? '手動入力' : 'CoreS3' }}
             </span>
           </div>
         </div>

--- a/web/app/utils/medical-inputs.ts
+++ b/web/app/utils/medical-inputs.ts
@@ -6,3 +6,10 @@
  * 単位 (テナント単位か端末単位か等) は未確定のため、今は定数 1 つで一律に隠す。
  */
 export const SHOW_BLOOD_PRESSURE = false
+
+/**
+ * 体温だけの運用 (SHOW_BLOOD_PRESSURE=false) で、CoreS3 から体温が届いてから
+ * 自動で次のステップへ進むまでの待ち時間 (ms)。値を確認できる程度に見せてから進む
+ * (Refs #238)。
+ */
+export const MEDICAL_AUTO_NEXT_DELAY_MS = 1500

--- a/web/tests/components/BleStatus.test.ts
+++ b/web/tests/components/BleStatus.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { ref, readonly } from 'vue'
 import { mountSuspended, mockNuxtImport } from '@nuxt/test-utils/runtime'
 
@@ -14,6 +14,8 @@ const latestTemperature = ref<{ value: number } | null>(null)
 const latestBloodPressure = ref<{ systolic: number, diastolic: number, pulse?: number } | null>(null)
 const hasMedicalData = ref(false)
 const startAutoConnectMock = vi.fn(async () => true)
+const clearReadingsMock = vi.fn()
+const resetGatewayMock = vi.fn()
 
 mockNuxtImport('useBleGateway', () => () => ({
   isConnected: readonly(isConnected),
@@ -26,12 +28,15 @@ mockNuxtImport('useBleGateway', () => () => ({
   transport: ref(null),
   connect: vi.fn(),
   startAutoConnect: startAutoConnectMock,
-  clearReadings: vi.fn(),
-  resetGateway: vi.fn(),
+  clearReadings: clearReadingsMock,
+  resetGateway: resetGatewayMock,
 }))
 
-// SHOW_BLOOD_PRESSURE は定数エクスポートなので、値ごとに vi.doMock + resetModules で
-// component を取り直す (モジュールスコープ状態のテスト分離パターンに準拠)。
+const AUTO_NEXT_DELAY_MS = 1500
+
+// SHOW_BLOOD_PRESSURE / MEDICAL_AUTO_NEXT_DELAY_MS は定数エクスポートなので、値ごとに
+// vi.doMock + resetModules で component を取り直す (モジュールスコープ状態のテスト分離
+// パターンに準拠)。
 describe('BleStatus — CoreS3 前提の文言・血圧の出し分け (Refs #238)', () => {
   beforeEach(() => {
     vi.resetModules()
@@ -44,10 +49,12 @@ describe('BleStatus — CoreS3 前提の文言・血圧の出し分け (Refs #23
     hasMedicalData.value = false
     startAutoConnectMock.mockReset()
     startAutoConnectMock.mockResolvedValue(true)
+    clearReadingsMock.mockReset()
+    resetGatewayMock.mockReset()
   })
 
   it('未接続なら CoreS3 前提の文言を出す (ATOM Lite の文言は残らない)', async () => {
-    vi.doMock('~/utils/medical-inputs', () => ({ SHOW_BLOOD_PRESSURE: false }))
+    vi.doMock('~/utils/medical-inputs', () => ({ SHOW_BLOOD_PRESSURE: false, MEDICAL_AUTO_NEXT_DELAY_MS: AUTO_NEXT_DELAY_MS }))
     startAutoConnectMock.mockResolvedValue(false)
     const { default: BleStatus } = await import('~/components/BleStatus.vue')
     const wrapper = await mountSuspended(BleStatus)
@@ -65,7 +72,7 @@ describe('BleStatus — CoreS3 前提の文言・血圧の出し分け (Refs #23
   })
 
   it('SHOW_BLOOD_PRESSURE=false: 接続中でも血圧の表示が出ない', async () => {
-    vi.doMock('~/utils/medical-inputs', () => ({ SHOW_BLOOD_PRESSURE: false }))
+    vi.doMock('~/utils/medical-inputs', () => ({ SHOW_BLOOD_PRESSURE: false, MEDICAL_AUTO_NEXT_DELAY_MS: AUTO_NEXT_DELAY_MS }))
     isConnected.value = true
     latestBloodPressure.value = { systolic: 120, diastolic: 80 }
     const { default: BleStatus } = await import('~/components/BleStatus.vue')
@@ -77,7 +84,7 @@ describe('BleStatus — CoreS3 前提の文言・血圧の出し分け (Refs #23
   })
 
   it('SHOW_BLOOD_PRESSURE=true: 接続中は従来どおり血圧を出す', async () => {
-    vi.doMock('~/utils/medical-inputs', () => ({ SHOW_BLOOD_PRESSURE: true }))
+    vi.doMock('~/utils/medical-inputs', () => ({ SHOW_BLOOD_PRESSURE: true, MEDICAL_AUTO_NEXT_DELAY_MS: AUTO_NEXT_DELAY_MS }))
     isConnected.value = true
     latestBloodPressure.value = { systolic: 118, diastolic: 76 }
     const { default: BleStatus } = await import('~/components/BleStatus.vue')
@@ -86,6 +93,164 @@ describe('BleStatus — CoreS3 前提の文言・血圧の出し分け (Refs #23
     expect(wrapper.text()).toContain('血圧')
     expect(wrapper.text()).toContain('118')
     expect(wrapper.text()).toContain('76')
+
+    wrapper.unmount()
+  })
+
+  it('測り直すボタンは resetGateway + clearReadings を呼ぶ', async () => {
+    vi.doMock('~/utils/medical-inputs', () => ({ SHOW_BLOOD_PRESSURE: false, MEDICAL_AUTO_NEXT_DELAY_MS: AUTO_NEXT_DELAY_MS }))
+    isConnected.value = true
+    latestTemperature.value = { value: 36.5 }
+    hasMedicalData.value = true
+    const { default: BleStatus } = await import('~/components/BleStatus.vue')
+    const wrapper = await mountSuspended(BleStatus)
+
+    const btn = wrapper.findAll('button').find(b => b.text() === '測り直す')
+    expect(btn).toBeTruthy()
+    await btn!.trigger('click')
+
+    expect(resetGatewayMock).toHaveBeenCalledTimes(1)
+    // clearReadings は mount 時 (onMounted) にも 1 回呼ばれているので合計 2 回
+    expect(clearReadingsMock).toHaveBeenCalledTimes(2)
+
+    wrapper.unmount()
+  })
+})
+
+describe('BleStatus — 体温到達で自動的に次へ進む (SHOW_BLOOD_PRESSURE=false、Refs #238)', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+    isConnected.value = true
+    thermometerConnected.value = true
+    latestTemperature.value = null
+    latestBloodPressure.value = null
+    hasMedicalData.value = false
+    clearReadingsMock.mockReset()
+    resetGatewayMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('mount 後に体温が届くと MEDICAL_AUTO_NEXT_DELAY_MS 後に next が 1 回だけ発火する', async () => {
+    vi.doMock('~/utils/medical-inputs', () => ({ SHOW_BLOOD_PRESSURE: false, MEDICAL_AUTO_NEXT_DELAY_MS: AUTO_NEXT_DELAY_MS }))
+    const { default: BleStatus } = await import('~/components/BleStatus.vue')
+    const wrapper = await mountSuspended(BleStatus)
+
+    // mount 後に新しい体温が届く
+    latestTemperature.value = { value: 36.5 }
+    await wrapper.vm.$nextTick()
+
+    expect(wrapper.emitted('next')).toBeFalsy()
+    await vi.advanceTimersByTimeAsync(AUTO_NEXT_DELAY_MS)
+
+    expect(wrapper.emitted('next')).toHaveLength(1)
+
+    // 続けて値が更新されても 2 回目が飛ばないこと (再スキャン等をしない限り)
+    await vi.advanceTimersByTimeAsync(AUTO_NEXT_DELAY_MS)
+    expect(wrapper.emitted('next')).toHaveLength(1)
+
+    wrapper.unmount()
+  })
+
+  it('mount 時点で既に値がある (前の運転者の値) なら自動で進まない', async () => {
+    // clearReadings は mock なので実際には消えない = mount 前の値が残るケースを再現
+    latestTemperature.value = { value: 36.2 }
+    vi.doMock('~/utils/medical-inputs', () => ({ SHOW_BLOOD_PRESSURE: false, MEDICAL_AUTO_NEXT_DELAY_MS: AUTO_NEXT_DELAY_MS }))
+    const { default: BleStatus } = await import('~/components/BleStatus.vue')
+    const wrapper = await mountSuspended(BleStatus)
+
+    await vi.advanceTimersByTimeAsync(AUTO_NEXT_DELAY_MS + 1000)
+    expect(wrapper.emitted('next')).toBeFalsy()
+
+    wrapper.unmount()
+  })
+
+  it('1500ms 経つ前に unmount したら next は飛ばない', async () => {
+    vi.doMock('~/utils/medical-inputs', () => ({ SHOW_BLOOD_PRESSURE: false, MEDICAL_AUTO_NEXT_DELAY_MS: AUTO_NEXT_DELAY_MS }))
+    const { default: BleStatus } = await import('~/components/BleStatus.vue')
+    const wrapper = await mountSuspended(BleStatus)
+
+    latestTemperature.value = { value: 36.5 }
+    await wrapper.vm.$nextTick()
+    wrapper.unmount()
+
+    await vi.advanceTimersByTimeAsync(AUTO_NEXT_DELAY_MS + 1000)
+    expect(wrapper.emitted('next')).toBeFalsy()
+  })
+
+  it('1500ms 経つ前に「次へ」を手動で押したら、その後タイマーは追加の next を出さない', async () => {
+    vi.doMock('~/utils/medical-inputs', () => ({ SHOW_BLOOD_PRESSURE: false, MEDICAL_AUTO_NEXT_DELAY_MS: AUTO_NEXT_DELAY_MS }))
+    hasMedicalData.value = true
+    const { default: BleStatus } = await import('~/components/BleStatus.vue')
+    const wrapper = await mountSuspended(BleStatus)
+
+    latestTemperature.value = { value: 36.5 }
+    await wrapper.vm.$nextTick()
+
+    const nextBtn = wrapper.findAll('button').find(b => b.text() === '次へ')
+    await nextBtn!.trigger('click')
+    expect(wrapper.emitted('next')).toHaveLength(1)
+
+    await vi.advanceTimersByTimeAsync(AUTO_NEXT_DELAY_MS + 1000)
+    // 手動の 1 回だけ (自動発火による 2 回目が無い)
+    expect(wrapper.emitted('next')).toHaveLength(1)
+
+    wrapper.unmount()
+  })
+
+  it('1500ms 経つ前に「スキップ」を押したら next は飛ばない', async () => {
+    vi.doMock('~/utils/medical-inputs', () => ({ SHOW_BLOOD_PRESSURE: false, MEDICAL_AUTO_NEXT_DELAY_MS: AUTO_NEXT_DELAY_MS }))
+    hasMedicalData.value = true
+    const { default: BleStatus } = await import('~/components/BleStatus.vue')
+    const wrapper = await mountSuspended(BleStatus)
+
+    latestTemperature.value = { value: 36.5 }
+    await wrapper.vm.$nextTick()
+
+    const skipBtn = wrapper.findAll('button').find(b => b.text() === 'スキップ')
+    await skipBtn!.trigger('click')
+    expect(wrapper.emitted('skip')).toHaveLength(1)
+
+    await vi.advanceTimersByTimeAsync(AUTO_NEXT_DELAY_MS + 1000)
+    expect(wrapper.emitted('next')).toBeFalsy()
+
+    wrapper.unmount()
+  })
+
+  it('1500ms 経つ前に測り直すと、タイマーが解除されて next は飛ばない', async () => {
+    vi.doMock('~/utils/medical-inputs', () => ({ SHOW_BLOOD_PRESSURE: false, MEDICAL_AUTO_NEXT_DELAY_MS: AUTO_NEXT_DELAY_MS }))
+    hasMedicalData.value = true
+    const { default: BleStatus } = await import('~/components/BleStatus.vue')
+    const wrapper = await mountSuspended(BleStatus)
+
+    latestTemperature.value = { value: 36.5 }
+    await wrapper.vm.$nextTick()
+
+    const rescanBtn = wrapper.findAll('button').find(b => b.text() === '測り直す')
+    await rescanBtn!.trigger('click')
+    expect(resetGatewayMock).toHaveBeenCalledTimes(1)
+    // clearReadings は mount 時 (onMounted) にも 1 回呼ばれているので合計 2 回
+    expect(clearReadingsMock).toHaveBeenCalledTimes(2)
+
+    await vi.advanceTimersByTimeAsync(AUTO_NEXT_DELAY_MS + 1000)
+    expect(wrapper.emitted('next')).toBeFalsy()
+
+    wrapper.unmount()
+  })
+
+  it('SHOW_BLOOD_PRESSURE=true なら体温が届いても自動で進まない (血圧を待つ運用)', async () => {
+    vi.doMock('~/utils/medical-inputs', () => ({ SHOW_BLOOD_PRESSURE: true, MEDICAL_AUTO_NEXT_DELAY_MS: AUTO_NEXT_DELAY_MS }))
+    const { default: BleStatus } = await import('~/components/BleStatus.vue')
+    const wrapper = await mountSuspended(BleStatus)
+
+    latestTemperature.value = { value: 36.5 }
+    await wrapper.vm.$nextTick()
+
+    await vi.advanceTimersByTimeAsync(AUTO_NEXT_DELAY_MS + 1000)
+    expect(wrapper.emitted('next')).toBeFalsy()
 
     wrapper.unmount()
   })


### PR DESCRIPTION
## 何を変えるか

運行者が体温を測ると、CoreS3 から体温が届いても「次へ」を押すまで次 (アルコール測定) へ進まなかった。血圧を画面から隠した (#241) ので体温だけで次へ進めるようにする。#238 の続き。

- `web/app/components/BleStatus.vue`: 血圧を出さない運用 (`SHOW_BLOOD_PRESSURE` が false) のときだけ、画面を開いた後に届いた体温を見て、約 1.5 秒値を見せてから自動で次へ進む。「次へ」「スキップ」のボタンは残す。画面を離れる・手動で次へ/スキップ・測り直すと待ちを止め、2 回進まない。通常点呼と自動点呼はどちらもこの部品を使うので、両方に効く。血圧を出す運用では今までどおり手動
- `web/app/utils/medical-inputs.ts`: 待ち時間の定数 `MEDICAL_AUTO_NEXT_DELAY_MS = 1500`
- 文言を CoreS3 前提に: 体温の画面のタブ名と完了の表示の「BLE機器」→「CoreS3」(通常点呼・自動点呼の 4 か所)、「別の機器を測定（再スキャン）」→「測り直す」(動きは読み値を消して CoreS3 に測り直させるだけ)

## テスト

- `BleStatus.test.ts` に 7 件 (fake timers): 画面を開いた後に体温が届く → 1.5 秒後に 1 回だけ次へ / 開いた時点で既に値がある → 進まない / 1.5 秒の前に画面を離れる・次へ・スキップ・測り直す → 追加で進まない / 血圧を出す運用 → 自動で進まない / 測り直すが CoreS3 のやり直しと読み値の消去を呼ぶ
- vitest 全体、`check_coverage_100`、`npx nuxi typecheck`

Refs #238
Refs ippoan/alc-app-s3#135

🤖 Generated with [Claude Code](https://claude.com/claude-code)
