### PR TITLE
fix(normal-measurement): 顔登録・メンテナンスのリンクを画面の最下部に戻す (Refs #238)

### DIFF
--- a/web/app/components/NormalMeasurement.vue
+++ b/web/app/components/NormalMeasurement.vue
@@ -636,6 +636,10 @@ const currentStepIndex = computed(() => stepKeys.indexOf(step.value))
       </div>
     </main>
 
+    <!-- 呼び出し元がカードの下に足したい内容 (例: 本日の打刻履歴)。空なら何も出ない。
+         直後のナビゲーションより上に出すことで、リンクの塊を画面最下部に保つ (Refs #238) -->
+    <slot name="below-card" />
+
     <!-- ナビゲーション (縦画面時のみ。横画面時は左列に配置) -->
     <footer v-if="!landscape" class="w-full max-w-md py-4">
       <div class="flex justify-center gap-4">

--- a/web/app/pages/index.vue
+++ b/web/app/pages/index.vue
@@ -446,20 +446,15 @@ function onRoleTabClick(role: RoleTab) {
         <!-- コンテンツ (1箇所のみ: 横画面=flex子要素, 縦画面=contents透過でルート直下) -->
         <div :class="isAndroidLandscape ? 'flex-1 min-w-0 flex flex-col' : 'contents'">
           <!-- PC のときだけ「本日の打刻履歴」を通常点呼のカードの下に出す (Refs ippoan/alc-app#238)。
-               isPC でなければ contents で透過し、NormalMeasurement 単体のレイアウトのまま。
-               幅は NormalMeasurement のカードの外枠 (max-w-md) に揃え、間隔は TimePunchKiosk の
-               NFC カードと打刻履歴の間隔 (mt-4) に合わせる。横に並べていたときは画面全幅に
-               広がって見出し・サブタブ (max-w-lg mx-auto) とバランスが崩れていたため縦積みに変更
-               (ユーザー報告)。NormalMeasurement 自身が flex-1 + overflow-y-auto を内蔵しているため
-               (ルートに静的クラスとして付いており、外から打ち消せない)、isPC のときは
-               ラッパーを **flex にしない (普通のブロック)**。ブロックの中では子の flex-1 は
-               効かないので、NormalMeasurement はその内容の高さのまま上に積まれる (「残りの高さ」
-               に縮められてカードが押しつぶされることがない)。スクロールはラッパーの overflow-y-auto
-               1 か所に集約する -->
-          <div v-if="driverSubTab === 'normal'" :class="isPC ? 'flex-1 min-h-0 overflow-y-auto' : 'contents'">
-            <NormalMeasurement :landscape="isAndroidLandscape" :class="isPC ? '' : 'flex-1 min-h-0'" />
-            <TodayPunchHistory v-if="isPC" class="w-full max-w-md mx-auto mt-4 px-4 pb-4" />
-          </div>
+               NormalMeasurement の below-card slot に入れる — 「顔登録」「メンテナンス」の
+               リンクより上 (= 画面最下部はリンクのまま) に置かれ、NormalMeasurement 自身が
+               持つ flex-1 + overflow-y-auto で一緒にスクロールする。ラッパーの特別な class 分岐は
+               不要 (#248 の overflow-y-auto トリックは NormalMeasurement 側に既にあるため) -->
+          <NormalMeasurement v-if="driverSubTab === 'normal'" :landscape="isAndroidLandscape" class="flex-1 min-h-0">
+            <template v-if="isPC" #below-card>
+              <TodayPunchHistory class="w-full max-w-md mx-auto mt-4" />
+            </template>
+          </NormalMeasurement>
           <TenkoKiosk v-if="driverSubTab === 'tenko'" :landscape="isAndroidLandscape" class="flex-1 min-h-0" />
           <TenkoKiosk v-if="driverSubTab === 'remote'" :remote-mode="true" :landscape="isAndroidLandscape" class="flex-1 min-h-0" />
           <TenkoKiosk v-if="driverSubTab === 'remote_demo'" :remote-mode="true" :demo-mode="true" :landscape="isAndroidLandscape" class="flex-1 min-h-0" />

--- a/web/tests/components/NormalMeasurement.test.ts
+++ b/web/tests/components/NormalMeasurement.test.ts
@@ -173,4 +173,19 @@ describe('NormalMeasurement — NFC ステップの乗務員照合', () => {
     expect(wrapper.find('.bg-red-50').exists()).toBe(false)
     wrapper.unmount()
   })
+
+  it('below-card slot の中身は「顔登録」「メンテナンス」のリンクより前 (画面上で上) に出る (Refs #238)', async () => {
+    const wrapper = await mountSuspended(NormalMeasurement, {
+      global: { stubs: { NfcStatus: NfcStatusStub, BleStatus: true, ClientOnly: false, Teleport: true } },
+      slots: { 'below-card': '<div data-testid="below-card-content">打刻履歴スロット</div>' },
+    })
+
+    const html = wrapper.html()
+    const slotIndex = html.indexOf('below-card-content')
+    const linkIndex = html.indexOf('顔登録')
+    expect(slotIndex).toBeGreaterThan(-1)
+    expect(linkIndex).toBeGreaterThan(-1)
+    expect(slotIndex).toBeLessThan(linkIndex)
+    wrapper.unmount()
+  })
 })

--- a/web/tests/pages/index.test.ts
+++ b/web/tests/pages/index.test.ts
@@ -58,11 +58,19 @@ mockNuxtImport('useAuth', () => () => ({
   activateFromRegistration: vi.fn(),
 }))
 
+// NormalMeasurement は below-card slot (本日の打刻履歴) を実際に描く必要があるため、
+// 自動 shallow stub (named slot を描かない) ではなく手書きの stub に差し替える。
+// TodayPunchHistory 側は自動 stub のまま — 「slot の中に出る」ことを DOM の入れ子で確かめる
+const NormalMeasurementStub = {
+  name: 'NormalMeasurement',
+  template: '<div class="normal-measurement-stub"><slot name="below-card" /></div>',
+}
+
 function mountIndex(route: string) {
   return mountSuspended(IndexPage, {
     route,
     shallow: true,
-    global: { stubs: { ManagerAlarmBar: false, ClientOnly: false } },
+    global: { stubs: { ManagerAlarmBar: false, ClientOnly: false, NormalMeasurement: NormalMeasurementStub } },
   })
 }
 
@@ -151,21 +159,19 @@ describe('pages/index — 本日の打刻履歴 (TodayPunchHistory) を通常点
     wrapper = null
   })
 
-  it('PC (Android/iPhone/iPad でない UA) では通常点呼のカードの下に本日の打刻履歴を出す', async () => {
+  it('PC (Android/iPhone/iPad でない UA) では通常点呼の below-card slot に本日の打刻履歴を出す', async () => {
     Object.defineProperty(navigator, 'userAgent', { value: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)', configurable: true })
     wrapper = await mountIndex('/?role=driver')
-    expect(wrapper.findComponent(NormalMeasurement).exists()).toBe(true)
+    const normalMeasurement = wrapper.find('.normal-measurement-stub')
+    expect(normalMeasurement.exists()).toBe(true)
     expect(wrapper.findComponent(TodayPunchHistory).exists()).toBe(true)
-    // 横並びではなく縦積み (NormalMeasurement の後ろに TodayPunchHistory) であることを
-    // DOM の出現順で確かめる (Refs ippoan/alc-app#238、ユーザー報告による横並びからの変更)
-    const html = wrapper.html()
-    expect(html.indexOf('normal-measurement-stub')).toBeGreaterThan(-1)
-    expect(html.indexOf('today-punch-history-stub')).toBeGreaterThan(html.indexOf('normal-measurement-stub'))
-    // ラッパーは flex にしない (普通のブロック) — NormalMeasurement.vue のルートが静的に
-    // flex-1 を持つため、flex 縦並びだと「残りの高さ」に押しつぶされる (裏取りで発覚)
-    const wrapperEl = wrapper.findComponent(NormalMeasurement).element.parentElement
-    expect(wrapperEl?.className).toBe('flex-1 min-h-0 overflow-y-auto')
-    expect(wrapperEl?.className).not.toContain('flex ')
+    // 「顔登録」「メンテナンス」を画面最下部に保つため below-card slot に入れる設計
+    // (Refs ippoan/alc-app#238) — 兄弟ではなく NormalMeasurement (stub) の**中**にあることを確かめる
+    expect(normalMeasurement.findComponent(TodayPunchHistory).exists()).toBe(true)
+    // #248 のラッパー div はもう無い — NormalMeasurement 自身の class に flex-1 min-h-0 が付く
+    // (他の driverSubTab 兄弟 (TenkoKiosk 等) と同じパターンに戻した)
+    expect(normalMeasurement.classes()).toContain('flex-1')
+    expect(normalMeasurement.classes()).toContain('min-h-0')
   })
 
   it('Android では本日の打刻履歴を出さない (通常点呼のみ)', async () => {


### PR DESCRIPTION
## 何を変えるか

PC の通常点呼の画面で、「顔登録」「メンテナンス」のリンクが通常点呼のカードと「本日の打刻履歴」の間に出ていた。リンクを画面のいちばん下に戻す。#238 の続き (#248 の見た目の直し)。

- `web/app/components/NormalMeasurement.vue`: 末尾のリンクの塊の直前に、呼び出し元がカードの下に足したい内容を差し込む口 (named slot `below-card`) を置く。空なら何も出ない
- `web/app/pages/index.vue`: PC のとき、本日の打刻履歴をその口に入れる。#248 で足した外側のラッパーは要らなくなったので外し、ほかのタブと同じ形に戻した。PC 以外は今までどおり

## テスト

- NormalMeasurement: slot の中身がリンクの塊より前に出る
- index: PC かつ通常点呼で打刻履歴が slot の中に出る / PC でなければ出ない
- vitest 全体、`check_coverage_100`、`npx nuxi typecheck`

Refs #238
Refs ippoan/alc-app-s3#135

🤖 Generated with [Claude Code](https://claude.com/claude-code)
