### PR TITLE
fix(api): 端末 JWT の経路で JSON の本文に Content-Type を付け、測定の保存が 415 で落ちるのを止める (Refs #238)

### DIFF
--- a/web/app/utils/api.ts
+++ b/web/app/utils/api.ts
@@ -124,6 +124,13 @@ async function proxyRequest<T>(path: string, jwt: string, options: RequestInit):
 async function bearerRequest<T>(url: string, jwt: string, options: RequestInit): Promise<T> {
   const headers = new Headers(options.headers)
   headers.set('Authorization', `Bearer ${jwt}`)
+  // 文字列の本文 (このモジュールでは JSON.stringify したもの) に Content-Type が無いと、
+  // ブラウザは text/plain を付けて送り、/api/proxy はそれをそのまま転送するので上流が
+  // JSON として受けない (415 になっていた。Refs #238)。管理者の経路 (createAuthFetch) と
+  // 同じく JSON を付ける。明示された Content-Type と FormData / Blob の本文は触らない
+  if (typeof options.body === 'string' && !headers.has('Content-Type')) {
+    headers.set('Content-Type', 'application/json')
+  }
   const res = await fetch(url, { ...options, headers })
   if (!res.ok) {
     const body = await res.text()

--- a/web/tests/utils/api.test.ts
+++ b/web/tests/utils/api.test.ts
@@ -2184,6 +2184,71 @@ describe.skipIf(isLive)('device JWT proxy 経路 (#434 3b)', () => {
     await expect(getEmployees()).rejects.toThrow('API エラー (500): Server Error')
   })
 
+  // --- Content-Type (Refs #238) ---
+  // JSON の本文に Content-Type が無いとブラウザは text/plain で送り、/api/proxy はそれを
+  // そのまま転送するので上流が JSON として受けなかった (415)。管理者の経路 (createAuthFetch)
+  // は JSON を既定で付けているので、device JWT の経路もそれに揃える
+
+  it('device JWT で POST (測定の開始) → Content-Type: application/json を付ける', async () => {
+    initApi(API_BASE, undefined, undefined, undefined, () => Promise.resolve('dev-jwt'))
+    mockFetch.mockResolvedValueOnce(okJson({ id: UUID1 }))
+    await startMeasurement(TEST_EMPLOYEE_ID)
+    const [url, init] = mockFetch.mock.calls[0]
+    expect(url).toBe('/api/proxy/measurements/start')
+    expect(init.method).toBe('POST')
+    const h = new Headers(init.headers)
+    expect(h.get('Content-Type')).toBe('application/json')
+    expect(h.get('Authorization')).toBe('Bearer dev-jwt')
+    expect(JSON.parse(init.body)).toEqual({ employee_id: TEST_EMPLOYEE_ID })
+  })
+
+  it('device JWT で POST (測定の保存 = 未送信の同期) → Content-Type: application/json を付ける', async () => {
+    initApi(API_BASE, undefined, undefined, undefined, () => Promise.resolve('dev-jwt'))
+    mockFetch.mockResolvedValueOnce(okJson({ id: UUID1 }))
+    const result: MeasurementResult = {
+      employeeId: TEST_EMPLOYEE_ID,
+      alcoholValue: 0,
+      resultType: 'normal',
+      deviceUseCount: 1,
+      measuredAt: new Date('2026-09-11T00:00:00Z'),
+    }
+    await saveMeasurement(result)
+    const [url, init] = mockFetch.mock.calls[0]
+    expect(url).toBe('/api/proxy/measurements')
+    expect(init.method).toBe('POST')
+    expect(new Headers(init.headers).get('Content-Type')).toBe('application/json')
+  })
+
+  it('device JWT で PUT (測定の更新) → Content-Type: application/json を付ける', async () => {
+    initApi(API_BASE, undefined, undefined, undefined, () => Promise.resolve('dev-jwt'))
+    mockFetch.mockResolvedValueOnce(okJson({ id: UUID1 }))
+    await updateMeasurement(UUID1, { status: 'completed' })
+    const [url, init] = mockFetch.mock.calls[0]
+    expect(url).toBe(`/api/proxy/measurements/${UUID1}`)
+    expect(init.method).toBe('PUT')
+    expect(new Headers(init.headers).get('Content-Type')).toBe('application/json')
+  })
+
+  it('device JWT で本文の無い GET には Content-Type を付けない', async () => {
+    initApi(API_BASE, undefined, undefined, undefined, () => Promise.resolve('dev-jwt'))
+    mockFetch.mockResolvedValueOnce(okJson({ id: UUID1 }))
+    await getMeasurement(UUID1)
+    const [url, init] = mockFetch.mock.calls[0]
+    expect(url).toBe(`/api/proxy/measurements/${UUID1}`)
+    expect(new Headers(init.headers).get('Content-Type')).toBeNull()
+  })
+
+  it('admin JWT の POST は今までどおり Content-Type: application/json (createAuthFetch)', async () => {
+    initApi(API_BASE, () => 'admin-jwt', () => 'tid')
+    mockFetch.mockResolvedValueOnce(okJson({ id: UUID1 }))
+    await startMeasurement(TEST_EMPLOYEE_ID)
+    const [url, init] = mockFetch.mock.calls[0]
+    expect(url).toBe('/api/proxy/measurements/start')
+    const h = new Headers(init.headers)
+    expect(h.get('Content-Type')).toBe('application/json')
+    expect(h.get('Authorization')).toBe('Bearer admin-jwt')
+  })
+
   // --- proxyRawFetch (blob/FormData raw 経路) の分岐カバレッジ ---
 
   it('device JWT → upload も /api/proxy 経由 (proxyRawFetch device 分岐)', async () => {

--- a/web/tests/utils/api.test.ts
+++ b/web/tests/utils/api.test.ts
@@ -2238,6 +2238,26 @@ describe.skipIf(isLive)('device JWT proxy 経路 (#434 3b)', () => {
     expect(new Headers(init.headers).get('Content-Type')).toBeNull()
   })
 
+  it('device JWT で FormData (顔写真) → Content-Type を付けない (ブラウザの multipart に任せる)', async () => {
+    initApi(API_BASE, undefined, undefined, undefined, () => Promise.resolve('dev-jwt'))
+    mockFetch.mockResolvedValueOnce(okJson({ url: 'https://r2/x.jpg' }))
+    await uploadFacePhoto(new Blob(['x']))
+    const [url, init] = mockFetch.mock.calls[0]
+    expect(url).toBe('/api/proxy/upload/face-photo')
+    expect(init.body).toBeInstanceOf(FormData)
+    expect(new Headers(init.headers).get('Content-Type')).toBeNull()
+  })
+
+  it('device JWT で明示された Content-Type (打刻の route) はそのまま', async () => {
+    initApi(API_BASE, undefined, undefined, undefined, () => Promise.resolve('dev-jwt'))
+    mockFetch.mockResolvedValueOnce(okJson({ seq: 1 }))
+    await punchTimecard('CARD-1')
+    const [url, init] = mockFetch.mock.calls[0]
+    expect(url).toBe('/api/timecard/punch')
+    expect(new Headers(init.headers).get('Content-Type')).toBe('application/json')
+    expect(new Headers(init.headers).get('Authorization')).toBe('Bearer dev-jwt')
+  })
+
   it('admin JWT の POST は今までどおり Content-Type: application/json (createAuthFetch)', async () => {
     initApi(API_BASE, () => 'admin-jwt', () => 'tid')
     mockFetch.mockResolvedValueOnce(okJson({ id: UUID1 }))


### PR DESCRIPTION
## 何を変えるか

端末 JWT で動く PC (運行者端末) で、測定の開始・保存・更新 (未送信の「同期する」を含む) が 415 で通らず、結果が「オフラインのためローカルに保存しました」のまま送れていなかった。#238 の続き。

- 原因: 端末 JWT の経路 (`web/app/utils/api.ts` の `bearerRequest`) が JSON の本文に Content-Type を付けておらず、ブラウザが `text/plain` で送っていた。`/api/proxy` と auth-worker は受け取った Content-Type をそのまま転送するので、上流が JSON として受けなかった
- 直し: 管理者の経路 (auth-client の `createAuthFetch`) と同じく、文字列の本文に Content-Type が無ければ `application/json` を付ける。明示された Content-Type と FormData / Blob の本文は触らない
- サーバーの proxy と auth-worker は変えない (受け取った Content-Type をそのまま転送する作りで正しい)

## テスト

- 端末 JWT の POST (開始・保存) と PUT (更新) で `/api/proxy` に `Content-Type: application/json` が付く / 本文の無い GET には付かない / 管理者の経路は今までどおり
- 直す前のコードでは POST・PUT の 3 件が落ちることを確認
- vitest 全体、`check_coverage_100` (api.ts 100%)、`npx nuxi typecheck`

Refs #238
Refs ippoan/alc-app-s3#135

🤖 Generated with [Claude Code](https://claude.com/claude-code)
