### PR TITLE
fix(camera): 録画中のカメラ映像を通常点呼の画面に映す (Refs #238)

### DIFF
--- a/web/app/components/NormalMeasurement.vue
+++ b/web/app/components/NormalMeasurement.vue
@@ -557,14 +557,14 @@ const currentStepIndex = computed(() => stepKeys.indexOf(step.value))
           <h2 class="text-lg font-semibold text-gray-700 mb-4">アルコール測定</h2>
           <p class="text-sm text-gray-500 mb-4">{{ employeeName }}</p>
 
-          <!-- 録画カメラプレビュー -->
-          <div v-if="isMeasuringCameraActive" class="relative mb-4 flex justify-center">
+          <!-- 録画カメラプレビュー (v-show: useCamera.start の時点で video が在る必要がある。v-if だと srcObject が入らず映像が出ない) -->
+          <div v-show="isMeasuringCameraActive" class="relative mb-4 flex justify-center">
             <video
               ref="measuringVideoRef"
               autoplay
               playsinline
               muted
-              class="w-40 h-30 rounded-lg object-cover border border-gray-200"
+              class="w-40 rounded-lg object-cover border border-gray-200"
             />
             <div
               v-if="isRecording"

--- a/web/tests/components/NormalMeasurement.test.ts
+++ b/web/tests/components/NormalMeasurement.test.ts
@@ -278,3 +278,32 @@ describe('NormalMeasurement — PC の段を CoreS3 に送る (useCoreS3Stage、
     wrapper.unmount()
   })
 })
+
+describe('NormalMeasurement — 録画カメラプレビュー (v-show、Refs #238)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('測定ステップでは、カメラ未起動 (isActive: false) でも video 要素はマウント済み (v-show で隠れているだけ)', async () => {
+    getEmployeeByNfcIdMock.mockResolvedValue(APPROVED_EMPLOYEE)
+    const wrapper = await mountSuspended(NormalMeasurement, {
+      global: {
+        stubs: {
+          NfcStatus: NfcStatusStub,
+          BleStatus: BleStatusStub,
+          AlcMeasurement: AlcMeasurementStub,
+          ClientOnly: false,
+          Teleport: true,
+        },
+      },
+    })
+
+    await touch(wrapper, '2601012901010')
+    wrapper.findComponent(BleStatusStub).vm.$emit('skip')
+    await wrapper.vm.$nextTick()
+
+    // useCamera のモックは isActive: ref(false) なので、v-if だった頃はここで要素が消えていた
+    expect(wrapper.find('video').exists()).toBe(true)
+    wrapper.unmount()
+  })
+})


### PR DESCRIPTION
## 何を直すか
運行者タブの通常点呼のアルコール測定の段で、「録画中」のバッジは出るのに、録っているカメラの映像が枠に映らなかった (録画そのものは正常にアップロードされている)。

## 原因
録画のプレビューの `<video>` が `v-if="isMeasuringCameraActive"` の中にあった。`useCamera.start()` は `isActive` を立てた同じ tick で `videoRef` に `srcObject` を入れるが、その時点では v-if がまだ描画されておらず要素が無いため、映像がつながらなかった。録画は要素ではなく stream から録るので影響していない。

## 変更
- `web/app/components/NormalMeasurement.vue`: プレビューの `v-if` を `v-show` にして video を常にマウントし、`start()` の即時接続に届くようにした。理由をコメントに 1 行
- Tailwind v3 に無い `h-30` クラス (効いていなかった) を削除。プレビューの大きさは変えていない
- `useCamera.ts` などの composable は変更なし (同じ形は NormalMeasurement の 1 か所だけ)

## テスト
- `web/tests/components/NormalMeasurement.test.ts`: 測定の段でカメラが未起動でも video 要素がマウントされていることを確かめる 1 本を追加
- `npx vitest run` 全通過 / `node scripts/check_coverage_100.mjs` 100% のまま / `npx nuxi typecheck` green

Refs #238
Refs ippoan/alc-app-s3#135

🤖 Generated with [Claude Code](https://claude.com/claude-code)
