### PR TITLE
feat(cores3): PC の今の段を CoreS3 に STAGE で送り、CoreS3 の画面を連動させる (Refs #238)

### DIFF
--- a/web/app/components/NormalMeasurement.vue
+++ b/web/app/components/NormalMeasurement.vue
@@ -19,6 +19,10 @@ const step = ref<'nfc' | 'medical' | 'measuring' | 'result'>('nfc')
 const employeeId = ref('')
 const measurementResult = ref<MeasurementResult | null>(null)
 
+// PC の今の段を CoreS3 に送り、画面を連動させる (Refs ippoan/alc-app-s3#135)
+const { syncStep, sendResult } = useCoreS3Stage()
+watch(step, syncStep, { immediate: true })
+
 const saveError = ref<string | null>(null)
 const isSaving = ref(false)
 const saveStatus = ref<'saved' | 'queued' | null>(null)
@@ -325,6 +329,8 @@ async function onMeasurementResult(result: MeasurementResult) {
   } finally {
     isSaving.value = false
   }
+
+  sendResult(result)
 }
 
 // リセット

--- a/web/app/components/TenkoKiosk.vue
+++ b/web/app/components/TenkoKiosk.vue
@@ -42,6 +42,10 @@ watch(() => step.value, (s) => {
   if (s === 'carrying_items') loadCarryingItems()
 })
 
+// PC の今の段を CoreS3 に送り、画面を連動させる (Refs ippoan/alc-app-s3#135)
+const { syncStep, sendResult } = useCoreS3Stage()
+watch(step, syncStep, { immediate: true })
+
 // アルコール測定完了後 (instruction / report ステップ) に WebRTC 接続
 watch(
   () => step.value,
@@ -181,6 +185,7 @@ onMounted(() => {
 function onMeasurementResult(result: MeasurementResult) {
   const alcoholResult = result.resultType === 'normal' ? 'pass' : 'fail'
   onAlcoholResult(alcoholResult, result.alcoholValue)
+  sendResult(result)
 }
 
 // --- BLE 医療データ → 送信 ---

--- a/web/app/composables/useCoreS3Stage.ts
+++ b/web/app/composables/useCoreS3Stage.ts
@@ -1,0 +1,79 @@
+import type { MeasurementResult } from '~/types'
+
+/** PC → CoreS3 に送る段階 (firmware の HostStage と固定の語彙。変えない) */
+export type CoreS3Stage = 'NFC' | 'TEMP' | 'ALCOHOL' | 'PC'
+
+/**
+ * 通常点呼 / 自動点呼 (TenkoKiosk) の step 名 → CoreS3 に送る段階の対応表 (1 か所に集約)。
+ * 対応表に無い step (result / instruction / report / completed など、結果画面や
+ * PC 単体の後始末) は送らない — 結果画面は既存の `RESULT` で入る (Refs ippoan/alc-app-s3#135)。
+ */
+const STEP_TO_STAGE: Record<string, CoreS3Stage | undefined> = {
+  nfc: 'NFC',
+  interrupted: 'NFC',
+  cancelled: 'NFC',
+  medical: 'TEMP',
+  measuring: 'ALCOHOL',
+  alcohol: 'ALCOHOL',
+  schedule_select: 'PC',
+  face_auth: 'PC',
+  self_declaration: 'PC',
+  daily_inspection: 'PC',
+  carrying_items: 'PC',
+  safety_result: 'PC',
+}
+
+/** step 名から送る段階を決める純関数。対応表に無ければ null (送らない)。 */
+export function stageForStep(step: string): CoreS3Stage | null {
+  return STEP_TO_STAGE[step] ?? null
+}
+
+// シングルトン: 直近に送った行 (再送防止 / CoreS3 の再接続時の再送に使う)
+let current: string | null = null
+/** onOpen の購読を 1 回だけにする (useCoreS3Stage は複数の component から呼ばれる) */
+let wired = false
+
+/**
+ * PC の今の段階を CoreS3 に `STAGE <段階>` で送る (送信専用、CoreS3 からの応答は読まない)。
+ * CoreS3 の画面を PC の流れに連動させるための送信口 (Refs ippoan/alc-app-s3#135)。
+ * 古い firmware は `STAGE` を未知のコマンドとして捨てるだけなので、firmware の OTA より
+ * 先にこちらをマージしても害は無い。
+ */
+export function useCoreS3Stage() {
+  const coreS3 = useCoreS3Serial()
+
+  if (!wired) {
+    wired = true
+    // CoreS3 の再起動・掴み直しで、直近に送った段階を取り戻す
+    coreS3.onOpen(() => {
+      if (current) void coreS3.write(current)
+    })
+  }
+
+  /** 同じ行は再送しない（再送すると CoreS3 側で値が消えることがある）。未接続なら送らない。 */
+  function send(line: string): void {
+    if (line === current) return
+    current = line
+    if (!coreS3.isConnected.value) return
+    void coreS3.write(line)
+  }
+
+  /** step が変わるたびに呼ぶ。対応表に無い step は何もしない。 */
+  function syncStep(step: string): void {
+    const stage = stageForStep(step)
+    if (stage === null) return
+    send(`STAGE ${stage}`)
+  }
+
+  /** 測定結果を CoreS3 に伝える (CoreS3 は Screen::Result へ)。`STAGE RESULT` は無い。 */
+  function sendResult(result: MeasurementResult): void {
+    if (!coreS3.isConnected.value) return
+    const verdict = result.resultType === 'normal' ? 'OK' : 'NG'
+    void coreS3.write(`RESULT ${verdict} ${result.alcoholValue.toFixed(3)}`)
+  }
+
+  return {
+    syncStep,
+    sendResult,
+  }
+}

--- a/web/coverage_100.toml
+++ b/web/coverage_100.toml
@@ -135,6 +135,10 @@ path = "app/composables/useCoreS3Serial.ts"
 branches = true
 
 [[files]]
+path = "app/composables/useCoreS3Stage.ts"
+branches = true
+
+[[files]]
 path = "app/composables/useHubClaim.ts"
 branches = true
 

--- a/web/tests/components/NormalMeasurement.test.ts
+++ b/web/tests/components/NormalMeasurement.test.ts
@@ -68,11 +68,31 @@ mockNuxtImport('useBleGateway', () => () => ({
   latestBloodPressure: readonly(ref(null)),
 }))
 
+// PC の段を CoreS3 に送る口 (Refs #238)。ここでは呼ばれたかだけを見る
+const syncStepMock = vi.fn()
+const sendResultMock = vi.fn()
+mockNuxtImport('useCoreS3Stage', () => () => ({
+  syncStep: syncStepMock,
+  sendResult: sendResultMock,
+}))
+
 // NfcStatus は表示と emit('read') だけなので、read を直接投げられるスタブに差し替える
 const NfcStatusStub = defineComponent({
   name: 'NfcStatus',
   emits: ['read'],
   template: '<div data-testid="nfc-stub" />',
+})
+
+// BleStatus / AlcMeasurement は composable への依存が重いので、emit だけ発火できるスタブに差し替える
+const BleStatusStub = defineComponent({
+  name: 'BleStatus',
+  emits: ['skip', 'next'],
+  template: '<div data-testid="ble-status-stub" />',
+})
+const AlcMeasurementStub = defineComponent({
+  name: 'AlcMeasurement',
+  emits: ['result', 'error', 'stateChange'],
+  template: '<div data-testid="alc-measurement-stub" />',
 })
 
 const APPROVED_EMPLOYEE = { id: 'emp-1', name: '山田太郎', face_approval_status: 'approved' }
@@ -186,6 +206,75 @@ describe('NormalMeasurement — NFC ステップの乗務員照合', () => {
     expect(slotIndex).toBeGreaterThan(-1)
     expect(linkIndex).toBeGreaterThan(-1)
     expect(slotIndex).toBeLessThan(linkIndex)
+    wrapper.unmount()
+  })
+})
+
+describe('NormalMeasurement — PC の段を CoreS3 に送る (useCoreS3Stage、Refs #238)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  async function mountWithStubs() {
+    return await mountSuspended(NormalMeasurement, {
+      global: {
+        stubs: {
+          NfcStatus: NfcStatusStub,
+          BleStatus: BleStatusStub,
+          AlcMeasurement: AlcMeasurementStub,
+          ClientOnly: false,
+          Teleport: true,
+        },
+      },
+    })
+  }
+
+  // watch(step, syncStep, { immediate: true }) は Vue の watch コールバック引数
+  // (newValue, oldValue, onCleanup) をそのまま syncStep に渡すので、見るのは 1 番目の引数だけ
+  function stepArgOf(call: unknown[]): unknown {
+    return call[0]
+  }
+
+  it('mount 時 (nfc ステップ) に syncStep が呼ばれる', async () => {
+    const wrapper = await mountWithStubs()
+    expect(syncStepMock.mock.calls.map(stepArgOf)).toContain('nfc')
+    wrapper.unmount()
+  })
+
+  it('ステップが変わるたびに syncStep が呼ばれる (nfc → medical → measuring)', async () => {
+    getEmployeeByNfcIdMock.mockResolvedValue(APPROVED_EMPLOYEE)
+    const wrapper = await mountWithStubs()
+
+    await touch(wrapper, '2601012901010')
+    expect(syncStepMock.mock.calls.map(stepArgOf)).toContain('medical')
+
+    wrapper.findComponent(BleStatusStub).vm.$emit('skip')
+    await wrapper.vm.$nextTick()
+    expect(syncStepMock.mock.calls.map(stepArgOf)).toContain('measuring')
+    wrapper.unmount()
+  })
+
+  it('測定結果が出ると sendResult が呼ばれる', async () => {
+    getEmployeeByNfcIdMock.mockResolvedValue(APPROVED_EMPLOYEE)
+    const wrapper = await mountWithStubs()
+
+    await touch(wrapper, '2601012901010')
+    wrapper.findComponent(BleStatusStub).vm.$emit('skip')
+    await wrapper.vm.$nextTick()
+
+    const result = {
+      employeeId: 'emp-1',
+      alcoholValue: 0.1,
+      resultType: 'normal',
+      deviceUseCount: 1,
+      measuredAt: new Date('2026-01-01'),
+    }
+    wrapper.findComponent(AlcMeasurementStub).vm.$emit('result', result)
+    await new Promise(resolve => setTimeout(resolve, 0))
+    await wrapper.vm.$nextTick()
+
+    expect(sendResultMock).toHaveBeenCalledTimes(1)
+    expect(sendResultMock.mock.calls[0]![0]).toMatchObject({ alcoholValue: 0.1, resultType: 'normal' })
     wrapper.unmount()
   })
 })

--- a/web/tests/components/TenkoKiosk.test.ts
+++ b/web/tests/components/TenkoKiosk.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ref } from 'vue'
+import { mountSuspended, mockNuxtImport } from '@nuxt/test-utils/runtime'
+import TenkoKiosk from '~/components/TenkoKiosk.vue'
+import type { TenkoStep } from '~/composables/useTenkoKiosk'
+
+// TenkoKiosk.vue は多くの composable (WebRTC・カメラ・指紋認証等) に依存するため、
+// ここでは「PC の段 (step) が変わると CoreS3 に STAGE / RESULT を送る」配線だけを見る。
+// useTenkoKiosk 自体は自前で mock し、step を外から動かせるようにする
+// (自動点呼のフロー自体は tests/composables/useTenkoKiosk.test.ts が担当)。
+
+const step = ref<TenkoStep>('nfc')
+
+mockNuxtImport('useTenkoKiosk', () => () => ({
+  step,
+  employeeId: ref(''),
+  employeeName: ref(''),
+  pendingSchedules: ref([]),
+  selectedSchedule: ref(null),
+  session: ref(null),
+  error: ref(null),
+  isLoading: ref(false),
+  safetyJudgment: ref(null),
+  tenkoType: ref(null),
+  isPreOperation: ref(true),
+  stepLabels: ref(['NFC']),
+  currentStepIndex: ref(0),
+  identifyEmployee: vi.fn(async () => {}),
+  selectSchedule: vi.fn(async () => {}),
+  onFaceAuthComplete: vi.fn(),
+  onAlcoholResult: vi.fn(),
+  onMedicalSubmit: vi.fn(),
+  onSelfDeclarationSubmit: vi.fn(),
+  onDailyInspectionSubmit: vi.fn(),
+  carryingItems: ref([]),
+  loadCarryingItems: vi.fn(),
+  onCarryingItemsSubmit: vi.fn(),
+  onInstructionConfirm: vi.fn(),
+  onReportSubmit: vi.fn(),
+  reset: vi.fn(),
+}))
+
+mockNuxtImport('useFaceSync', () => () => ({
+  isSyncing: ref(false),
+  sync: vi.fn(async () => {}),
+}))
+
+mockNuxtImport('useDemoMode', () => () => ({
+  isDemoMode: ref(false),
+}))
+
+mockNuxtImport('useWebRtc', () => () => ({
+  isConnected: ref(false),
+  isPeerConnected: ref(false),
+  remoteStream: ref(null),
+  error: ref(null),
+  connect: vi.fn(async () => {}),
+  startStreaming: vi.fn(async () => {}),
+  disconnect: vi.fn(),
+}))
+
+mockNuxtImport('useCamera', () => () => ({
+  stream: ref(null),
+  videoRef: ref(null),
+  isActive: ref(false),
+  start: vi.fn(async () => {}),
+  stop: vi.fn(),
+}))
+
+mockNuxtImport('useBleGateway', () => () => ({
+  latestTemperature: ref(null),
+  latestBloodPressure: ref(null),
+}))
+
+mockNuxtImport('useFingerprint', () => () => ({
+  isFingerprintAvailable: ref(false),
+  isEmployeeAuthorized: vi.fn(() => false),
+  authorizeEmployee: vi.fn(),
+  requestFingerprint: vi.fn(),
+}))
+
+// PC の段を CoreS3 に送る口 (Refs #238)。ここでは呼ばれたかだけを見る
+const syncStepMock = vi.fn()
+const sendResultMock = vi.fn()
+mockNuxtImport('useCoreS3Stage', () => () => ({
+  syncStep: syncStepMock,
+  sendResult: sendResultMock,
+}))
+
+async function mountKiosk() {
+  return await mountSuspended(TenkoKiosk, {
+    shallow: true,
+  })
+}
+
+/** watch(step, syncStep, {...}) は Vue の watch コールバック引数をそのまま渡すので、見るのは 1 番目の引数だけ */
+function stepArgOf(call: unknown[]): unknown {
+  return call[0]
+}
+
+describe('TenkoKiosk — PC の段を CoreS3 に送る (useCoreS3Stage、Refs #238)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    step.value = 'nfc'
+  })
+
+  it('mount 時 (nfc ステップ) に syncStep が呼ばれる', async () => {
+    const wrapper = await mountKiosk()
+    expect(syncStepMock.mock.calls.map(stepArgOf)).toContain('nfc')
+    wrapper.unmount()
+  })
+
+  it('step が変わるたびに syncStep が呼ばれる', async () => {
+    const wrapper = await mountKiosk()
+
+    step.value = 'medical'
+    await wrapper.vm.$nextTick()
+    expect(syncStepMock.mock.calls.map(stepArgOf)).toContain('medical')
+
+    step.value = 'alcohol'
+    await wrapper.vm.$nextTick()
+    expect(syncStepMock.mock.calls.map(stepArgOf)).toContain('alcohol')
+    wrapper.unmount()
+  })
+
+  it('測定結果が出ると sendResult が呼ばれる', async () => {
+    const wrapper = await mountKiosk()
+
+    step.value = 'alcohol'
+    await wrapper.vm.$nextTick()
+
+    const result = {
+      employeeId: 'emp-1',
+      alcoholValue: 0.1,
+      resultType: 'normal',
+      deviceUseCount: 1,
+      measuredAt: new Date('2026-01-01'),
+    }
+    wrapper.findComponent({ name: 'AlcMeasurement' }).vm.$emit('result', result)
+    await wrapper.vm.$nextTick()
+
+    expect(sendResultMock).toHaveBeenCalledTimes(1)
+    expect(sendResultMock.mock.calls[0]![0]).toMatchObject({ alcoholValue: 0.1, resultType: 'normal' })
+    wrapper.unmount()
+  })
+})

--- a/web/tests/composables/useCoreS3Stage.test.ts
+++ b/web/tests/composables/useCoreS3Stage.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mockNuxtImport } from '@nuxt/test-utils/runtime'
+import type { MeasurementResult } from '~/types'
+
+// useCoreS3Stage はモジュールスコープに直近送信 (current) + onOpen 購読済みフラグ (wired)
+// を持つシングルトンなので、テスト毎に resetModules + dynamic import で分離する
+// (useDeviceToken.test.ts と同型)。useCoreS3Serial は Nuxt auto-import なので mockNuxtImport。
+const coreS3Mock = vi.hoisted(() => ({
+  isConnected: { value: true },
+  write: vi.fn(async () => true),
+  onOpen: vi.fn(),
+}))
+mockNuxtImport('useCoreS3Serial', () => () => coreS3Mock)
+
+type Mod = typeof import('~/composables/useCoreS3Stage')
+
+async function load(): Promise<Mod> {
+  return await import('~/composables/useCoreS3Stage')
+}
+
+function makeResult(overrides: Partial<MeasurementResult> = {}): MeasurementResult {
+  return {
+    employeeId: 'emp-1',
+    alcoholValue: 0.1,
+    resultType: 'normal',
+    deviceUseCount: 1,
+    measuredAt: new Date('2026-01-01'),
+    ...overrides,
+  }
+}
+
+describe('useCoreS3Stage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.resetModules()
+    coreS3Mock.isConnected.value = true
+    coreS3Mock.write.mockReset()
+    coreS3Mock.write.mockResolvedValue(true)
+    coreS3Mock.onOpen.mockReset()
+  })
+
+  describe('stageForStep — 対応表 (全 step 名)', () => {
+    it.each([
+      ['nfc', 'NFC'],
+      ['interrupted', 'NFC'],
+      ['cancelled', 'NFC'],
+      ['medical', 'TEMP'],
+      ['measuring', 'ALCOHOL'],
+      ['alcohol', 'ALCOHOL'],
+      ['schedule_select', 'PC'],
+      ['face_auth', 'PC'],
+      ['self_declaration', 'PC'],
+      ['daily_inspection', 'PC'],
+      ['carrying_items', 'PC'],
+      ['safety_result', 'PC'],
+      ['result', null],
+      ['instruction', null],
+      ['report', null],
+      ['completed', null],
+      ['unknown_step_xyz', null],
+    ] as const)('%s → %s', async (step, expected) => {
+      const { stageForStep } = await load()
+      expect(stageForStep(step)).toBe(expected)
+    })
+  })
+
+  describe('syncStep', () => {
+    it('対応表にある step で STAGE <段階> を送る', async () => {
+      const { useCoreS3Stage } = await load()
+      const { syncStep } = useCoreS3Stage()
+      syncStep('nfc')
+      expect(coreS3Mock.write).toHaveBeenCalledWith('STAGE NFC')
+    })
+
+    it('対応表に無い step では何も送らない', async () => {
+      const { useCoreS3Stage } = await load()
+      const { syncStep } = useCoreS3Stage()
+      syncStep('result')
+      expect(coreS3Mock.write).not.toHaveBeenCalled()
+    })
+
+    it('同じ段が続いても再送しない (再送すると CoreS3 側で値が消えることがある)', async () => {
+      const { useCoreS3Stage } = await load()
+      const { syncStep } = useCoreS3Stage()
+      syncStep('nfc')
+      syncStep('nfc')
+      expect(coreS3Mock.write).toHaveBeenCalledTimes(1)
+    })
+
+    it('段が変われば送る', async () => {
+      const { useCoreS3Stage } = await load()
+      const { syncStep } = useCoreS3Stage()
+      syncStep('nfc')
+      syncStep('medical')
+      expect(coreS3Mock.write).toHaveBeenNthCalledWith(1, 'STAGE NFC')
+      expect(coreS3Mock.write).toHaveBeenNthCalledWith(2, 'STAGE TEMP')
+    })
+
+    it('未接続では何も送らない', async () => {
+      coreS3Mock.isConnected.value = false
+      const { useCoreS3Stage } = await load()
+      const { syncStep } = useCoreS3Stage()
+      syncStep('nfc')
+      expect(coreS3Mock.write).not.toHaveBeenCalled()
+    })
+
+    it('onOpen (CoreS3 の再接続) で直近の段を再送する', async () => {
+      const { useCoreS3Stage } = await load()
+      const { syncStep } = useCoreS3Stage()
+      syncStep('medical')
+      expect(coreS3Mock.onOpen).toHaveBeenCalledTimes(1)
+
+      const onOpenCb = coreS3Mock.onOpen.mock.calls[0]![0] as () => void
+      coreS3Mock.write.mockClear()
+      onOpenCb()
+      expect(coreS3Mock.write).toHaveBeenCalledWith('STAGE TEMP')
+    })
+
+    it('未接続のまま送った段も、接続後の onOpen で送られる', async () => {
+      coreS3Mock.isConnected.value = false
+      const { useCoreS3Stage } = await load()
+      const { syncStep } = useCoreS3Stage()
+      syncStep('nfc')
+      expect(coreS3Mock.write).not.toHaveBeenCalled()
+
+      const onOpenCb = coreS3Mock.onOpen.mock.calls[0]![0] as () => void
+      coreS3Mock.isConnected.value = true
+      onOpenCb()
+      expect(coreS3Mock.write).toHaveBeenCalledWith('STAGE NFC')
+    })
+
+    it('複数 component から呼んでも onOpen の購読は 1 回だけ (シングルトン)', async () => {
+      const { useCoreS3Stage } = await load()
+      useCoreS3Stage()
+      useCoreS3Stage()
+      expect(coreS3Mock.onOpen).toHaveBeenCalledTimes(1)
+    })
+
+    it('何も送っていないうちに onOpen が来ても何もしない', async () => {
+      const { useCoreS3Stage } = await load()
+      useCoreS3Stage()
+      const onOpenCb = coreS3Mock.onOpen.mock.calls[0]![0] as () => void
+      onOpenCb()
+      expect(coreS3Mock.write).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('sendResult', () => {
+    it('normal → RESULT OK <値> (小数 3 桁)', async () => {
+      const { useCoreS3Stage } = await load()
+      const { sendResult } = useCoreS3Stage()
+      sendResult(makeResult({ alcoholValue: 0.1, resultType: 'normal' }))
+      expect(coreS3Mock.write).toHaveBeenCalledWith('RESULT OK 0.100')
+    })
+
+    it('over → RESULT NG', async () => {
+      const { useCoreS3Stage } = await load()
+      const { sendResult } = useCoreS3Stage()
+      sendResult(makeResult({ alcoholValue: 0.5, resultType: 'over' }))
+      expect(coreS3Mock.write).toHaveBeenCalledWith('RESULT NG 0.500')
+    })
+
+    it('error → RESULT NG', async () => {
+      const { useCoreS3Stage } = await load()
+      const { sendResult } = useCoreS3Stage()
+      sendResult(makeResult({ alcoholValue: 0, resultType: 'error' }))
+      expect(coreS3Mock.write).toHaveBeenCalledWith('RESULT NG 0.000')
+    })
+
+    it('未接続では何も送らない', async () => {
+      coreS3Mock.isConnected.value = false
+      const { useCoreS3Stage } = await load()
+      const { sendResult } = useCoreS3Stage()
+      sendResult(makeResult())
+      expect(coreS3Mock.write).not.toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
## 何を変えるか

運行者端末で、CoreS3 の画面が PC の点呼の流れと連動していなかった。PC の今の段を CoreS3 に新しいコマンド `STAGE NFC|TEMP|ALCOHOL|PC` で送る (web 側、送信だけ)。CoreS3 がそれを受けて画面を切り替える firmware は ippoan/alc-app-s3#232 (マージ済み、OTA で入る)。#238 の続き。

- 新規 `web/app/composables/useCoreS3Stage.ts`: 画面の段 → STAGE の対応表を 1 か所にまとめる。同じ行は再送しない。CoreS3 がつながり直したら直近の段を送り直す。測定の結果は既存の `RESULT OK|NG <値>` で送る
- `NormalMeasurement.vue` / `TenkoKiosk.vue`: 段の変化を見て送る 1 行と、結果を送る 1 行を足す
- 対応: NFC 待ち・中断・キャンセル → NFC / 体温 → TEMP / アルコール → ALCOHOL / 予定の選択・顔認証・自己申告・安全の結果・日常点検・携行品 → PC / 結果・指示・報告・完了 → 送らない (結果の画面は RESULT で入る)
- 古い firmware は STAGE を未知のコマンドとして捨てるだけなので、OTA より先に入っても害は無い。web に firmware の版の判定は入れない
- `web/coverage_100.toml` に useCoreS3Stage を登録 (100%)

## テスト

- useCoreS3Stage: 対応表 (全段) / 同じ行を再送しない / 段が変われば送る / つながり直しで送り直す / 結果の書式 / 未接続では送らない
- NormalMeasurement / TenkoKiosk: 段の変化で送り、結果で RESULT を送る
- vitest 全体、`check_coverage_100`、`npx nuxi typecheck`

Refs #238
Refs ippoan/alc-app-s3#135

🤖 Generated with [Claude Code](https://claude.com/claude-code)
