### PR TITLE
feat(measurement): 録画した動画を測定詳細と点呼タブで再生する (Refs #238)

### DIFF
--- a/web/app/components/HubMeasurementsViewer.vue
+++ b/web/app/components/HubMeasurementsViewer.vue
@@ -10,9 +10,9 @@
 //
 // 並びは backend 固定で `created_at DESC`。総件数は返らない (ingest テーブルが
 // 伸び続けるため) ので、ページャは has_more と offset だけで組む。
-import { getEmployees, listHubMeasurements } from '~/utils/api'
+import { getEmployees, getMeasurements, listHubMeasurements } from '~/utils/api'
 import { readAlcohol, type AlcoholPayload } from '~/utils/alcohol'
-import { HUB_MEASUREMENT_KINDS, type ApiEmployee, type HubMeasurement } from '~/types'
+import { HUB_MEASUREMENT_KINDS, type ApiEmployee, type ApiMeasurement, type HubMeasurement } from '~/types'
 
 const PAGE_SIZE = 50
 
@@ -264,6 +264,53 @@ function employeeOf(row: SessionRow): ApiEmployee | null {
   return row.license ? (employeeByNfc.value.get(row.license.nfcId) ?? null) : null
 }
 
+// --- 測定詳細を開く (点呼タブ → PC 側の測定、Refs #238, ippoan/alc-app-s3#135) ---
+// hub_measurements には PC 側の measurements への直接のキーが無いので、
+// 「同じ乗務員・近い時刻」で探して当てる (厳密な 1 対 1 の紐づけではない)。
+
+/** 行ごとの取得状態。押した行だけ更新する。 */
+const measurementLookup = ref<Map<string, { loading: boolean, error: string | null }>>(new Map())
+const selectedMeasurement = ref<ApiMeasurement | null>(null)
+const selectedEmployeeName = ref('')
+
+const MEASUREMENT_LOOKUP_WINDOW_MS = 15 * 60 * 1000
+
+function setLookupState(key: string, state: { loading: boolean, error: string | null }) {
+  const next = new Map(measurementLookup.value)
+  next.set(key, state)
+  measurementLookup.value = next
+}
+
+async function openMeasurementForRow(row: SessionRow) {
+  const employee = employeeOf(row)
+  if (!employee) return
+
+  setLookupState(row.key, { loading: true, error: null })
+  try {
+    const center = new Date(row.createdAt).getTime()
+    const res = await getMeasurements({
+      employee_id: employee.id,
+      date_from: new Date(center - MEASUREMENT_LOOKUP_WINDOW_MS).toISOString(),
+      date_to: new Date(center + MEASUREMENT_LOOKUP_WINDOW_MS).toISOString(),
+    })
+    if (res.measurements.length === 0) {
+      setLookupState(row.key, { loading: false, error: 'この点呼に対応する測定が見つかりません' })
+      return
+    }
+    const nearest = res.measurements.reduce((best, m) => {
+      const diff = Math.abs(new Date(m.measured_at).getTime() - center)
+      const bestDiff = Math.abs(new Date(best.measured_at).getTime() - center)
+      return diff < bestDiff ? m : best
+    })
+    setLookupState(row.key, { loading: false, error: null })
+    selectedEmployeeName.value = employee.name
+    selectedMeasurement.value = nearest
+  }
+  catch {
+    setLookupState(row.key, { loading: false, error: '測定を取得できませんでした' })
+  }
+}
+
 // ★ 畳むのは**このページに載っている測定だけ**。点呼がページ境界をまたぐと
 // 前後のページに分かれて出る (API は測定単位で offset を切るため)。件数表示に
 // 測定と点呼の両方を出して、行数と件数が合わないのを迷わせない。
@@ -435,9 +482,23 @@ onMounted(() => {
                   >{{ item.kind }}</span>
                 </td>
                 <td class="px-2 py-2">
-                  <button class="text-blue-600 hover:underline text-xs" @click="toggle(row.key)">
-                    {{ expanded.has(row.key) ? '閉じる' : `JSON を表示 (${row.items.length})` }}
-                  </button>
+                  <div class="flex flex-col items-start gap-1">
+                    <button class="text-blue-600 hover:underline text-xs" @click="toggle(row.key)">
+                      {{ expanded.has(row.key) ? '閉じる' : `JSON を表示 (${row.items.length})` }}
+                    </button>
+                    <button
+                      v-if="employeeOf(row)"
+                      class="text-blue-600 hover:underline text-xs disabled:opacity-50 disabled:cursor-not-allowed"
+                      :disabled="measurementLookup.get(row.key)?.loading"
+                      @click="openMeasurementForRow(row)"
+                    >
+                      {{ measurementLookup.get(row.key)?.loading ? '検索中…' : '測定詳細' }}
+                    </button>
+                    <span
+                      v-if="measurementLookup.get(row.key)?.error"
+                      class="text-xs text-red-600"
+                    >{{ measurementLookup.get(row.key)?.error }}</span>
+                  </div>
                 </td>
               </tr>
               <tr v-if="expanded.has(row.key)" class="bg-gray-50">
@@ -476,5 +537,13 @@ onMounted(() => {
         </div>
       </div>
     </div>
+
+    <!-- 測定詳細 (近い時刻の測定を探して当てる。厳密な 1 対 1 の紐づけではない) -->
+    <MeasurementDetail
+      v-if="selectedMeasurement"
+      :measurement="selectedMeasurement"
+      :employee-name="selectedEmployeeName"
+      @close="selectedMeasurement = null"
+    />
   </div>
 </template>

--- a/web/app/components/MeasurementDetail.vue
+++ b/web/app/components/MeasurementDetail.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import type { ApiMeasurement } from '~/types'
-import { fetchFacePhoto } from '~/utils/api'
+import { fetchFacePhoto, fetchMeasurementVideo } from '~/utils/api'
 
 const props = defineProps<{
   measurement: ApiMeasurement
@@ -14,6 +14,9 @@ const emit = defineEmits<{
 const facePhotoUrl = ref<string | null>(null)
 const isLoadingPhoto = ref(false)
 
+const videoUrl = ref<string | null>(null)
+const isLoadingVideo = ref(false)
+
 async function loadFacePhoto() {
   if (!props.measurement.face_photo_url) return
   isLoadingPhoto.value = true
@@ -24,14 +27,44 @@ async function loadFacePhoto() {
   }
 }
 
+async function loadVideo() {
+  if (!props.measurement.video_url) return
+  isLoadingVideo.value = true
+  try {
+    videoUrl.value = await fetchMeasurementVideo(props.measurement.id)
+  } finally {
+    isLoadingVideo.value = false
+  }
+}
+
+/** MediaRecorder で録った webm は長さの情報を持たず `duration === Infinity` になり、
+ * シークバーが効かない。既知の回避: 一度末尾近くまで seek すると duration が確定する。 */
+function onVideoLoadedMetadata(e: Event) {
+  const video = e.target as HTMLVideoElement
+  if (video.duration === Infinity) {
+    video.currentTime = 1e101
+  }
+}
+
+function onVideoTimeUpdate(e: Event) {
+  const video = e.target as HTMLVideoElement
+  if (video.currentTime > 1e100) {
+    video.currentTime = 0
+  }
+}
+
 onMounted(() => {
   loadFacePhoto()
+  loadVideo()
   document.addEventListener('keydown', onKeydown)
 })
 
 onUnmounted(() => {
   if (facePhotoUrl.value) {
     URL.revokeObjectURL(facePhotoUrl.value)
+  }
+  if (videoUrl.value) {
+    URL.revokeObjectURL(videoUrl.value)
   }
   document.removeEventListener('keydown', onKeydown)
 })
@@ -140,6 +173,23 @@ function statusColor(m: ApiMeasurement) {
               {{ statusLabel(measurement) }}
             </span>
           </div>
+        </div>
+
+        <!-- 録画 -->
+        <div v-if="measurement.video_url" class="space-y-2">
+          <p class="text-xs text-gray-400 font-medium">録画</p>
+          <div v-if="isLoadingVideo" class="text-sm text-gray-400">読み込み中…</div>
+          <video
+            v-else-if="videoUrl"
+            :src="videoUrl"
+            controls
+            playsinline
+            preload="metadata"
+            class="w-full aspect-video rounded-lg bg-black"
+            @loadedmetadata="onVideoLoadedMetadata"
+            @timeupdate="onVideoTimeUpdate"
+          />
+          <div v-else class="text-sm text-gray-400">録画を読み込めませんでした</div>
         </div>
 
         <!-- アルコール検査 -->

--- a/web/app/utils/api.ts
+++ b/web/app/utils/api.ts
@@ -369,20 +369,28 @@ export async function runDriverMasterSync(): Promise<DriverMasterSyncResult> {
   return bearerRequest<DriverMasterSyncResult>('/api/driver-master/run', jwt, { method: 'POST' })
 }
 
-/** 測定の顔写真を取得 (認証付きプロキシ経由) */
-export async function fetchFacePhoto(measurementId: string): Promise<string | null> {
+/** 認証付きプロキシ経由でバイナリを取得し、object URL にする (顔写真・録画動画で共用)。 */
+async function fetchObjectUrl(path: string): Promise<string | null> {
   if (!apiBase) return null
 
   try {
-    const res = await proxyRawFetch(`/api/measurements/${measurementId}/face-photo`, {
-      cache: 'no-store',
-    })
+    const res = await proxyRawFetch(path, { cache: 'no-store' })
     if (!res.ok) return null
     const blob = await res.blob()
     return URL.createObjectURL(blob)
   } catch {
     return null
   }
+}
+
+/** 測定の顔写真を取得 (認証付きプロキシ経由) */
+export async function fetchFacePhoto(measurementId: string): Promise<string | null> {
+  return fetchObjectUrl(`/api/measurements/${measurementId}/face-photo`)
+}
+
+/** 測定の録画動画を取得 (認証付きプロキシ経由) */
+export async function fetchMeasurementVideo(measurementId: string): Promise<string | null> {
+  return fetchObjectUrl(`/api/measurements/${measurementId}/video`)
 }
 
 /** 顔写真をアップロード */

--- a/web/tests/components/HubMeasurementsViewer.test.ts
+++ b/web/tests/components/HubMeasurementsViewer.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import HubMeasurementsViewer from '~/components/HubMeasurementsViewer.vue'
+
+// 点呼タブ (システム管理者「点呼」) から測定詳細を開く (Refs #238, ippoan/alc-app-s3#135)。
+// hub_measurements には PC 側の measurements への直接のキーが無いので、
+// 「同じ乗務員・近い時刻」で getMeasurements を検索して当てる。
+
+const listHubMeasurementsMock = vi.fn(async () => ({ items: [] as any[], limit: 50, offset: 0, has_more: false }))
+const getEmployeesMock = vi.fn(async () => [] as any[])
+const getMeasurementsMock = vi.fn(async () => ({ measurements: [] as any[], total: 0, page: 1, per_page: 20 }))
+const fetchFacePhotoMock = vi.fn(async () => null as string | null)
+const fetchMeasurementVideoMock = vi.fn(async () => null as string | null)
+
+vi.mock('~/utils/api', () => ({
+  listHubMeasurements: (...args: any[]) => listHubMeasurementsMock(...args),
+  getEmployees: (...args: any[]) => getEmployeesMock(...args),
+  getMeasurements: (...args: any[]) => getMeasurementsMock(...args),
+  fetchFacePhoto: (...args: any[]) => fetchFacePhotoMock(...args),
+  fetchMeasurementVideo: (...args: any[]) => fetchMeasurementVideoMock(...args),
+}))
+
+/** onMounted の await 群を流し切る */
+const flush = () => new Promise(resolve => setTimeout(resolve, 0))
+
+const EMPLOYEE = { id: 'emp-1', tenant_id: 't-1', nfc_id: 'nfc-1', name: '山田太郎', role: ['driver'], created_at: '2026-01-01T00:00:00Z', updated_at: '2026-01-01T00:00:00Z' }
+
+/** 乗務員が引ける行 (免許証あり、nfc_id が employee と一致)。 */
+const ROW_WITH_EMPLOYEE = {
+  id: 'hm-1', tenant_id: 't-1', device_id: 'dev-1', kind: 'license', seq: 1,
+  session_id: 's-1', recorded_at: '2026-09-12T00:33:00.000Z', created_at: '2026-09-12T00:33:00.000Z',
+  payload: { nfc_id: 'nfc-1', issue: '20200101', expiry: '20300101' },
+}
+
+/** 乗務員が引けない行 (免許証タップ無し = 単発のアルコール測定)。 */
+const ROW_WITHOUT_EMPLOYEE = {
+  id: 'hm-2', tenant_id: 't-1', device_id: 'dev-1', kind: 'alcohol', seq: 1,
+  session_id: 's-2', recorded_at: '2026-09-12T01:00:00.000Z', created_at: '2026-09-12T01:00:00.000Z',
+  payload: { value: 0.1, result: 'normal' },
+}
+
+function apiMeasurement(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'm-near', tenant_id: 't-1', employee_id: 'emp-1', alcohol_value: 0.1, result_type: 'normal',
+    device_use_count: 1, measured_at: '2026-09-12T00:33:00.000Z', created_at: '2026-09-12T00:33:00.000Z',
+    updated_at: '2026-09-12T00:33:00.000Z', status: 'completed',
+    ...overrides,
+  }
+}
+
+async function mountViewer() {
+  const wrapper = await mountSuspended(HubMeasurementsViewer)
+  await flush()
+  await wrapper.vm.$nextTick()
+  return wrapper
+}
+
+describe('HubMeasurementsViewer — 点呼タブから測定詳細を開く', () => {
+  beforeEach(() => {
+    listHubMeasurementsMock.mockClear()
+    listHubMeasurementsMock.mockResolvedValue({ items: [ROW_WITH_EMPLOYEE, ROW_WITHOUT_EMPLOYEE], limit: 50, offset: 0, has_more: false })
+    getEmployeesMock.mockClear()
+    getEmployeesMock.mockResolvedValue([EMPLOYEE])
+    getMeasurementsMock.mockClear()
+    getMeasurementsMock.mockResolvedValue({ measurements: [], total: 0, page: 1, per_page: 20 })
+    fetchFacePhotoMock.mockClear()
+    fetchMeasurementVideoMock.mockClear()
+  })
+
+  it('乗務員が引けた行にだけ「測定詳細」ボタンを出す', async () => {
+    const wrapper = await mountViewer()
+    const rows = wrapper.findAll('tbody > tr').filter(tr => !tr.text().includes('端末計時'))
+    expect(rows).toHaveLength(2)
+    const buttonTexts = (tr: typeof rows[number]) => tr.findAll('button').map(b => b.text())
+
+    expect(buttonTexts(rows[0]!)).toContain('測定詳細')
+    expect(buttonTexts(rows[1]!)).not.toContain('測定詳細')
+    wrapper.unmount()
+  })
+
+  it('一覧の読み込み時には getMeasurements を呼ばない (行ごとの N+1 を作らない)', async () => {
+    await mountViewer()
+    expect(getMeasurementsMock).not.toHaveBeenCalled()
+  })
+
+  it('押すと employee_id と ±15 分の ISO (UTC) で getMeasurements が 1 回呼ばれ、いちばん近い測定で開く', async () => {
+    const near = apiMeasurement({ id: 'm-near', measured_at: '2026-09-12T00:30:00.000Z', alcohol_value: 0.111 })
+    const far = apiMeasurement({ id: 'm-far', measured_at: '2026-09-12T00:20:00.000Z', alcohol_value: 0.222 })
+    getMeasurementsMock.mockResolvedValueOnce({ measurements: [far, near], total: 2, page: 1, per_page: 20 })
+
+    const wrapper = await mountViewer()
+    const rows = wrapper.findAll('tbody > tr').filter(tr => !tr.text().includes('端末計時'))
+    const btn = rows[0]!.findAll('button').find(b => b.text() === '測定詳細')!
+    await btn.trigger('click')
+    await flush()
+    await wrapper.vm.$nextTick()
+
+    expect(getMeasurementsMock).toHaveBeenCalledTimes(1)
+    expect(getMeasurementsMock).toHaveBeenCalledWith({
+      employee_id: 'emp-1',
+      date_from: '2026-09-12T00:18:00.000Z',
+      date_to: '2026-09-12T00:48:00.000Z',
+    })
+    // いちばん近い (誤差 3 分) 側の測定値が開く
+    expect(wrapper.text()).toContain('0.111')
+    expect(wrapper.text()).not.toContain('0.222')
+    wrapper.unmount()
+  })
+
+  it('取得中はボタンを disabled にする', async () => {
+    let resolveFn: ((v: any) => void) | undefined
+    getMeasurementsMock.mockImplementationOnce(() => new Promise((resolve) => { resolveFn = resolve }))
+    const wrapper = await mountViewer()
+    const rows = wrapper.findAll('tbody > tr').filter(tr => !tr.text().includes('端末計時'))
+    const btn = rows[0]!.findAll('button').find(b => b.text() === '測定詳細' || b.text() === '検索中…')!
+    await btn.trigger('click')
+    await wrapper.vm.$nextTick()
+
+    const btnAfter = rows[0]!.findAll('button').find(b => b.text() === '検索中…')!
+    expect(btnAfter.attributes('disabled')).toBeDefined()
+
+    resolveFn!({ measurements: [], total: 0, page: 1, per_page: 20 })
+    await flush()
+    wrapper.unmount()
+  })
+
+  it('0 件なら「この点呼に対応する測定が見つかりません」を行内に出す', async () => {
+    getMeasurementsMock.mockResolvedValueOnce({ measurements: [], total: 0, page: 1, per_page: 20 })
+    const wrapper = await mountViewer()
+    const rows = wrapper.findAll('tbody > tr').filter(tr => !tr.text().includes('端末計時'))
+    const btn = rows[0]!.findAll('button').find(b => b.text() === '測定詳細')!
+    await btn.trigger('click')
+    await flush()
+    await wrapper.vm.$nextTick()
+
+    expect(rows[0]!.text()).toContain('この点呼に対応する測定が見つかりません')
+    wrapper.unmount()
+  })
+
+  it('失敗したら「測定を取得できませんでした」を行内に出す', async () => {
+    getMeasurementsMock.mockRejectedValueOnce(new Error('network error'))
+    const wrapper = await mountViewer()
+    const rows = wrapper.findAll('tbody > tr').filter(tr => !tr.text().includes('端末計時'))
+    const btn = rows[0]!.findAll('button').find(b => b.text() === '測定詳細')!
+    await btn.trigger('click')
+    await flush()
+    await wrapper.vm.$nextTick()
+
+    expect(rows[0]!.text()).toContain('測定を取得できませんでした')
+    wrapper.unmount()
+  })
+})

--- a/web/tests/components/MeasurementDetail.test.ts
+++ b/web/tests/components/MeasurementDetail.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import MeasurementDetail from '~/components/MeasurementDetail.vue'
+import type { ApiMeasurement } from '~/types'
+
+// 測定詳細に録画を再生する (Refs #238, ippoan/alc-app-s3#135)。
+// video_url がある測定だけ fetchMeasurementVideo を呼んで <video> を出す。
+
+const fetchFacePhotoMock = vi.fn(async () => null as string | null)
+const fetchMeasurementVideoMock = vi.fn(async () => null as string | null)
+
+vi.mock('~/utils/api', () => ({
+  fetchFacePhoto: (...args: any[]) => fetchFacePhotoMock(...args),
+  fetchMeasurementVideo: (...args: any[]) => fetchMeasurementVideoMock(...args),
+}))
+
+/** onMounted の await 群を流し切る */
+const flush = () => new Promise(resolve => setTimeout(resolve, 0))
+
+function baseMeasurement(overrides: Partial<ApiMeasurement> = {}): ApiMeasurement {
+  return {
+    id: 'm-1',
+    tenant_id: 't-1',
+    employee_id: 'emp-1',
+    alcohol_value: 0,
+    result_type: 'normal',
+    device_use_count: 1,
+    measured_at: '2026-09-12T00:33:00Z',
+    created_at: '2026-09-12T00:33:00Z',
+    updated_at: '2026-09-12T00:33:00Z',
+    status: 'completed',
+    ...overrides,
+  }
+}
+
+describe('MeasurementDetail — 録画の再生', () => {
+  beforeEach(() => {
+    fetchFacePhotoMock.mockClear()
+    fetchFacePhotoMock.mockResolvedValue(null)
+    fetchMeasurementVideoMock.mockClear()
+    fetchMeasurementVideoMock.mockResolvedValue(null)
+    vi.stubGlobal('URL', {
+      createObjectURL: vi.fn(() => 'blob:http://localhost/video'),
+      revokeObjectURL: vi.fn(),
+    })
+  })
+
+  it('video_url がある測定では fetchMeasurementVideo を呼び <video> を出す', async () => {
+    fetchMeasurementVideoMock.mockResolvedValueOnce('blob:http://localhost/video')
+    const wrapper = await mountSuspended(MeasurementDetail, {
+      props: { measurement: baseMeasurement({ video_url: 'https://example.com/video.webm' }), employeeName: '山田太郎' },
+    })
+    await flush()
+    expect(fetchMeasurementVideoMock).toHaveBeenCalledWith('m-1')
+    const video = wrapper.find('video')
+    expect(video.exists()).toBe(true)
+    expect(video.attributes('src')).toBe('blob:http://localhost/video')
+    wrapper.unmount()
+  })
+
+  it('video_url が無い測定では fetchMeasurementVideo を呼ばず <video> も出さない', async () => {
+    const wrapper = await mountSuspended(MeasurementDetail, {
+      props: { measurement: baseMeasurement({ video_url: null }), employeeName: '山田太郎' },
+    })
+    await flush()
+    expect(fetchMeasurementVideoMock).not.toHaveBeenCalled()
+    expect(wrapper.find('video').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('取得に失敗 (null) したら「録画を読み込めませんでした」を出す', async () => {
+    fetchMeasurementVideoMock.mockResolvedValueOnce(null)
+    const wrapper = await mountSuspended(MeasurementDetail, {
+      props: { measurement: baseMeasurement({ video_url: 'https://example.com/video.webm' }), employeeName: '山田太郎' },
+    })
+    await flush()
+    expect(wrapper.text()).toContain('録画を読み込めませんでした')
+    expect(wrapper.find('video').exists()).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('unmount で動画の object URL を revoke する', async () => {
+    fetchMeasurementVideoMock.mockResolvedValueOnce('blob:http://localhost/video')
+    const wrapper = await mountSuspended(MeasurementDetail, {
+      props: { measurement: baseMeasurement({ video_url: 'https://example.com/video.webm' }), employeeName: '山田太郎' },
+    })
+    await flush()
+    wrapper.unmount()
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:http://localhost/video')
+  })
+})

--- a/web/tests/utils/api.test.ts
+++ b/web/tests/utils/api.test.ts
@@ -10,7 +10,7 @@ import {
   updateEmployeeFace, approveFace, rejectFace, getFaceData,
   updateEmployeeNfcId, updateEmployeeLicense, clearEmployeeLicense,
   // Face photo
-  fetchFacePhoto, uploadFacePhoto, uploadReportAudio, uploadBlowVideo,
+  fetchFacePhoto, fetchMeasurementVideo, uploadFacePhoto, uploadReportAudio, uploadBlowVideo,
   // Tenko schedules
   createSchedule, batchCreateSchedules, listSchedules, getSchedule, updateSchedule, deleteSchedule, getPendingSchedules,
   // Tenko sessions
@@ -1344,6 +1344,53 @@ restoreNativeApis()
       initApi('')
       const result = await fetchFacePhoto(UUID1)
       expect(result).toBeNull()
+    })
+  })
+
+  // ============================================================
+  // fetchMeasurementVideo
+  // ============================================================
+
+  describe('fetchMeasurementVideo', () => {
+    beforeEach(() => {
+      if (!isLive) {
+        vi.stubGlobal('URL', {
+          createObjectURL: vi.fn(() => 'blob:http://localhost/video'),
+          revokeObjectURL: vi.fn(),
+        })
+      }
+    })
+
+    afterEach(async () => {
+      if (!isLive) vi.unstubAllGlobals()
+      await setupApi()
+    })
+
+    it('should fetch the video and return an object URL on success', async () => {
+      if (isLive) {
+        restoreNativeApis()
+        ;(globalThis.URL as any).createObjectURL = vi.fn((_blob: Blob) => 'blob:test/video')
+        try {
+          const result = await fetchMeasurementVideo(SEED_MEASUREMENT_ID)
+          // 録画が存在する場合は blob URL、存在しない場合は null (R2 に未保存)
+          if (result !== null) {
+            expect(result).toBe('blob:test/video')
+          }
+        } finally {
+          delete (globalThis.URL as any).createObjectURL
+        }
+        return
+      }
+      stubResponse({
+        ok: true,
+        blob: () => Promise.resolve(new Blob(['video'])),
+      })
+
+      const result = await fetchMeasurementVideo(UUID1)
+      assertMock(() => {
+        expect(result).toBe('blob:http://localhost/video')
+        expect(mockFetch.mock.calls[0][0]).toBe(`https://api.example.com/api/measurements/${UUID1}/video`)
+      })
     })
   })
 


### PR DESCRIPTION
## 何を直すか
運行者タブの通常点呼で録画した動画 (`measurements.video_url`) はサーバーに保存されているが、再生できる画面がどこにも無かった。運行管理者の測定詳細にも、システム管理者の「点呼」タブにも出ない。

## 変更
- `web/app/utils/api.ts`: 認証つきで blob を取って object URL を返す処理を `fetchObjectUrl` (非公開) に寄せ、`fetchFacePhoto` と新しい `fetchMeasurementVideo` がそれを使う
- `web/app/components/MeasurementDetail.vue`: `video_url` がある測定だけ、顔写真の下に録画を再生する `<video>` を出す。閉じるときに object URL を解放する。MediaRecorder で録った webm は長さの情報を持たずシークできないため、既知の回避 (読み込み時に末尾へ飛ばして戻す) を入れた
- `web/app/components/HubMeasurementsViewer.vue`: 乗務員が分かる行に「測定詳細」ボタンを置く。押すと同じ乗務員の ±15 分の測定を 1 回だけ取り、時刻がいちばん近い測定の詳細 (上の再生つき) を開く。取得中・失敗・該当なしを行ごとに表示する。一覧の読み込み時には問い合わせない
- サーバー側は変更なし (動画を返す API は既存)

## テスト
- `web/tests/utils/api.test.ts`: `fetchMeasurementVideo` を追加 (既存の `fetchFacePhoto` のテストはそのまま通る)
- `web/tests/components/MeasurementDetail.test.ts` (新規) / `web/tests/components/HubMeasurementsViewer.test.ts` (新規)
- `npx vitest run` 全通過 / `node scripts/check_coverage_100.mjs` 100% のまま (`api.ts` は branches 含む) / `npx nuxi typecheck` green

Refs #238
Refs ippoan/alc-app-s3#135

🤖 Generated with [Claude Code](https://claude.com/claude-code)
