### PR TITLE
fix(punch-history): 通常点呼の打刻履歴をカードの下に縦に並べ、取得失敗を「まだありません」と見せない (Refs #238)

### DIFF
--- a/web/app/components/TodayPunchHistory.vue
+++ b/web/app/components/TodayPunchHistory.vue
@@ -24,6 +24,13 @@ const employeeMap = computed(() => {
 
 /** 本日の打刻 (新しい順)。**サーバから引き直したものだけ**を出す。 */
 const recentPunches = ref<{ key: string; name: string; time: string }[]>([])
+/**
+ * 取得が 1 度でも成功したか。**「本日の打刻はまだありません」は取得成功で
+ * 0 件のときだけ**出す (Refs ippoan/alc-app#238)。端末 JWT がまだ無い/取得に
+ * 失敗した間の空を「まだありません」と見せると、実際は打刻があるのに
+ * 「無い」と誤解させる — その間は「読み込み中…」のままにする
+ */
+const hasLoadedOnce = ref(false)
 /** 直近に自分で打った行 (数秒だけ強調する)。 */
 const highlightedKey = ref<string | null>(null)
 let highlightTimer: ReturnType<typeof setTimeout> | null = null
@@ -68,6 +75,7 @@ async function loadTodayPunches() {
       name: displayName(p),
       time: formatTime(p.punched_at),
     }))
+    hasLoadedOnce.value = true
   }
   catch (e) { console.error('[TodayPunchHistory] Failed to load today punches:', e) }
 }
@@ -178,6 +186,9 @@ defineExpose({ reload, highlight })
         </tbody>
       </table>
     </div>
+  </div>
+  <div v-else-if="!hasLoadedOnce" class="bg-white rounded-2xl shadow-sm border p-8 text-center text-gray-400 text-sm">
+    読み込み中…
   </div>
   <div v-else class="bg-white rounded-2xl shadow-sm border p-8 text-center text-gray-400 text-sm">
     本日の打刻はまだありません

--- a/web/app/components/TodayPunchHistory.vue
+++ b/web/app/components/TodayPunchHistory.vue
@@ -25,12 +25,13 @@ const employeeMap = computed(() => {
 /** 本日の打刻 (新しい順)。**サーバから引き直したものだけ**を出す。 */
 const recentPunches = ref<{ key: string; name: string; time: string }[]>([])
 /**
- * 取得が 1 度でも成功したか。**「本日の打刻はまだありません」は取得成功で
- * 0 件のときだけ**出す (Refs ippoan/alc-app#238)。端末 JWT がまだ無い/取得に
- * 失敗した間の空を「まだありません」と見せると、実際は打刻があるのに
- * 「無い」と誤解させる — その間は「読み込み中…」のままにする
+ * 直近の取得状態。**「本日の打刻はまだありません」は取得成功で 0 件のときだけ**
+ * 出す (Refs ippoan/alc-app#238)。端末 JWT がまだ無い/取得に失敗した間の空を
+ * 「まだありません」と見せると、実際は打刻があるのに「無い」と誤解させる。
+ * 取得中と取得失敗を区別しないと、失敗し続けたときに「読み込み中…」のまま
+ * 止まって見える (実際は止まっていない) ので、この 2 つも分ける
  */
-const hasLoadedOnce = ref(false)
+const loadStatus = ref<'loading' | 'error' | 'loaded'>('loading')
 /** 直近に自分で打った行 (数秒だけ強調する)。 */
 const highlightedKey = ref<string | null>(null)
 let highlightTimer: ReturnType<typeof setTimeout> | null = null
@@ -75,9 +76,12 @@ async function loadTodayPunches() {
       name: displayName(p),
       time: formatTime(p.punched_at),
     }))
-    hasLoadedOnce.value = true
+    loadStatus.value = 'loaded'
   }
-  catch (e) { console.error('[TodayPunchHistory] Failed to load today punches:', e) }
+  catch (e) {
+    console.error('[TodayPunchHistory] Failed to load today punches:', e)
+    loadStatus.value = 'error'
+  }
 }
 
 async function loadEmployees() {
@@ -187,8 +191,11 @@ defineExpose({ reload, highlight })
       </table>
     </div>
   </div>
-  <div v-else-if="!hasLoadedOnce" class="bg-white rounded-2xl shadow-sm border p-8 text-center text-gray-400 text-sm">
+  <div v-else-if="loadStatus === 'loading'" class="bg-white rounded-2xl shadow-sm border p-8 text-center text-gray-400 text-sm">
     読み込み中…
+  </div>
+  <div v-else-if="loadStatus === 'error'" class="bg-white rounded-2xl shadow-sm border p-8 text-center text-gray-400 text-sm">
+    打刻履歴を読み込めませんでした
   </div>
   <div v-else class="bg-white rounded-2xl shadow-sm border p-8 text-center text-gray-400 text-sm">
     本日の打刻はまだありません

--- a/web/app/pages/index.vue
+++ b/web/app/pages/index.vue
@@ -450,10 +450,13 @@ function onRoleTabClick(role: RoleTab) {
                幅は NormalMeasurement のカードの外枠 (max-w-md) に揃え、間隔は TimePunchKiosk の
                NFC カードと打刻履歴の間隔 (mt-4) に合わせる。横に並べていたときは画面全幅に
                広がって見出し・サブタブ (max-w-lg mx-auto) とバランスが崩れていたため縦積みに変更
-               (ユーザー報告)。NormalMeasurement 自身が flex-1 + overflow-y-auto を内蔵しているため、
-               isPC のときは NormalMeasurement 側の flex-1 min-h-0 を外し、このラッパーで
-               まとめてスクロールさせる -->
-          <div v-if="driverSubTab === 'normal'" :class="isPC ? 'flex-1 min-h-0 overflow-y-auto flex flex-col' : 'contents'">
+               (ユーザー報告)。NormalMeasurement 自身が flex-1 + overflow-y-auto を内蔵しているため
+               (ルートに静的クラスとして付いており、外から打ち消せない)、isPC のときは
+               ラッパーを **flex にしない (普通のブロック)**。ブロックの中では子の flex-1 は
+               効かないので、NormalMeasurement はその内容の高さのまま上に積まれる (「残りの高さ」
+               に縮められてカードが押しつぶされることがない)。スクロールはラッパーの overflow-y-auto
+               1 か所に集約する -->
+          <div v-if="driverSubTab === 'normal'" :class="isPC ? 'flex-1 min-h-0 overflow-y-auto' : 'contents'">
             <NormalMeasurement :landscape="isAndroidLandscape" :class="isPC ? '' : 'flex-1 min-h-0'" />
             <TodayPunchHistory v-if="isPC" class="w-full max-w-md mx-auto mt-4 px-4 pb-4" />
           </div>

--- a/web/app/pages/index.vue
+++ b/web/app/pages/index.vue
@@ -445,11 +445,17 @@ function onRoleTabClick(role: RoleTab) {
 
         <!-- コンテンツ (1箇所のみ: 横画面=flex子要素, 縦画面=contents透過でルート直下) -->
         <div :class="isAndroidLandscape ? 'flex-1 min-w-0 flex flex-col' : 'contents'">
-          <!-- PC のときだけ「本日の打刻履歴」を通常点呼の隣に出す (Refs ippoan/alc-app#238)。
-               isPC でなければ contents で透過し、NormalMeasurement 単体のレイアウトのまま -->
-          <div v-if="driverSubTab === 'normal'" :class="isPC ? 'flex-1 min-h-0 flex gap-4' : 'contents'">
-            <NormalMeasurement :landscape="isAndroidLandscape" class="flex-1 min-h-0" />
-            <TodayPunchHistory v-if="isPC" class="w-96 shrink-0" />
+          <!-- PC のときだけ「本日の打刻履歴」を通常点呼のカードの下に出す (Refs ippoan/alc-app#238)。
+               isPC でなければ contents で透過し、NormalMeasurement 単体のレイアウトのまま。
+               幅は NormalMeasurement のカードの外枠 (max-w-md) に揃え、間隔は TimePunchKiosk の
+               NFC カードと打刻履歴の間隔 (mt-4) に合わせる。横に並べていたときは画面全幅に
+               広がって見出し・サブタブ (max-w-lg mx-auto) とバランスが崩れていたため縦積みに変更
+               (ユーザー報告)。NormalMeasurement 自身が flex-1 + overflow-y-auto を内蔵しているため、
+               isPC のときは NormalMeasurement 側の flex-1 min-h-0 を外し、このラッパーで
+               まとめてスクロールさせる -->
+          <div v-if="driverSubTab === 'normal'" :class="isPC ? 'flex-1 min-h-0 overflow-y-auto flex flex-col' : 'contents'">
+            <NormalMeasurement :landscape="isAndroidLandscape" :class="isPC ? '' : 'flex-1 min-h-0'" />
+            <TodayPunchHistory v-if="isPC" class="w-full max-w-md mx-auto mt-4 px-4 pb-4" />
           </div>
           <TenkoKiosk v-if="driverSubTab === 'tenko'" :landscape="isAndroidLandscape" class="flex-1 min-h-0" />
           <TenkoKiosk v-if="driverSubTab === 'remote'" :remote-mode="true" :landscape="isAndroidLandscape" class="flex-1 min-h-0" />

--- a/web/tests/components/TodayPunchHistory.test.ts
+++ b/web/tests/components/TodayPunchHistory.test.ts
@@ -57,9 +57,34 @@ describe('TodayPunchHistory — 今日の打刻の取得と表示', () => {
     wrapper.unmount()
   })
 
-  it('打刻が無ければ「本日の打刻はまだありません」を出す', async () => {
+  it('取得成功で 0 件なら「本日の打刻はまだありません」を出す', async () => {
     const wrapper = await mountSuspended(TodayPunchHistory)
+    await flush()
     expect(wrapper.text()).toContain('本日の打刻はまだありません')
+    wrapper.unmount()
+  })
+
+  it('取得が完了するまでは「読み込み中…」を出す (「まだありません」ではない)', async () => {
+    let resolvePunches: ((v: { punches: any[] }) => void) | undefined
+    listTimePunchesMock.mockImplementationOnce(() => new Promise((resolve) => { resolvePunches = resolve }))
+    const wrapper = await mountSuspended(TodayPunchHistory)
+    await flush()
+    expect(wrapper.text()).toContain('読み込み中…')
+    expect(wrapper.text()).not.toContain('本日の打刻はまだありません')
+
+    // 取得が完了すれば「まだありません」に切り替わる
+    resolvePunches!({ punches: [] })
+    await flush()
+    expect(wrapper.text()).toContain('本日の打刻はまだありません')
+    wrapper.unmount()
+  })
+
+  it('取得に失敗した間は「まだありません」を出さない (端末 JWT が無い/取得失敗の空を「無い」と誤解させない、Refs #238)', async () => {
+    listTimePunchesMock.mockRejectedValueOnce(new Error('network error'))
+    const wrapper = await mountSuspended(TodayPunchHistory)
+    await flush()
+    expect(wrapper.text()).toContain('読み込み中…')
+    expect(wrapper.text()).not.toContain('本日の打刻はまだありません')
     wrapper.unmount()
   })
 
@@ -156,6 +181,26 @@ describe('TodayPunchHistory — 端末 JWT が取れたら一覧を引き直す 
     await flush()
     expect(getEmployeesMock).toHaveBeenCalledTimes(2)
     expect(listTimePunchesMock).toHaveBeenCalledTimes(2)
+    wrapper.unmount()
+  })
+
+  it('JWT が無くて最初の取得が失敗しても、hasDeviceJwt が true になったら取り直して表示する (index.vue に置いたときの再現、Refs #238)', async () => {
+    listTimePunchesMock.mockRejectedValueOnce(new Error('unauthorized'))
+    const wrapper = await mountSuspended(TodayPunchHistory)
+    await flush()
+    // JWT 無しの最初の取得は失敗 → 「まだありません」ではなく「読み込み中…」のまま
+    expect(wrapper.text()).toContain('読み込み中…')
+    expect(wrapper.text()).not.toContain('本日の打刻はまだありません')
+
+    listTimePunchesMock.mockResolvedValueOnce({
+      punches: [
+        { id: 'p1', employee_id: null, employee_name: '田中次郎', card_id: null, punched_at: '2026-09-11T02:00:00Z' },
+      ],
+    })
+    deviceJwtReady.value = true
+    await flush()
+    expect(wrapper.text()).toContain('田中次郎')
+    expect(wrapper.text()).not.toContain('読み込み中…')
     wrapper.unmount()
   })
 

--- a/web/tests/components/TodayPunchHistory.test.ts
+++ b/web/tests/components/TodayPunchHistory.test.ts
@@ -79,12 +79,13 @@ describe('TodayPunchHistory — 今日の打刻の取得と表示', () => {
     wrapper.unmount()
   })
 
-  it('取得に失敗した間は「まだありません」を出さない (端末 JWT が無い/取得失敗の空を「無い」と誤解させない、Refs #238)', async () => {
+  it('取得に失敗したら「打刻履歴を読み込めませんでした」を出す (「まだありません」でも「読み込み中…」のままでもない、Refs #238)', async () => {
     listTimePunchesMock.mockRejectedValueOnce(new Error('network error'))
     const wrapper = await mountSuspended(TodayPunchHistory)
     await flush()
-    expect(wrapper.text()).toContain('読み込み中…')
+    expect(wrapper.text()).toContain('打刻履歴を読み込めませんでした')
     expect(wrapper.text()).not.toContain('本日の打刻はまだありません')
+    expect(wrapper.text()).not.toContain('読み込み中…')
     wrapper.unmount()
   })
 
@@ -188,8 +189,8 @@ describe('TodayPunchHistory — 端末 JWT が取れたら一覧を引き直す 
     listTimePunchesMock.mockRejectedValueOnce(new Error('unauthorized'))
     const wrapper = await mountSuspended(TodayPunchHistory)
     await flush()
-    // JWT 無しの最初の取得は失敗 → 「まだありません」ではなく「読み込み中…」のまま
-    expect(wrapper.text()).toContain('読み込み中…')
+    // JWT 無しの最初の取得は失敗 → 「まだありません」ではなく「読み込めませんでした」
+    expect(wrapper.text()).toContain('打刻履歴を読み込めませんでした')
     expect(wrapper.text()).not.toContain('本日の打刻はまだありません')
 
     listTimePunchesMock.mockResolvedValueOnce({
@@ -201,6 +202,7 @@ describe('TodayPunchHistory — 端末 JWT が取れたら一覧を引き直す 
     await flush()
     expect(wrapper.text()).toContain('田中次郎')
     expect(wrapper.text()).not.toContain('読み込み中…')
+    expect(wrapper.text()).not.toContain('読み込めませんでした')
     wrapper.unmount()
   })
 

--- a/web/tests/pages/index.test.ts
+++ b/web/tests/pages/index.test.ts
@@ -161,6 +161,11 @@ describe('pages/index — 本日の打刻履歴 (TodayPunchHistory) を通常点
     const html = wrapper.html()
     expect(html.indexOf('normal-measurement-stub')).toBeGreaterThan(-1)
     expect(html.indexOf('today-punch-history-stub')).toBeGreaterThan(html.indexOf('normal-measurement-stub'))
+    // ラッパーは flex にしない (普通のブロック) — NormalMeasurement.vue のルートが静的に
+    // flex-1 を持つため、flex 縦並びだと「残りの高さ」に押しつぶされる (裏取りで発覚)
+    const wrapperEl = wrapper.findComponent(NormalMeasurement).element.parentElement
+    expect(wrapperEl?.className).toBe('flex-1 min-h-0 overflow-y-auto')
+    expect(wrapperEl?.className).not.toContain('flex ')
   })
 
   it('Android では本日の打刻履歴を出さない (通常点呼のみ)', async () => {

--- a/web/tests/pages/index.test.ts
+++ b/web/tests/pages/index.test.ts
@@ -141,7 +141,7 @@ describe('pages/index — 警告デバイスの見張り', () => {
   })
 })
 
-describe('pages/index — 本日の打刻履歴 (TodayPunchHistory) を通常点呼の隣に出すのは PC だけ (Refs ippoan/alc-app#238)', () => {
+describe('pages/index — 本日の打刻履歴 (TodayPunchHistory) を通常点呼のカードの下に出すのは PC だけ (Refs ippoan/alc-app#238)', () => {
   let wrapper: VueWrapper | null = null
   const originalUserAgent = navigator.userAgent
 
@@ -151,11 +151,16 @@ describe('pages/index — 本日の打刻履歴 (TodayPunchHistory) を通常点
     wrapper = null
   })
 
-  it('PC (Android/iPhone/iPad でない UA) では通常点呼の隣に本日の打刻履歴も出す', async () => {
+  it('PC (Android/iPhone/iPad でない UA) では通常点呼のカードの下に本日の打刻履歴を出す', async () => {
     Object.defineProperty(navigator, 'userAgent', { value: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)', configurable: true })
     wrapper = await mountIndex('/?role=driver')
     expect(wrapper.findComponent(NormalMeasurement).exists()).toBe(true)
     expect(wrapper.findComponent(TodayPunchHistory).exists()).toBe(true)
+    // 横並びではなく縦積み (NormalMeasurement の後ろに TodayPunchHistory) であることを
+    // DOM の出現順で確かめる (Refs ippoan/alc-app#238、ユーザー報告による横並びからの変更)
+    const html = wrapper.html()
+    expect(html.indexOf('normal-measurement-stub')).toBeGreaterThan(-1)
+    expect(html.indexOf('today-punch-history-stub')).toBeGreaterThan(html.indexOf('normal-measurement-stub'))
   })
 
   it('Android では本日の打刻履歴を出さない (通常点呼のみ)', async () => {


### PR DESCRIPTION
## 何を変えるか

PC の通常点呼の画面で「本日の打刻履歴」を横に並べていたが (#242)、2 列が画面の全幅に広がり、上の見出し・サブタブと揃わずバランスが崩れていた。タイムカードの画面と同じく、通常点呼のカードの下に同じ幅で縦に並べる。#238 の続き。

- `web/app/pages/index.vue`: PC のときの並びを横から縦に。打刻履歴は通常点呼のカードと同じ幅・中央寄せで、その下に置く (間隔はタイムカードの画面と同じ)。スクロールは外側の 1 か所にまとめた。PC 以外は今までどおり
- `web/app/components/TodayPunchHistory.vue`: 取得に失敗した空 (端末の認証がまだ済んでいない等) と「今日はまだ 0 件」が同じ「本日の打刻はまだありません」に見えていた。最初の取得が成功するまでは「読み込み中…」、成功して 0 件のときだけ「まだありません」を出す。認証が済んだら取り直して表示する

## テスト

- index.test.ts: PC かつ通常点呼で、打刻履歴が通常点呼の後ろ (下) に出る / PC でなければ出ない
- TodayPunchHistory.test.ts: 読み込み中 → 取得成功 0 件で「まだありません」/ 取得失敗では「読み込み中…」のまま / 認証が後から済むと取り直して表示
- vitest 全体、`check_coverage_100`、`npx nuxi typecheck`

Refs #238
Refs ippoan/alc-app-s3#135

🤖 Generated with [Claude Code](https://claude.com/claude-code)
