### PR TITLE
fix(measurement): 録画中のカメラ映像をカードの横幅いっぱいに映す (Refs #238)

### DIFF
--- a/web/app/components/NormalMeasurement.vue
+++ b/web/app/components/NormalMeasurement.vue
@@ -564,7 +564,7 @@ const currentStepIndex = computed(() => stepKeys.indexOf(step.value))
               autoplay
               playsinline
               muted
-              class="w-40 rounded-lg object-cover border border-gray-200"
+              class="w-full aspect-video rounded-lg object-cover border border-gray-200"
             />
             <div
               v-if="isRecording"


### PR DESCRIPTION
## 何を直すか
#253 で、通常点呼のアルコール測定の段に録画中のカメラ映像が映るようになったが、横 160px (`w-40`) で小さすぎた。

## 変更
- `web/app/components/NormalMeasurement.vue`: 録画プレビューの `<video>` のクラスを `w-40` → `w-full aspect-video` にし、アルコール測定のカードの横幅いっぱい (16:9) に映す
- クラスの変更だけ。`v-show`・「録画中」のバッジ・script・`useCamera` / `useVideoRecorder` は変えていない

## テスト
- `npx vitest run` 全通過 / `node scripts/check_coverage_100.mjs` 100% のまま / `npx nuxi typecheck` green

Refs #238
Refs ippoan/alc-app-s3#135

🤖 Generated with [Claude Code](https://claude.com/claude-code)
