### PR TITLE
fix(kiosk): 起動時の「確認中」を最初の端末 JWT の取得まで延ばし、未登録の帯のちらつきを止める (Refs #238)

### DIFF
--- a/web/app/composables/useCoreS3Serial.ts
+++ b/web/app/composables/useCoreS3Serial.ts
@@ -111,11 +111,9 @@ let logReplyGeneration = 0
 
 /**
  * 起動時の探索 (startupProbe) の 1 本。起動から数えて 1 回だけ作り、以後は同じものを返す —
- * 端末 JWT の取得も「確認中」の表示も、この 1 本の 3 秒を共有する (Refs ippoan/alc-app#238)
+ * 端末 JWT の取得 (useDeviceToken) がこの 1 本を待つ (Refs ippoan/alc-app#238)
  */
 let startupProbePromise: Promise<boolean> | null = null
-/** startupProbePromise が未解決の間だけ true */
-const isStartupProbing = ref(false)
 
 /**
  * 行の接頭辞から素性を決める。
@@ -353,13 +351,9 @@ export function useCoreS3Serial() {
    * 起動時の探索。初回の呼び出しで connect(0) を始め、claim されたら true、
    * CLAIM_TIMEOUT (3 秒) で false に解決する。2 回目以降は同じ promise を返すので、
    * 待つのは起動から数えて 1 回だけ。WebSerial 非対応なら探索せず false
-   * (isStartupProbing も立てない)
    */
   function startupProbe(): Promise<boolean> {
-    if (!startupProbePromise) {
-      if (isSupported) isStartupProbing.value = true
-      startupProbePromise = connect(0).finally(() => { isStartupProbing.value = false })
-    }
+    if (!startupProbePromise) startupProbePromise = connect(0)
     return startupProbePromise
   }
 
@@ -399,7 +393,6 @@ export function useCoreS3Serial() {
     sendGrace,
     connect,
     startupProbe,
-    isStartupProbing: readonly(isStartupProbing),
     requestPort,
     release,
     disconnect,

--- a/web/app/composables/useDeviceToken.ts
+++ b/web/app/composables/useDeviceToken.ts
@@ -40,6 +40,9 @@
  *   過ぎていれば自然に再試行する)。失敗理由は `lastError` に残し、成功したら null に戻す。
  * - `/device/alarm-token` の応答に載る `tenant_id` が `deviceTenantId` と食い違っても
  *   拒否しない (`console.warn` のみ — 発行元 auth-worker 側の判断を尊重する)。
+ * - 起動時の 1 本 (`startupDeviceJwt`、Refs #238): 最初の `getDeviceJwt()` を起動から 1 回だけ作って
+ *   共有する (CoreS3 の探索を最大 3 秒待ち、繋がっていれば署名で取る)。`isStartupJwtPending` は
+ *   その 1 本が未解決かつ起動から 3 秒以内の間だけ true — 運行者タブの「確認中」はこれだけを見る。
  */
 import { ref, computed, readonly } from 'vue'
 import { signAlarmDeviceNonce } from '~/composables/useDeviceLogin'
@@ -55,6 +58,11 @@ const DEFAULT_TTL_SECONDS = 3600
 const CORE_S3_DEFAULT_TTL_SECONDS = 900
 /** CoreS3 署名経路が失敗してから、これだけ試さない (ms)。再接続での解除は無い。 */
 const CORE_S3_BACKOFF_MS = 60_000
+/**
+ * 起動時の 1 本 (startupDeviceJwt) を「確認中」として待つ上限 (ms)。
+ * useCoreS3Serial の claim 待ち (3 秒) と同じ起点・同じ長さ
+ */
+const STARTUP_TIMEOUT_MS = 3000
 
 const isClient = typeof window !== 'undefined'
 
@@ -79,6 +87,10 @@ let coreS3BackoffUntilMs = 0
 const lastError = ref<string | null>(null)
 // CoreS3 の再接続監視 (キャッシュ破棄) を二重登録しないためのガード (useHubClaim と同じ流儀)
 let closeListenerInstalled = false
+// 起動時の 1 本 (= 最初の getDeviceJwt()、Refs #238)。起動から 1 回だけ作り、以後は同じものを返す
+let startupJwtPromise: Promise<string | null> | null = null
+// startupJwtPromise が未解決、かつ起動から STARTUP_TIMEOUT_MS 以内の間だけ true
+const isStartupJwtPending = ref(false)
 
 export function useDeviceToken() {
   const config = useRuntimeConfig()
@@ -138,6 +150,24 @@ export function useDeviceToken() {
       jwtInFlight = mintDeviceJwt().finally(() => { jwtInFlight = null })
     }
     return jwtInFlight
+  }
+
+  /**
+   * 起動時の 1 本。初回の呼び出しで getDeviceJwt() を始める (中で CoreS3 の探索を最大 3 秒待ち、
+   * 繋がっていれば署名で取る)。2 回目以降は同じ promise を返す — 途中の getDeviceJwt() も
+   * single-flight で同じ取得に合流する。`isStartupJwtPending` は「1 本の解決」か
+   * 「起動から STARTUP_TIMEOUT_MS」の早い方で下りる (fetch に timeout が無いので上限を外さない)。
+   * WebSerial 非対応なら null で何もしない (最初から確認中にしない)
+   */
+  function startupDeviceJwt(): Promise<string | null> {
+    if (!coreS3.isSupported) return Promise.resolve(null)
+    if (!startupJwtPromise) {
+      startupJwtPromise = getDeviceJwt()
+      isStartupJwtPending.value = true
+      const deadline = new Promise<void>(resolve => setTimeout(resolve, STARTUP_TIMEOUT_MS))
+      void Promise.race([startupJwtPromise, deadline]).finally(() => { isStartupJwtPending.value = false })
+    }
+    return startupJwtPromise
   }
 
   /** cache 以外の 2 経路を順に試す (CoreS3 の署名 → credential)。 */
@@ -283,6 +313,9 @@ export function useDeviceToken() {
     storeKioskCredential,
     clearKioskCredential,
     getDeviceJwt,
+    startupDeviceJwt,
+    /** 起動時の 1 本 (startupDeviceJwt) が未解決かつ起動から 3 秒以内の間だけ true */
+    isStartupJwtPending: readonly(isStartupJwtPending),
     pairKioskDevice,
     setupAsKiosk,
     /** CoreS3 署名経路の直近の失敗理由。成功 / 未試行なら null */

--- a/web/app/composables/useHubClaim.ts
+++ b/web/app/composables/useHubClaim.ts
@@ -7,7 +7,8 @@
  * あいだは `useDeviceToken` の署名先が CoreS3 に切り替わっており (#234-2)、
  * `getDeviceJwt()` を呼べば nonce 取得・署名・mint まで自力で完結する。ここは
  * 「繋がったら 1 回呼んでおく」だけの先取りに縮小した (isDeviceActivated には無関係に動く)。
- * 起動時の CoreS3 の探索 (`startupProbe`) もここで 1 回だけ始める (Refs ippoan/alc-app#238)。
+ * 起動時の 1 本 (`useDeviceToken().startupDeviceJwt`: CoreS3 の探索 → 最初の端末 JWT の取得、
+ * 上限 3 秒) もここで 1 回だけ始める (Refs ippoan/alc-app#238)。
  *
  * ファイル名と戻り値の形 `{ lastError, attemptClaim }` は据え置く
  * (`TimePunchKiosk.vue` が `useHubClaim().lastError` を参照するため)。
@@ -18,7 +19,7 @@
 let listenerInstalled = false
 
 export function useHubClaim() {
-  const { getDeviceJwt, lastError } = useDeviceToken()
+  const { getDeviceJwt, lastError, startupDeviceJwt } = useDeviceToken()
   const coreS3 = useCoreS3Serial()
 
   /** CoreS3 接続中に device JWT を先取りする (getDeviceJwt 自体が single-flight/cache を持つ) */
@@ -31,9 +32,10 @@ export function useHubClaim() {
   if (!listenerInstalled) {
     listenerInstalled = true
     coreS3.onOpen(() => { void attemptClaim() })
-    // 起動時に CoreS3 を 1 回探す (最大 3 秒。getDeviceJwt の待ちもこの 1 本を共有する)。
+    // 起動時の 1 本 (CoreS3 の探索 ≤3 秒 + 最初の端末 JWT の取得) をここで始める。
+    // onOpen の attemptClaim は起動中なら同じ in-flight に合流する (二重取得にならない)。
     // 繋がると 3 秒ごとの `HB OK` が全ページで始まるが、運行者端末では NFC の画面で既に同じことが起きている
-    void coreS3.startupProbe()
+    void startupDeviceJwt()
   }
 
   return {

--- a/web/app/composables/useKioskAccess.ts
+++ b/web/app/composables/useKioskAccess.ts
@@ -11,21 +11,20 @@
  * `useAuth.ts` には置かない — `useDeviceToken` が `useAuth` の `deviceTenantId` を
  * 読むため、逆向きに `useAuth` から `useDeviceToken` を呼ぶと相互依存になる。
  *
- * `isCheckingKioskAccess` (Refs #238): 起動直後、CoreS3 の探索 (`useCoreS3Serial`
- * `isStartupProbing`、上限 3 秒) が終わるまでは「まだ無い」と「このまま無い」を
- * 区別できない。探索中は「未登録」の案内を出さず確認中として扱う。
+ * `isCheckingKioskAccess` (Refs #238): 起動時の 1 本 (`useDeviceToken().startupDeviceJwt`:
+ * CoreS3 の探索 → 最初の端末 JWT の取得、上限 3 秒) が終わるまでは「まだ無い」と
+ * 「このまま無い」を区別できない。その間は「未登録」の案内を出さず確認中として扱う。
  */
 export function useKioskAccess() {
   const { isAuthenticated, isDeviceActivated } = useAuth()
-  const { hasDeviceJwt } = useDeviceToken()
-  const { isStartupProbing } = useCoreS3Serial()
+  const { hasDeviceJwt, isStartupJwtPending } = useDeviceToken()
 
   const hasKioskAccess = computed(() =>
     isAuthenticated.value || isDeviceActivated.value || hasDeviceJwt.value,
   )
 
   const isCheckingKioskAccess = computed(() =>
-    !hasKioskAccess.value && isStartupProbing.value,
+    !hasKioskAccess.value && isStartupJwtPending.value,
   )
 
   return { hasKioskAccess, isCheckingKioskAccess }

--- a/web/tests/composables/useCoreS3Serial.test.ts
+++ b/web/tests/composables/useCoreS3Serial.test.ts
@@ -777,23 +777,20 @@ describe('useCoreS3Serial', () => {
   // ---------- startupProbe (Refs ippoan/alc-app#238) ----------
 
   describe('startupProbe', () => {
-    it('何度呼んでも 1 本で、claim されたら true (isStartupProbing は false → true → false)', async () => {
+    it('何度呼んでも 1 本で、claim されたら true', async () => {
       const dev = createMockPort()
       const getPorts = vi.fn(async () => [dev.port])
       installSerialMock({ getPorts })
       await load()
       dev.emit('{"type":"ready","version":"1.0.0"}\n')
-      expect(core.isStartupProbing.value).toBe(false)
 
       const first = core.startupProbe()
-      expect(core.isStartupProbing.value).toBe(true)
       expect(core.startupProbe()).toBe(first)
       // 別の呼び出し元 (別の useCoreS3Serial()) からも同じ 1 本
       expect(mod.useCoreS3Serial().startupProbe()).toBe(first)
 
       await vi.advanceTimersByTimeAsync(0)
       await expect(first).resolves.toBe(true)
-      expect(core.isStartupProbing.value).toBe(false)
       expect(core.isConnected.value).toBe(true)
       expect(getPorts).toHaveBeenCalledTimes(1)
     })
@@ -808,14 +805,11 @@ describe('useCoreS3Serial', () => {
 
       await vi.advanceTimersByTimeAsync(2999)
       expect(settled).toBe(false)
-      expect(core.isStartupProbing.value).toBe(true)
 
       await vi.advanceTimersByTimeAsync(1)
       await expect(first).resolves.toBe(false)
-      expect(core.isStartupProbing.value).toBe(false)
 
       expect(core.startupProbe()).toBe(first)
-      expect(core.isStartupProbing.value).toBe(false)
     })
 
     it('接続済みなら待たずに true', async () => {
@@ -823,16 +817,13 @@ describe('useCoreS3Serial', () => {
       await connectWithJson(dev)
 
       await expect(core.startupProbe()).resolves.toBe(true)
-      expect(core.isStartupProbing.value).toBe(false)
     })
 
-    it('WebSerial 非対応なら探索せず即 false (isStartupProbing は立たない)', async () => {
+    it('WebSerial 非対応なら探索せず即 false', async () => {
       await load()
 
-      const p = core.startupProbe()
-      expect(core.isStartupProbing.value).toBe(false)
-      await expect(p).resolves.toBe(false)
-      expect(core.isStartupProbing.value).toBe(false)
+      await expect(core.startupProbe()).resolves.toBe(false)
+      expect(core.isConnected.value).toBe(false)
     })
   })
 

--- a/web/tests/composables/useDeviceToken.test.ts
+++ b/web/tests/composables/useDeviceToken.test.ts
@@ -17,12 +17,12 @@ const SECRET = 'sec-xyz'
 // useCoreS3Serial / useAuth は Nuxt auto-import なので mockNuxtImport、
 // signAlarmDeviceNonce は useDeviceToken.ts が明示 import するので vi.mock で差し替える。
 const coreS3Mock = vi.hoisted(() => ({
+  isSupported: true as boolean,
   isConnected: { value: false },
   request: vi.fn(),
   onClose: vi.fn(),
   // 起動時の探索 (Refs #238)。既定は「繋がらなかった」
   startupProbe: vi.fn(async () => false),
-  isStartupProbing: { value: false },
 }))
 mockNuxtImport('useCoreS3Serial', () => () => coreS3Mock)
 
@@ -45,6 +45,7 @@ beforeEach(() => {
   vi.restoreAllMocks()
   vi.resetModules()
   localStorage.clear()
+  coreS3Mock.isSupported = true
   coreS3Mock.isConnected.value = false
   coreS3Mock.request.mockReset()
   coreS3Mock.onClose.mockReset()
@@ -711,6 +712,133 @@ describe('useDeviceToken (#434 step 3c)', () => {
       useDeviceToken()
 
       expect(coreS3Mock.onClose).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('startupDeviceJwt / isStartupJwtPending (Refs #238)', () => {
+    /** 積まれた microtask (race の finally まで) を流し切る */
+    const flush = () => new Promise(resolve => setTimeout(resolve, 0))
+
+    /** 起動時の探索で CoreS3 が繋がる (startupProbe が接続を立てて true) */
+    function probeConnects(): void {
+      coreS3Mock.startupProbe.mockImplementation(async () => {
+        coreS3Mock.isConnected.value = true
+        return true
+      })
+    }
+
+    it('探索で繋がれば JWT が取れるまで true、取れたら false。2 回目は同じ 1 本、途中の getDeviceJwt は合流する', async () => {
+      probeConnects()
+      signAlarmDeviceNonceMock.mockResolvedValue({ pubkey: 'pub-1', sig: 'sig-1' })
+      let nonceCalls = 0
+      vi.stubGlobal('fetch', vi.fn((url: string) => {
+        if (url.endsWith('/device/alarm-nonce')) {
+          nonceCalls += 1
+          return Promise.resolve({ ok: true, json: () => Promise.resolve({ nonce: 'n1' }) })
+        }
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ access_token: 's3r-jwt', expires_in: 900 }) })
+      }))
+
+      const useDeviceToken = await load()
+      const { startupDeviceJwt, getDeviceJwt, isStartupJwtPending, hasDeviceJwt } = useDeviceToken()
+      expect(isStartupJwtPending.value).toBe(false)
+
+      const first = startupDeviceJwt()
+      expect(isStartupJwtPending.value).toBe(true)
+      expect(startupDeviceJwt()).toBe(first)
+      // onOpen → attemptClaim の getDeviceJwt() を模す: 起動中の取得に合流する
+      const joined = getDeviceJwt()
+
+      await expect(first).resolves.toBe('s3r-jwt')
+      await expect(joined).resolves.toBe('s3r-jwt')
+      await flush()
+      expect(nonceCalls).toBe(1)
+      expect(hasDeviceJwt.value).toBe(true)
+      expect(isStartupJwtPending.value).toBe(false)
+    })
+
+    it('探索で繋がらなければ (CoreS3 無し) null で解決した時点で false、fetch しない', async () => {
+      const fetchMock = vi.fn()
+      vi.stubGlobal('fetch', fetchMock)
+
+      const useDeviceToken = await load()
+      const { startupDeviceJwt, isStartupJwtPending } = useDeviceToken()
+
+      const p = startupDeviceJwt()
+      expect(isStartupJwtPending.value).toBe(true)
+      await expect(p).resolves.toBeNull()
+      await flush()
+      expect(isStartupJwtPending.value).toBe(false)
+      expect(coreS3Mock.startupProbe).toHaveBeenCalledTimes(1)
+      expect(fetchMock).not.toHaveBeenCalled()
+    })
+
+    it('起動から 3 秒で取得が終わっていなくても下り、その後に取れれば hasDeviceJwt=true', async () => {
+      vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+      try {
+        probeConnects()
+        signAlarmDeviceNonceMock.mockResolvedValue({ pubkey: 'pub-1', sig: 'sig-1' })
+        let resolveToken: ((res: unknown) => void) | null = null
+        vi.stubGlobal('fetch', vi.fn((url: string) => {
+          if (url.endsWith('/device/alarm-nonce')) {
+            return Promise.resolve({ ok: true, json: () => Promise.resolve({ nonce: 'n1' }) })
+          }
+          return new Promise((resolve) => { resolveToken = resolve })
+        }))
+
+        const useDeviceToken = await load()
+        const { startupDeviceJwt, isStartupJwtPending, hasDeviceJwt } = useDeviceToken()
+
+        const p = startupDeviceJwt()
+        await vi.advanceTimersByTimeAsync(2999)
+        expect(isStartupJwtPending.value).toBe(true)
+        await vi.advanceTimersByTimeAsync(1)
+        expect(isStartupJwtPending.value).toBe(false)
+        expect(hasDeviceJwt.value).toBe(false)
+
+        expect(resolveToken).not.toBeNull()
+        resolveToken!({ ok: true, json: () => Promise.resolve({ access_token: 's3r-jwt', expires_in: 900 }) })
+        await expect(p).resolves.toBe('s3r-jwt')
+        expect(hasDeviceJwt.value).toBe(true)
+      }
+      finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it('WebSerial 非対応なら null、フラグは立たず、探索も fetch もしない', async () => {
+      coreS3Mock.isSupported = false
+      const fetchMock = vi.fn()
+      vi.stubGlobal('fetch', fetchMock)
+
+      const useDeviceToken = await load()
+      const { startupDeviceJwt, isStartupJwtPending } = useDeviceToken()
+
+      const p = startupDeviceJwt()
+      expect(isStartupJwtPending.value).toBe(false)
+      await expect(p).resolves.toBeNull()
+      expect(isStartupJwtPending.value).toBe(false)
+      expect(coreS3Mock.startupProbe).not.toHaveBeenCalled()
+      expect(fetchMock).not.toHaveBeenCalled()
+    })
+
+    it('取得に失敗しても (alarm-token 401) 1 本が解決した時点で下り、lastError が残る', async () => {
+      probeConnects()
+      signAlarmDeviceNonceMock.mockResolvedValue({ pubkey: 'pub-1', sig: 'sig-1' })
+      vi.stubGlobal('fetch', vi.fn((url: string) => {
+        if (url.endsWith('/device/alarm-nonce')) {
+          return Promise.resolve({ ok: true, json: () => Promise.resolve({ nonce: 'n1' }) })
+        }
+        return Promise.resolve({ ok: false, status: 401, json: () => Promise.resolve({ error: 'invalid_alarm_token' }) })
+      }))
+
+      const useDeviceToken = await load()
+      const { startupDeviceJwt, isStartupJwtPending, lastError } = useDeviceToken()
+
+      await expect(startupDeviceJwt()).resolves.toBeNull()
+      await flush()
+      expect(isStartupJwtPending.value).toBe(false)
+      expect(lastError.value).toContain('alarm-token http 401')
     })
   })
 })

--- a/web/tests/composables/useHubClaim.test.ts
+++ b/web/tests/composables/useHubClaim.test.ts
@@ -11,15 +11,12 @@ import { mockNuxtImport } from '@nuxt/test-utils/runtime'
  * useCoreS3Serial / useDeviceToken の実体は他のテストが担保済みなのでここでは mock する。
  */
 
-const coreS3Mock = vi.hoisted(() => ({
-  onOpen: vi.fn(),
-  startupProbe: vi.fn(async () => false),
-  isStartupProbing: { value: false },
-}))
+const coreS3Mock = vi.hoisted(() => ({ onOpen: vi.fn() }))
 mockNuxtImport('useCoreS3Serial', () => () => coreS3Mock)
 
 const deviceTokenMock = vi.hoisted(() => ({
   getDeviceJwt: vi.fn(async () => 'jwt-1'),
+  startupDeviceJwt: vi.fn(async () => null),
   lastError: { value: null as string | null },
 }))
 mockNuxtImport('useDeviceToken', () => () => deviceTokenMock)
@@ -64,12 +61,12 @@ describe('useHubClaim', () => {
     expect(coreS3Mock.onOpen).toHaveBeenCalledTimes(1)
   })
 
-  it('起動時に CoreS3 の探索 (startupProbe) を 1 回だけ始める (Refs #238)', async () => {
+  it('起動時の 1 本 (startupDeviceJwt) を 1 回だけ始める (Refs #238)', async () => {
     const useHubClaim = await load()
     useHubClaim()
     useHubClaim()
 
-    expect(coreS3Mock.startupProbe).toHaveBeenCalledTimes(1)
+    expect(deviceTokenMock.startupDeviceJwt).toHaveBeenCalledTimes(1)
   })
 
   it('attemptClaim は isDeviceActivated に関係なく毎回 getDeviceJwt を呼ぶ (guard を持たない)', async () => {

--- a/web/tests/composables/useKioskAccess.test.ts
+++ b/web/tests/composables/useKioskAccess.test.ts
@@ -8,8 +8,8 @@ const accessToken = ref<string | null>(null)
 const deviceTenantId = ref<string | null>(null)
 const hasDeviceJwt = ref(false)
 
-// isStartupProbing は useCoreS3Serial.ts の起動時探索フラグ (Refs #238)。
-const isStartupProbing = ref(false)
+// isStartupJwtPending は useDeviceToken.ts の起動時の 1 本 (探索 → 最初の端末 JWT) のフラグ (Refs #238)。
+const isStartupJwtPending = ref(false)
 
 mockNuxtImport('useAuth', () => () => ({
   accessToken,
@@ -20,11 +20,7 @@ mockNuxtImport('useAuth', () => () => ({
 
 mockNuxtImport('useDeviceToken', () => () => ({
   hasDeviceJwt,
-}))
-
-mockNuxtImport('useCoreS3Serial', () => () => ({
-  startupProbe: async () => false,
-  isStartupProbing,
+  isStartupJwtPending,
 }))
 
 describe('useKioskAccess', () => {
@@ -32,7 +28,7 @@ describe('useKioskAccess', () => {
     accessToken.value = null
     deviceTenantId.value = null
     hasDeviceJwt.value = false
-    isStartupProbing.value = false
+    isStartupJwtPending.value = false
   })
 
   it('3 条件すべて false なら hasKioskAccess は false', async () => {
@@ -62,31 +58,31 @@ describe('useKioskAccess', () => {
     expect(hasKioskAccess.value).toBe(true)
   })
 
-  // isCheckingKioskAccess の真理値表 (hasKioskAccess × isStartupProbing, Refs #238)
+  // isCheckingKioskAccess の真理値表 (hasKioskAccess × isStartupJwtPending, Refs #238)
   describe('isCheckingKioskAccess', () => {
-    it('hasKioskAccess=false, isStartupProbing=false → false (確認中ではない=未登録確定)', async () => {
+    it('hasKioskAccess=false, isStartupJwtPending=false → false (確認中ではない=未登録確定)', async () => {
       const { useKioskAccess } = await import('~/composables/useKioskAccess')
       const { isCheckingKioskAccess } = useKioskAccess()
       expect(isCheckingKioskAccess.value).toBe(false)
     })
 
-    it('hasKioskAccess=false, isStartupProbing=true → true (確認中)', async () => {
-      isStartupProbing.value = true
+    it('hasKioskAccess=false, isStartupJwtPending=true → true (確認中)', async () => {
+      isStartupJwtPending.value = true
       const { useKioskAccess } = await import('~/composables/useKioskAccess')
       const { isCheckingKioskAccess } = useKioskAccess()
       expect(isCheckingKioskAccess.value).toBe(true)
     })
 
-    it('hasKioskAccess=true, isStartupProbing=false → false (そもそもアクセスあり)', async () => {
+    it('hasKioskAccess=true, isStartupJwtPending=false → false (そもそもアクセスあり)', async () => {
       accessToken.value = 'jwt'
       const { useKioskAccess } = await import('~/composables/useKioskAccess')
       const { isCheckingKioskAccess } = useKioskAccess()
       expect(isCheckingKioskAccess.value).toBe(false)
     })
 
-    it('hasKioskAccess=true, isStartupProbing=true → false (アクセスがあるので確認中扱いにしない)', async () => {
+    it('hasKioskAccess=true, isStartupJwtPending=true → false (アクセスがあるので確認中扱いにしない)', async () => {
       accessToken.value = 'jwt'
-      isStartupProbing.value = true
+      isStartupJwtPending.value = true
       const { useKioskAccess } = await import('~/composables/useKioskAccess')
       const { isCheckingKioskAccess } = useKioskAccess()
       expect(isCheckingKioskAccess.value).toBe(false)


### PR DESCRIPTION
## 何を変えるか

運行者タブを開き直すたびに「未登録」の帯が一瞬出ていた (CoreS3 は登録済みで、すぐに消える)。起動時の「確認中」が見ていたのは「CoreS3 のポートが開いたか」までで、そのあとの端末 JWT の取得の往復の間は「確認中でも許可済みでもない」状態になっていた。「確認中」を最初の端末 JWT の取得が終わるまでに延ばす。#238 の続き (#239・#240 の修正)。

- `web/app/composables/useDeviceToken.ts`: 起動時の 1 本 `startupDeviceJwt()` (= 最初の端末 JWT の取得。起動から 1 回だけ作って共有) と `isStartupJwtPending` を追加。フラグは「取得の完了」か「起動から 3 秒」の早い方で下りる。Web Serial が使えない環境では最初から立てない
- `web/app/composables/useHubClaim.ts`: 起動時に `startupDeviceJwt()` を 1 回始める。CoreS3 がつながったときの取得は同じ取得に合流する (二重に取らない)
- `web/app/composables/useKioskAccess.ts`: 「確認中」は `isStartupJwtPending` だけを見る (依存は useKioskAccess → useDeviceToken → useCoreS3Serial の向きのまま)
- `web/app/composables/useCoreS3Serial.ts`: 読み手が居なくなった `isStartupProbing` を撤去 (起動時の探索 `startupProbe` は残す)

## テスト

- useDeviceToken: 探索成功 → 取得まで確認中・取れたら解除 / 2 回目は同じ取得・途中の取得は合流 (往復 1 回) / 探索失敗は即解除・通信なし / fake timers で 2999 ms は確認中・3000 ms で解除・その後の取得で許可済み / 非対応は立てない / 失敗 (401) でも解除されエラーが残る
- useHubClaim: 起動時に 1 回だけ始める / useKioskAccess: 真理値表を新しいフラグに / useCoreS3Serial: 探索の同一性・3 秒・非対応を維持
- vitest 全体、`check_coverage_100`、`npx nuxi typecheck`

Refs #238
Refs ippoan/alc-app-s3#135

🤖 Generated with [Claude Code](https://claude.com/claude-code)
