### PR TITLE
feat(web): 通常点呼の測定の保存に点呼記録の印を足す (Refs #238)

### DIFF
--- a/web/app/components/NormalMeasurement.vue
+++ b/web/app/components/NormalMeasurement.vue
@@ -285,6 +285,7 @@ async function onMeasurementResult(result: MeasurementResult) {
         medical_measured_at: result.medicalMeasuredAt?.toISOString(),
         face_verified: null,
         medical_manual_input: medicalInputSource.value === 'manual' ? true : undefined,
+        record_as_tenko: true,
       }
       console.log('[Measurement] updateMeasurement PUT data:', JSON.stringify(updateData))
       await updateMeasurement(activeMeasurementId.value, updateData)

--- a/web/app/utils/api.ts
+++ b/web/app/utils/api.ts
@@ -209,6 +209,7 @@ export async function saveMeasurement(result: MeasurementResult, facePhotoBlob?:
       diastolic: result.diastolic,
       pulse: result.pulse,
       medical_measured_at: result.medicalMeasuredAt?.toISOString(),
+      record_as_tenko: true,
     }),
   })
 }

--- a/web/app/utils/offline-queue.ts
+++ b/web/app/utils/offline-queue.ts
@@ -308,6 +308,7 @@ export async function flush(
           diastolic: entry.result.diastolic,
           pulse: entry.result.pulse,
           medical_measured_at: entry.result.medicalMeasuredAt,
+          record_as_tenko: true,
         })
       } else {
         // 従来の POST パス

--- a/web/tests/components/NormalMeasurement.test.ts
+++ b/web/tests/components/NormalMeasurement.test.ts
@@ -3,6 +3,7 @@ import { ref, readonly, defineComponent } from 'vue'
 import { mountSuspended, mockNuxtImport } from '@nuxt/test-utils/runtime'
 import NormalMeasurement from '~/components/NormalMeasurement.vue'
 import { employeeNotFoundByNfc } from '~/utils/employee-lookup-messages'
+import { updateMeasurement } from '~/utils/api'
 
 // --- API のモック (NFC → 乗務員照合だけを動かす) ---
 
@@ -63,8 +64,10 @@ mockNuxtImport('useVideoRecorder', () => () => ({
   stopRecording: vi.fn(async () => null),
 }))
 
+// record_as_tenko のテストで測定途中の温度 PUT を発火させたいので、値を差し替えられる ref にしておく
+const bleTemperatureRef = ref<{ value: number; unit: 'celsius'; measuredAt: Date } | null>(null)
 mockNuxtImport('useBleGateway', () => () => ({
-  latestTemperature: readonly(ref(null)),
+  latestTemperature: readonly(bleTemperatureRef),
   latestBloodPressure: readonly(ref(null)),
 }))
 
@@ -304,6 +307,73 @@ describe('NormalMeasurement — 録画カメラプレビュー (v-show、Refs #2
 
     // useCamera のモックは isActive: ref(false) なので、v-if だった頃はここで要素が消えていた
     expect(wrapper.find('video').exists()).toBe(true)
+    wrapper.unmount()
+  })
+})
+
+describe('NormalMeasurement — record_as_tenko (Refs #238)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    bleTemperatureRef.value = null
+  })
+
+  async function mountWithStubs() {
+    return await mountSuspended(NormalMeasurement, {
+      global: {
+        stubs: {
+          NfcStatus: NfcStatusStub,
+          BleStatus: BleStatusStub,
+          AlcMeasurement: AlcMeasurementStub,
+          ClientOnly: false,
+          Teleport: true,
+        },
+      },
+    })
+  }
+
+  it('完了の PUT (measuring 終了時) には record_as_tenko: true が入る', async () => {
+    getEmployeeByNfcIdMock.mockResolvedValue(APPROVED_EMPLOYEE)
+    const wrapper = await mountWithStubs()
+
+    await touch(wrapper, '2601012901010')
+    wrapper.findComponent(BleStatusStub).vm.$emit('skip')
+    await wrapper.vm.$nextTick()
+
+    const result = {
+      employeeId: 'emp-1',
+      alcoholValue: 0.1,
+      resultType: 'normal',
+      deviceUseCount: 1,
+      measuredAt: new Date('2026-01-01'),
+    }
+    wrapper.findComponent(AlcMeasurementStub).vm.$emit('result', result)
+    await new Promise(resolve => setTimeout(resolve, 0))
+    await wrapper.vm.$nextTick()
+
+    const completedCall = vi.mocked(updateMeasurement).mock.calls.find(
+      call => (call[1] as Record<string, unknown>).status === 'completed',
+    )
+    expect(completedCall).toBeDefined()
+    expect(completedCall![0]).toBe('measurement-1')
+    expect((completedCall![1] as Record<string, unknown>).record_as_tenko).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('測定途中 (BLE 体温) の PUT には record_as_tenko が入らない', async () => {
+    getEmployeeByNfcIdMock.mockResolvedValue(APPROVED_EMPLOYEE)
+    const wrapper = await mountWithStubs()
+
+    await touch(wrapper, '2601012901010')
+
+    bleTemperatureRef.value = { value: 36.5, unit: 'celsius', measuredAt: new Date('2026-01-01') }
+    await wrapper.vm.$nextTick()
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(vi.mocked(updateMeasurement)).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(updateMeasurement).mock.calls[0]![0]).toBe('measurement-1')
+    const body = vi.mocked(updateMeasurement).mock.calls[0]![1] as Record<string, unknown>
+    expect(body.temperature).toBe(36.5)
+    expect(body).not.toHaveProperty('record_as_tenko')
     wrapper.unmount()
   })
 })

--- a/web/tests/utils/api.test.ts
+++ b/web/tests/utils/api.test.ts
@@ -457,6 +457,8 @@ describe('api', () => {
         expect(body.employee_id).toBe(TEST_EMPLOYEE_ID)
         expect(body.alcohol_value).toBe(0.0)
         expect(body.result_type).toBe('normal')
+        // 通常点呼は全件が点呼記録の対象 (Refs #238)
+        expect(body.record_as_tenko).toBe(true)
       })
       expect(response.id).toBeDefined()
       assertMock(() => expect(response.id).toBe('123'))

--- a/web/tests/utils/offline-queue.test.ts
+++ b/web/tests/utils/offline-queue.test.ts
@@ -178,6 +178,8 @@ describe('offline-queue', () => {
         alcohol_value: 0.0,
         result_type: 'normal',
         face_photo_url: 'https://example.com/photo.jpg',
+        // 通常点呼は全件が点呼記録の対象 (Refs #238)
+        record_as_tenko: true,
       })
       expect(result).toEqual({ sent: 1, failed: 0 })
     })


### PR DESCRIPTION
運行者タブの「通常点呼」はいま measurements だけを書き、点呼のセッションと記録を作らない。そのため運行管理者の「点呼記録」に通常点呼が 1 件も出ない。

これを直すために、**測定の保存の要求そのものに印 `record_as_tenko` を足し、サーバーが同じ書き込みの中で点呼記録を作る**形にする。この PR はその web 側 (印を送る 3 か所) だけで、サーバー側の受け口は別 PR。

## 変更

| 場所 | 何を足したか |
|---|---|
| `web/app/utils/api.ts` `saveMeasurement` の POST body | `record_as_tenko: true` |
| `web/app/components/NormalMeasurement.vue` `updateData` (完了の PUT) | `record_as_tenko: true` |
| `web/app/utils/offline-queue.ts` flush の PUT body | `record_as_tenko: true` |

**足していない側** (意図的):

- BLE の測定途中の PUT — まだ完了していないので記録を作らせない
- video_url の PUT — 測定の後追いの更新で、記録のスナップショットには入らない

`git grep -n "record_as_tenko" -- web/app` はちょうど 3 行を返す。

## なぜ 2 本目の要求を送らないのか

「測定を保存したあとに web からもう 1 本要求を送る」案は、保留 store・送り直しの仕組み・IndexedDB の版上げが要る。版を上げると**既存のキューごと止まる**ため、オフラインで貯めた測定を落としかねない。

印だけなら、既存のオフラインキューの `retryCount` / `MAX_RETRIES` がそのまま送り直しになり、**新しい仕組みを 0 本で済ませられる**。

## 互換

知らないフィールドはサーバー側で無視されるので、**サーバー側の対応より先にこれがマージされても動作は変わらない**。

## テスト

- `saveMeasurement` の POST body に印が入ること
- `NormalMeasurement` の**完了の PUT には入り、測定途中の PUT には入らない**こと (両方をアサート)
- offline-queue の flush の PUT body に印が入ること

vitest 78 files / 1715 passed、`check_coverage_100` は exit 0 (`api.ts` / `offline-queue.ts` とも lines・branches 100%)。

Refs #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)
