### PR TITLE
fix(result): 運行者の結果カードから「使用回数」を外す (Refs #238)

### DIFF
--- a/web/app/components/ResultCard.vue
+++ b/web/app/components/ResultCard.vue
@@ -97,10 +97,6 @@ const timeDisplay = computed(() => {
           <span class="font-mono font-bold text-lg">{{ alcoholDisplay }}</span>
         </div>
         <div class="flex justify-between">
-          <span class="text-sm text-gray-500">使用回数</span>
-          <span class="font-mono">{{ result.deviceUseCount }} 回</span>
-        </div>
-        <div class="flex justify-between">
           <span class="text-sm text-gray-500">測定日時</span>
           <span class="text-sm">{{ timeDisplay }}</span>
         </div>


### PR DESCRIPTION
## 何を変えるか

運行者の測定結果のカード (`web/app/components/ResultCard.vue`) から「使用回数」の行を外す。使用回数はアルコールチェッカーの機器の管理のための情報で、運行者の結果の画面に出す必要は無い。#238 の続き。

- 保存に送る使用回数 (`deviceUseCount`) と、管理側の測定の詳細 (`MeasurementDetail.vue`) の表示は変えない
- ResultCard を使っているのは通常点呼の結果の画面だけ (自動点呼は別の部品)

## テスト

- 使用回数の表示を確かめている既存テストは無い。vitest 全体、`check_coverage_100`、`npx nuxi typecheck`

Refs #238
Refs ippoan/alc-app-s3#135

🤖 Generated with [Claude Code](https://claude.com/claude-code)
